### PR TITLE
Fixed type cast error in fmax() in hydro_cuda.cu

### DIFF
--- a/src/hydro_cuda.cu
+++ b/src/hydro_cuda.cu
@@ -658,7 +658,7 @@ __global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_gh
     cs = sqrt(d_inv * gamma * P);
     max_dti[tid] = fmax((fabs(vx)+cs)/dx, (fabs(vy)+cs)/dy);
     max_dti[tid] = fmax(max_dti[tid], (fabs(vz)+cs)/dz);
-    max_dti[tid] = fmax(max_dti[tid], 0);
+    max_dti[tid] = fmax(max_dti[tid], 0.0);
   }
   __syncthreads();
   


### PR DESCRIPTION
On sparkle, compiling with

$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2018 NVIDIA Corporation
Built on Sat_Aug_25_21:08:01_CDT_2018
Cuda compilation tools, release 10.0, V10.0.130

Gave the following compile error.

src/hydro_cuda.cu(661): error: calling a constexpr __host__ function("fmax") from a __global__ function("Calc_dt_3D") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.

The function fmax() exists in math.h and cuda.h.  Because the constant "0" was being specified, I think the compiler interpreted this as an int and thought math:fmax() from the host was being called. A float must be provided to cuda:fmax(), so changing "0" to "0.0" fixed the problem.