### PR TITLE
Set etah=0 when H_CORRECTION is off on HLLC and ROE solvers 

### DIFF
--- a/src/hllc_cuda.cu
+++ b/src/hllc_cuda.cu
@@ -43,8 +43,13 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
   #ifdef SCALAR
   Real dscl[NSCALARS], dscr[NSCALARS], scl[NSCALARS], scr[NSCALARS], scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS], f_sc[NSCALARS];
   #endif
+  
+  #ifdef H_CORRECTION
   // Retrieve etah value
   Real etah = dev_etah[tid];
+  #else
+  Real etah = 0.0;
+  #endif
 
 
   int o1, o2, o3;

--- a/src/roe_cuda.cu
+++ b/src/roe_cuda.cu
@@ -92,9 +92,10 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
     dger = dev_bounds_R[(n_fields-1)*n_cells + tid];
     #endif
 
-
+    #ifdef H_CORRECTION
     // retrieve etah value
     etah = dev_etah[tid];
+    #endif // etah = 0 if not H_CORRECTION
 
     // calculate primative variables
     vxl = mxl / dl;


### PR DESCRIPTION
Avoid uninitialized values for etah when H_CORRECTION if off.