### PR TITLE
Dual energy fix

### DIFF
--- a/src/CTU_3D_cuda.cu
+++ b/src/CTU_3D_cuda.cu
@@ -198,7 +198,11 @@ Real CTU_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1, int nx,
     #endif //HLLC
     CudaCheckError();
     #endif //CTU
-
+    
+    #ifdef DE
+    // Compute the divergence of Vel before updating the conserved array, this solves sincronization issues when adding this term on Update_Conserved_Variables_3D
+    Partial_Update_Advected_Internal_Energy_3D<<<dim1dGrid,dim1dBlock>>>( dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, nx_s, ny_s, nz_s, n_ghost, dx, dy, dz,  dt, gama, n_fields );
+    #endif
   
     // Step 5: Update the conserved variable array
     Update_Conserved_Variables_3D<<<dim1dGrid,dim1dBlock>>>(dev_conserved, F_x, F_y, F_z, nx_s, ny_s, nz_s, x_off, y_off, z_off, n_ghost, dx, dy, dz, xbound, ybound, zbound, dt, gama, n_fields);
@@ -207,6 +211,7 @@ Real CTU_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1, int nx,
 
     // Synchronize the total and internal energies
     #ifdef DE
+    Select_Internal_Energy_3D<<<dim1dGrid,dim1dBlock>>>(dev_conserved, nx_s, ny_s, nz_s, n_ghost, n_fields);
     Sync_Energies_3D<<<dim1dGrid,dim1dBlock>>>(dev_conserved, nx_s, ny_s, nz_s, n_ghost, gama, n_fields);
     CudaCheckError();
     #endif

--- a/src/VL_3D_cuda.cu
+++ b/src/VL_3D_cuda.cu
@@ -207,6 +207,11 @@ Real VL_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1, int nx, 
     Calculate_HLLC_Fluxes_CUDA<<<dim1dGrid,dim1dBlock>>>(Q_Lz, Q_Rz, F_z, nx_s, ny_s, nz_s, n_ghost, gama, 2, n_fields);
     #endif //HLLC
     CudaCheckError();
+    
+    #ifdef DE
+    // Compute the divergence of Vel before updating the conserved array, this solves sincronization issues when adding this term on Update_Conserved_Variables_3D
+    Partial_Update_Advected_Internal_Energy<<<dim1dGrid,dim1dBlock>>>( dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, nx_s, ny_s, nz_s, n_ghost, dx, dy, dz,  dt, gama, n_fields );
+    #endif
 
 
     // Step 6: Update the conserved variable array

--- a/src/VL_3D_cuda.cu
+++ b/src/VL_3D_cuda.cu
@@ -210,7 +210,7 @@ Real VL_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1, int nx, 
     
     #ifdef DE
     // Compute the divergence of Vel before updating the conserved array, this solves sincronization issues when adding this term on Update_Conserved_Variables_3D
-    Partial_Update_Advected_Internal_Energy<<<dim1dGrid,dim1dBlock>>>( dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, nx_s, ny_s, nz_s, n_ghost, dx, dy, dz,  dt, gama, n_fields );
+    Partial_Update_Advected_Internal_Energy_3D<<<dim1dGrid,dim1dBlock>>>( dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, nx_s, ny_s, nz_s, n_ghost, dx, dy, dz,  dt, gama, n_fields );
     #endif
 
 
@@ -219,6 +219,7 @@ Real VL_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1, int nx, 
     CudaCheckError();
 
     #ifdef DE
+    Select_Internal_Energy_3D<<<dim1dGrid,dim1dBlock>>>(dev_conserved, nx_s, ny_s, nz_s, n_ghost, n_fields);
     Sync_Energies_3D<<<dim1dGrid,dim1dBlock>>>(dev_conserved, nx_s, ny_s, nz_s, n_ghost, gama, n_fields);
     CudaCheckError();
     #endif

--- a/src/exact_cuda.cu
+++ b/src/exact_cuda.cu
@@ -10,6 +10,11 @@
 #include"global_cuda.h"
 #include"exact_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
+
+
 
 /*! \fn Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int n_fields)
  *  \brief Exact Riemann solver based on the Fortran code given in Sec. 4.9 of Toro (1999). */
@@ -40,7 +45,7 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
   Real vm, pm; //velocity and pressure in the star region
 
   #ifdef DE
-  Real gel, ger;
+  Real gel, ger, E_kin, E, dge ;
   #endif
 
   #ifdef SCALAR
@@ -57,7 +62,14 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
     vxl = dev_bounds_L[o1*n_cells + tid]/dl;
     vyl = dev_bounds_L[o2*n_cells + tid]/dl;
     vzl = dev_bounds_L[o3*n_cells + tid]/dl;
+    #ifdef DE //PRESSURE_DE
+    E = dev_bounds_L[4*n_cells + tid];
+    E_kin = 0.5 * dl * ( vxl*vxl + vyl*vyl + vzl*vzl );
+    dge = dev_bounds_L[(n_fields-1)*n_cells + tid];
+    pl = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else   
     pl  = (dev_bounds_L[4*n_cells + tid] - 0.5*dl*(vxl*vxl + vyl*vyl + vzl*vzl)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     pl  = fmax(pl, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -65,13 +77,20 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
     }
     #endif
     #ifdef DE
-    gel = dev_bounds_L[(n_fields-1)*n_cells + tid]/dl;
+    gel = dge / dl;
     #endif
     dr  = dev_bounds_R[            tid];
     vxr = dev_bounds_R[o1*n_cells + tid]/dr;
     vyr = dev_bounds_R[o2*n_cells + tid]/dr;
     vzr = dev_bounds_R[o3*n_cells + tid]/dr;
+    #ifdef DE //PRESSURE_DE
+    E = dev_bounds_R[4*n_cells + tid];
+    E_kin = 0.5 * dr * ( vxr*vxr + vyr*vyr + vzr*vzr );
+    dge = dev_bounds_R[(n_fields-1)*n_cells + tid];
+    pr = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else   
     pr  = (dev_bounds_R[4*n_cells + tid] - 0.5*dr*(vxr*vxr + vyr*vyr + vzr*vzr)) * (gamma - 1.0);  
+    #endif //PRESSURE_DE
     pr  = fmax(pr, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -79,7 +98,7 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
     }
     #endif
     #ifdef DE
-    ger = dev_bounds_R[(n_fields-1)*n_cells + tid]/dr;
+    ger = dge / dr;
     #endif
 
 

--- a/src/global.h
+++ b/src/global.h
@@ -42,6 +42,9 @@ typedef double Real;
 #define NSCALARS 1
 #endif
 
+// Parameters for Dual Energy Implementation
+#define DE_ETA_1 0.001
+#define DE_ETA_2 0.1
 
 #define SIGN(a) ( ((a) < 0.) ? -1. : 1. )
 

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -418,6 +418,10 @@ class Grid3D
     /*! \fn void Disk_3D(parameters P)
      *  \brief Initialize the grid with a 3D disk following a Miyamoto-Nagai profile. */
     void Disk_3D(parameters P);    
+    
+    /*! \fn void Spherical_Overpressure_3D()
+     *  \brief Initialize the grid with a 3D spherical overdensity and overpressue. */
+    void Spherical_Overpressure_3D();
 
     /*! \fn void Set_Boundary_Conditions(parameters P)
      *  \brief Set the boundary conditions based on info in the parameters structure. */

--- a/src/hllc_cuda.cu
+++ b/src/hllc_cuda.cu
@@ -9,6 +9,9 @@
 #include"global_cuda.h"
 #include"hllc_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
 
 
 /*! \fn Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int n_fields)
@@ -38,7 +41,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
   Real f_d, f_mx, f_my, f_mz, f_E;
   Real Sl, Sr, Sm, cfl, cfr, ps;
   #ifdef DE
-  Real dgel, dger, gel, ger, gels, gers, f_ge_l, f_ge_r, f_ge;
+  Real dgel, dger, gel, ger, gels, gers, f_ge_l, f_ge_r, f_ge, E_kin;
   #endif
   #ifdef SCALAR
   Real dscl[NSCALARS], dscr[NSCALARS], scl[NSCALARS], scr[NSCALARS], scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS], f_sc[NSCALARS];
@@ -95,7 +98,12 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
     vxl = mxl / dl;
     vyl = myl / dl;
     vzl = mzl / dl;
+    #ifdef DE //PRESSURE_DE
+    E_kin = 0.5 * dl * ( vxl*vxl + vyl*vyl + vzl*vzl );
+    pl = Get_Pressure_From_DE( El, El - E_kin, dgel, gamma ); 
+    #else
     pl  = (El - 0.5*dl*(vxl*vxl + vyl*vyl + vzl*vzl)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     pl  = fmax(pl, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -108,7 +116,12 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
     vxr = mxr / dr;
     vyr = myr / dr;
     vzr = mzr / dr;
+    #ifdef DE //PRESSURE_DE
+    E_kin = 0.5 * dr * ( vxr*vxr + vyr*vyr + vzr*vzr );
+    pr = Get_Pressure_From_DE( Er, Er - E_kin, dger, gamma );
+    #else
     pr  = (Er - 0.5*dr*(vxr*vxr + vyr*vyr + vzr*vzr)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     pr  = fmax(pr, (Real) TINY_NUMBER);    
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {

--- a/src/hydro_cuda.cu
+++ b/src/hydro_cuda.cu
@@ -675,5 +675,20 @@ __global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_gh
 
 }
 
+#ifdef DE
+__host__ __device__ Real Get_Pressure_From_DE( Real E, Real U_total, Real U_advected, Real gamma ){
+  
+  Real U, P;
+  Real eta = DE_ETA_1;
+  
+  // Apply same condition as Byan+2013 to select the internal energy from which compute pressure.
+  if( U_total / E > eta ) U = U_total;
+  else U = U_advected;
+  
+  P = U * (gamma - 1.0);
+  return P;
+}
+#endif //DE
+
 
 #endif //CUDA

--- a/src/hydro_cuda.cu
+++ b/src/hydro_cuda.cu
@@ -771,6 +771,9 @@ __global__ void Select_Internal_Energy_3D( Real *dev_conserved, int nx, int ny, 
     if (U_total/Emax > eta_2 ) U = U_total;
     else U = U_advected;
     
+    //Optional: Avoid Negative Internal  Energies
+    U = fmax(U, (Real) TINY_NUMBER);
+    
     //Write Selected internal energy to the GasEnergy array ONLY 
     //to avoid mixing updated and non-updated values of E for the
     //since the Dual Energy condition depends on the neighbour cells

--- a/src/hydro_cuda.h
+++ b/src/hydro_cuda.h
@@ -34,7 +34,10 @@ __global__ void Sync_Energies_2D(Real *dev_conserved, int nx, int ny, int n_ghos
 
 __global__ void Sync_Energies_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, Real gamma, int n_fields);
 
+
 __host__ __device__ Real Get_Pressure_From_DE( Real E, Real U_total, Real U_advected, Real gamma );
+
+__global__ void Partial_Update_Advected_Internal_Energy( Real *dev_conserved, Real *Q_Lx, Real *Q_Rx, Real *Q_Ly, Real *Q_Ry, Real *Q_Lz, Real *Q_Rz, int nx, int ny, int nz,  int n_ghost, Real dx, Real dy, Real dz,  Real dt, Real gamma, int n_fields );
 
 #endif //HYDRO_CUDA_H
 #endif //CUDA

--- a/src/hydro_cuda.h
+++ b/src/hydro_cuda.h
@@ -34,6 +34,7 @@ __global__ void Sync_Energies_2D(Real *dev_conserved, int nx, int ny, int n_ghos
 
 __global__ void Sync_Energies_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, Real gamma, int n_fields);
 
+__host__ __device__ Real Get_Pressure_From_DE( Real E, Real U_total, Real U_advected, Real gamma );
 
 #endif //HYDRO_CUDA_H
 #endif //CUDA

--- a/src/hydro_cuda.h
+++ b/src/hydro_cuda.h
@@ -37,7 +37,10 @@ __global__ void Sync_Energies_3D(Real *dev_conserved, int nx, int ny, int nz, in
 
 __host__ __device__ Real Get_Pressure_From_DE( Real E, Real U_total, Real U_advected, Real gamma );
 
-__global__ void Partial_Update_Advected_Internal_Energy( Real *dev_conserved, Real *Q_Lx, Real *Q_Rx, Real *Q_Ly, Real *Q_Ry, Real *Q_Lz, Real *Q_Rz, int nx, int ny, int nz,  int n_ghost, Real dx, Real dy, Real dz,  Real dt, Real gamma, int n_fields );
+__global__ void Partial_Update_Advected_Internal_Energy_3D( Real *dev_conserved, Real *Q_Lx, Real *Q_Rx, Real *Q_Ly, Real *Q_Ry, Real *Q_Lz, Real *Q_Rz, int nx, int ny, int nz,  int n_ghost, Real dx, Real dy, Real dz,  Real dt, Real gamma, int n_fields );
+
+__global__ void Select_Internal_Energy_3D( Real *dev_conserved, int nx, int ny, int nz,  int n_ghost, int n_fields );
+
 
 #endif //HYDRO_CUDA_H
 #endif //CUDA

--- a/src/initial_conditions.cpp
+++ b/src/initial_conditions.cpp
@@ -53,7 +53,9 @@ void Grid3D::Set_Initial_Conditions(parameters P) {
   } else if (strcmp(P.init, "Disk_2D")==0) {
     Disk_2D();    
   } else if (strcmp(P.init, "Disk_3D")==0) {
-    Disk_3D(P);    
+    Disk_3D(P);
+  } else if (strcmp(P.init, "Spherical_Overpressure_3D")==0) {
+    Spherical_Overpressure_3D();     
   } else if (strcmp(P.init, "Read_Grid")==0) {
     Read_Grid(P);    
   } else {
@@ -997,6 +999,54 @@ void Grid3D::Disk_2D()
 
 }
 
+/*! \fn void Spherical_Overpressure_3D()
+ *  \brief Spherical overdensity and overpressure causing an spherical explosion */
+void Grid3D::Spherical_Overpressure_3D()
+{
+  int i, j, k, id;
+  Real x_pos, y_pos, z_pos, r, center_x, center_y, center_z;
+  Real density, pressure, overDensity, overPressure, energy;
+  Real vx, vy, vz, v2;
+  center_x = 0.5;
+  center_y = 0.5;
+  center_z = 0.5;
+  overDensity = 1;
+  overPressure = 10;
+  vx = 0;
+  vy = 0;
+  vz = 0;
+
+  // set the initial values of the conserved variables
+  for (k=H.n_ghost; k<H.nz-H.n_ghost; k++) {
+    for (j=H.n_ghost; j<H.ny-H.n_ghost; j++) {
+      for (i=H.n_ghost; i<H.nx-H.n_ghost; i++) {
+        id = i + j*H.nx + k*H.nx*H.ny;
+
+        // // get the centered cell positions at (i,j,k)
+        Get_Position(i, j, k, &x_pos, &y_pos, &z_pos);
+        density = 0.1;
+        pressure = 1;
+
+        r = sqrt( (x_pos-center_x)*(x_pos-center_x) + (y_pos-center_y)*(y_pos-center_y) + (z_pos-center_z)*(z_pos-center_z) );
+        if ( r < 0.2 ){
+          density = overDensity;
+          pressure += overPressure;
+        }
+        v2 = vx*vx + vy*vy + vz*vz;
+        energy = pressure/(gama-1) + 0.5*density*v2;
+        C.density[id] = density;
+        C.momentum_x[id] = density*vx;
+        C.momentum_y[id] = density*vy;
+        C.momentum_z[id] = density*vz;
+        C.Energy[id] = energy;
+
+        #ifdef DE
+        C.GasEnergy[id] = pressure/(gama-1);
+        #endif
+      }
+    }
+  }
+}
 
 
 

--- a/src/plmc_cuda.cu
+++ b/src/plmc_cuda.cu
@@ -11,6 +11,10 @@
 #include"global_cuda.h"
 #include"plmc_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
+
 
 /*! \fn __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx, int ny, int nz, int n_ghost, Real dx, Real dt, Real gamma, int dir)
  *  \brief When passed a stencil of conserved variables, returns the left and right 
@@ -63,6 +67,7 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
   Real del_ge_L, del_ge_R, del_ge_C, del_ge_G;
   Real del_ge_m_i;
   Real ge_L_iph, ge_R_imh;
+  Real E, E_kin, dge;
   #ifndef VL
   Real sum_ge;
   #endif //CTU 
@@ -112,7 +117,14 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_i =  dev_conserved[o1*n_cells + id] / d_i;
     vy_i =  dev_conserved[o2*n_cells + id] / d_i;
     vz_i =  dev_conserved[o3*n_cells + id] / d_i;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_i * ( vx_i*vx_i + vy_i*vy_i + vz_i*vz_i );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_i = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_i  = (dev_conserved[4*n_cells + id] - 0.5*d_i*(vx_i*vx_i + vy_i*vy_i + vz_i*vz_i)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_i  = fmax(p_i, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -120,7 +132,7 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_i =  dev_conserved[(n_fields-1)*n_cells + id] / d_i;
+    ge_i =  dge / d_i;
     #endif
     // cell i-1
     if (dir == 0) id = xid-1 + yid*nx + zid*nx*ny;
@@ -130,7 +142,14 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imo =  dev_conserved[o1*n_cells + id] / d_imo;
     vy_imo =  dev_conserved[o2*n_cells + id] / d_imo;
     vz_imo =  dev_conserved[o3*n_cells + id] / d_imo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imo * ( vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_imo  = (dev_conserved[4*n_cells + id] - 0.5*d_imo*(vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imo  = fmax(p_imo, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -138,7 +157,7 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_imo =  dev_conserved[(n_fields-1)*n_cells + id] / d_imo;
+    ge_imo =  dge / d_imo;
     #endif
     // cell i+1
     if (dir == 0) id = xid+1 + yid*nx + zid*nx*ny;
@@ -148,7 +167,14 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipo =  dev_conserved[o1*n_cells + id] / d_ipo;
     vy_ipo =  dev_conserved[o2*n_cells + id] / d_ipo;
     vz_ipo =  dev_conserved[o3*n_cells + id] / d_ipo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipo * ( vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipo  = (dev_conserved[4*n_cells + id] - 0.5*d_ipo*(vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipo  = fmax(p_ipo, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -156,7 +182,7 @@ __global__ void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_ipo =  dev_conserved[(n_fields-1)*n_cells + id] / d_ipo;
+    ge_ipo =  dge / d_ipo;
     #endif
 
 

--- a/src/plmp_cuda.cu
+++ b/src/plmp_cuda.cu
@@ -9,6 +9,10 @@
 #include"global_cuda.h"
 #include"plmp_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
+
 
 /*! \fn __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx, int ny, int nz, int n_ghost, Real dx, Real dt, Real gamma, int dir, int n_fields)
  *  \brief When passed a stencil of conserved variables, returns the left and right 
@@ -41,7 +45,7 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
   Real mx_R, my_R, mz_R, E_R;
 
   #ifdef DE
-  Real ge_i, ge_imo, ge_ipo, ge_L, ge_R, dge_L, dge_R;
+  Real ge_i, ge_imo, ge_ipo, ge_L, ge_R, dge_L, dge_R, E_kin, E, dge;
   #endif
   #ifdef SCALAR
   Real scalar_i[NSCALARS], scalar_imo[NSCALARS], scalar_ipo[NSCALARS];
@@ -94,7 +98,14 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_i =  dev_conserved[o1*n_cells + id] / d_i;
     vy_i =  dev_conserved[o2*n_cells + id] / d_i;
     vz_i =  dev_conserved[o3*n_cells + id] / d_i;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_i * ( vx_i*vx_i + vy_i*vy_i + vz_i*vz_i );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_i = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_i  = (dev_conserved[4*n_cells + id] - 0.5*d_i*(vx_i*vx_i + vy_i*vy_i + vz_i*vz_i)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_i  = fmax(p_i, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -102,7 +113,7 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_i = dev_conserved[(n_fields-1)*n_cells + id] / d_i;
+    ge_i = dge / d_i;
     #endif
     // cell i-1
     if (dir == 0) id = xid-1 + yid*nx + zid*nx*ny;
@@ -112,7 +123,14 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imo =  dev_conserved[o1*n_cells + id] / d_imo;
     vy_imo =  dev_conserved[o2*n_cells + id] / d_imo;
     vz_imo =  dev_conserved[o3*n_cells + id] / d_imo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imo * ( vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_imo  = (dev_conserved[4*n_cells + id] - 0.5*d_imo*(vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imo  = fmax(p_imo, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -120,7 +138,7 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_imo =  dev_conserved[(n_fields-1)*n_cells + id] / d_imo;
+    ge_imo = dge / d_imo;
     #endif    
     // cell i+1
     if (dir == 0) id = xid+1 + yid*nx + zid*nx*ny;
@@ -130,7 +148,14 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipo =  dev_conserved[o1*n_cells + id] / d_ipo;
     vy_ipo =  dev_conserved[o2*n_cells + id] / d_ipo;
     vz_ipo =  dev_conserved[o3*n_cells + id] / d_ipo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipo * ( vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipo  = (dev_conserved[4*n_cells + id] - 0.5*d_ipo*(vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipo  = fmax(p_ipo, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -138,7 +163,7 @@ __global__ void PLMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     }
     #endif
     #ifdef DE
-    ge_ipo =  dev_conserved[(n_fields-1)*n_cells + id] / d_ipo;
+    ge_ipo =  dge / d_ipo;
     #endif
 
 

--- a/src/ppmc_cuda.cu
+++ b/src/ppmc_cuda.cu
@@ -10,6 +10,9 @@
 #include"global_cuda.h"
 #include"ppmc_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
 
 
 /*! \fn void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx, int ny, int nz, int n_ghost, Real dx, Real dt, Real gamma, int dir, int n_fields)
@@ -70,6 +73,7 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
   Real del_ge_L, del_ge_R, del_ge_C, del_ge_G;
   Real del_ge_m_imo, del_ge_m_i, del_ge_m_ipo;
   Real ge_L, ge_R;
+  Real  E_kin, E, dge;
   #ifdef CTU
   Real chi_ge, sum_ge, ge_6;
   #endif
@@ -119,10 +123,17 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_i =  dev_conserved[o1*n_cells + id] / d_i;
     vy_i =  dev_conserved[o2*n_cells + id] / d_i;
     vz_i =  dev_conserved[o3*n_cells + id] / d_i;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_i * ( vx_i*vx_i + vy_i*vy_i + vz_i*vz_i );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_i = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else   
     p_i  = (dev_conserved[4*n_cells + id] - 0.5*d_i*(vx_i*vx_i + vy_i*vy_i + vz_i*vz_i)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_i  = fmax(p_i, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_i =  dev_conserved[(n_fields-1)*n_cells + id] / d_i;
+    ge_i =  dge / d_i;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -137,10 +148,17 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imo =  dev_conserved[o1*n_cells + id] / d_imo;
     vy_imo =  dev_conserved[o2*n_cells + id] / d_imo;
     vz_imo =  dev_conserved[o3*n_cells + id] / d_imo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imo * ( vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else 
     p_imo  = (dev_conserved[4*n_cells + id] - 0.5*d_imo*(vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imo  = fmax(p_imo, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_imo =  dev_conserved[(n_fields-1)*n_cells + id] / d_imo;
+    ge_imo =  dge / d_imo;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -155,10 +173,17 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipo =  dev_conserved[o1*n_cells + id] / d_ipo;
     vy_ipo =  dev_conserved[o2*n_cells + id] / d_ipo;
     vz_ipo =  dev_conserved[o3*n_cells + id] / d_ipo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipo * ( vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipo  = (dev_conserved[4*n_cells + id] - 0.5*d_ipo*(vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipo  = fmax(p_ipo, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_ipo =  dev_conserved[(n_fields-1)*n_cells + id] / d_ipo;
+    ge_ipo =  dge / d_ipo;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -173,10 +198,17 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imt =  dev_conserved[o1*n_cells + id] / d_imt;
     vy_imt =  dev_conserved[o2*n_cells + id] / d_imt;
     vz_imt =  dev_conserved[o3*n_cells + id] / d_imt;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imt * ( vx_imt*vx_imt + vy_imt*vy_imt + vz_imt*vz_imt );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imt = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_imt  = (dev_conserved[4*n_cells + id] - 0.5*d_imt*(vx_imt*vx_imt + vy_imt*vy_imt + vz_imt*vz_imt)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imt  = fmax(p_imt, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_imt =  dev_conserved[(n_fields-1)*n_cells + id] / d_imt;
+    ge_imt =  dge / d_imt;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -191,10 +223,17 @@ __global__ void PPMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipt =  dev_conserved[o1*n_cells + id] / d_ipt;
     vy_ipt =  dev_conserved[o2*n_cells + id] / d_ipt;
     vz_ipt =  dev_conserved[o3*n_cells + id] / d_ipt;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipt * ( vx_ipt*vx_ipt + vy_ipt*vy_ipt + vz_ipt*vz_ipt );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipt = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipt  = (dev_conserved[4*n_cells + id] - 0.5*d_ipt*(vx_ipt*vx_ipt + vy_ipt*vy_ipt + vz_ipt*vz_ipt)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipt  = fmax(p_ipt, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_ipt =  dev_conserved[(n_fields-1)*n_cells + id] / d_ipt;
+    ge_ipt =  dge / d_ipt;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {

--- a/src/ppmp_cuda.cu
+++ b/src/ppmp_cuda.cu
@@ -10,6 +10,10 @@
 #include"global_cuda.h"
 #include"ppmp_cuda.h"
 
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
+
 #define STEEPENING
 #define FLATTENING
 
@@ -66,7 +70,7 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
   #endif  
 
   #ifdef DE
-  Real ge_i, ge_imo, ge_ipo, ge_imt, ge_ipt, ge_L, ge_R;
+  Real ge_i, ge_imo, ge_ipo, ge_imt, ge_ipt, ge_L, ge_R, E_kin, E, dge;
   #ifdef CTU
   Real del_ge, ge_6, geL_0, geR_0;
   #endif
@@ -116,10 +120,17 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_i =  dev_conserved[o1*n_cells + id] / d_i;
     vy_i =  dev_conserved[o2*n_cells + id] / d_i;
     vz_i =  dev_conserved[o3*n_cells + id] / d_i;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_i * ( vx_i*vx_i + vy_i*vy_i + vz_i*vz_i );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_i = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else 
     p_i  = (dev_conserved[4*n_cells + id] - 0.5*d_i*(vx_i*vx_i + vy_i*vy_i + vz_i*vz_i)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_i  = fmax(p_i, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_i = dev_conserved[(n_fields-1)*n_cells + id] / d_i;
+    ge_i = dge / d_i;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -134,10 +145,17 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imo =  dev_conserved[o1*n_cells + id] / d_imo;
     vy_imo =  dev_conserved[o2*n_cells + id] / d_imo;
     vz_imo =  dev_conserved[o3*n_cells + id] / d_imo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imo * ( vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else    
     p_imo  = (dev_conserved[4*n_cells + id] - 0.5*d_imo*(vx_imo*vx_imo + vy_imo*vy_imo + vz_imo*vz_imo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imo  = fmax(p_imo, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_imo = dev_conserved[(n_fields-1)*n_cells + id] / d_imo;
+    ge_imo = dge / d_imo;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -152,10 +170,17 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipo =  dev_conserved[o1*n_cells + id] / d_ipo;
     vy_ipo =  dev_conserved[o2*n_cells + id] / d_ipo;
     vz_ipo =  dev_conserved[o3*n_cells + id] / d_ipo;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipo * ( vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipo = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipo  = (dev_conserved[4*n_cells + id] - 0.5*d_ipo*(vx_ipo*vx_ipo + vy_ipo*vy_ipo + vz_ipo*vz_ipo)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipo  = fmax(p_ipo, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_ipo = dev_conserved[(n_fields-1)*n_cells + id] / d_ipo;
+    ge_ipo = dge / d_ipo;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -170,10 +195,17 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_imt =  dev_conserved[o1*n_cells + id] / d_imt;
     vy_imt =  dev_conserved[o2*n_cells + id] / d_imt;
     vz_imt =  dev_conserved[o3*n_cells + id] / d_imt;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_imt * ( vx_imt*vx_imt + vy_imt*vy_imt + vz_imt*vz_imt );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_imt = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_imt  = (dev_conserved[4*n_cells + id] - 0.5*d_imt*(vx_imt*vx_imt + vy_imt*vy_imt + vz_imt*vz_imt)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_imt  = fmax(p_imt, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_imt = dev_conserved[(n_fields-1)*n_cells + id] / d_imt;
+    ge_imt = dge / d_imt;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -188,10 +220,17 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
     vx_ipt =  dev_conserved[o1*n_cells + id] / d_ipt;
     vy_ipt =  dev_conserved[o2*n_cells + id] / d_ipt;
     vz_ipt =  dev_conserved[o3*n_cells + id] / d_ipt;
+    #ifdef DE //PRESSURE_DE
+    E = dev_conserved[4*n_cells + id];
+    E_kin = 0.5 * d_ipt * ( vx_ipt*vx_ipt + vy_ipt*vy_ipt + vz_ipt*vz_ipt );
+    dge = dev_conserved[(n_fields-1)*n_cells + id];
+    p_ipt = Get_Pressure_From_DE( E, E - E_kin, dge, gamma ); 
+    #else
     p_ipt  = (dev_conserved[4*n_cells + id] - 0.5*d_ipt*(vx_ipt*vx_ipt + vy_ipt*vy_ipt + vz_ipt*vz_ipt)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     p_ipt  = fmax(p_ipt, (Real) TINY_NUMBER);
     #ifdef DE
-    ge_ipt = dev_conserved[(n_fields-1)*n_cells + id] / d_ipt;
+    ge_ipt = dge / d_ipt;
     #endif
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {

--- a/src/ppmp_cuda.cu
+++ b/src/ppmp_cuda.cu
@@ -15,8 +15,8 @@
 #endif
 
 #define STEEPENING
-#define FLATTENING
-
+// #define FLATTENING
+//Note: FLATTENING needs 3 ghost cells, currently PPMP is initialized with only 2 ghost cells ( 2 on each side, 4 net ghost cells )
 
 /*! \fn __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int n_fields)
  *  \brief When passed a stencil of conserved variables, returns the left and right 
@@ -95,20 +95,39 @@ __global__ void PPMP_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bou
   int xid = tid - zid*nx*ny - yid*nx;
 
   int xs, xe, ys, ye, zs, ze;
+  
+  // 
+  // if (dir == 0) {
+  //   xs = 3; xe = nx-4;
+  //   ys = 0; ye = ny;
+  //   zs = 0; ze = nz;
+  // }
+  // if (dir == 1) {
+  //   xs = 0; xe = nx;
+  //   ys = 3; ye = ny-4;
+  //   zs = 0; ze = nz;
+  // }
+  // if (dir == 2) {
+  //   xs = 0; xe = nx;
+  //   ys = 0; ye = ny;
+  //   zs = 3; ze = nz-4;
+  // }
+  
+  //Ignore only the 2 ghost cells on each side ( intead of ignoring 3 ghost cells on each side )
   if (dir == 0) {
-    xs = 3; xe = nx-4;
+    xs = 2; xe = nx-3;
     ys = 0; ye = ny;
     zs = 0; ze = nz;
   }
   if (dir == 1) {
     xs = 0; xe = nx;
-    ys = 3; ye = ny-4;
+    ys = 2; ye = ny-3;
     zs = 0; ze = nz;
   }
   if (dir == 2) {
     xs = 0; xe = nx;
     ys = 0; ye = ny;
-    zs = 3; ze = nz-4;
+    zs = 2; ze = nz-3;
   }
 
   if (xid >= xs && xid < xe && yid >= ys && yid < ye && zid >= zs && zid < ze)

--- a/src/roe_cuda.cu
+++ b/src/roe_cuda.cu
@@ -9,7 +9,9 @@
 #include"global_cuda.h"
 #include"roe_cuda.h"
 
-
+#ifdef DE //PRESSURE_DE
+#include"hydro_cuda.h"
+#endif
 
 /*! \fn Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, Real *dev_etah, int dir, int n_fields)
  *  \brief Roe Riemann solver based on the version described in Stone et al, 2008. */
@@ -43,7 +45,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
   Real test0, test1, test2, test3, test4;
   int hlle_flag = 0;
   #ifdef DE
-  Real dgel, gel, dger, ger, f_ge_l, f_ge_r;
+  Real dgel, gel, dger, ger, f_ge_l, f_ge_r, E_kin;
   #endif
   #ifdef SCALAR
   Real dscalarl[NSCALARS], scalarl[NSCALARS], dscalarr[NSCALARS], scalarr[NSCALARS], f_scalar_l[NSCALARS], f_scalar_r[NSCALARS];
@@ -96,7 +98,12 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
     vxl = mxl / dl;
     vyl = myl / dl;
     vzl = mzl / dl;
+    #ifdef DE //PRESSURE_DE
+    E_kin = 0.5 * dl * ( vxl*vxl + vyl*vyl + vzl*vzl );
+    pl = Get_Pressure_From_DE( El, El - E_kin, dgel, gamma ); 
+    #else
     pl  = (El - 0.5*dl*(vxl*vxl + vyl*vyl + vzl*vzl)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     pl  = fmax(pl, (Real) TINY_NUMBER);
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {
@@ -109,7 +116,12 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
     vxr = mxr / dr;
     vyr = myr / dr;
     vzr = mzr / dr;
+    #ifdef DE //PRESSURE_DE
+    E_kin = 0.5 * dr * ( vxr*vxr + vyr*vyr + vzr*vzr );
+    pr = Get_Pressure_From_DE( Er, Er - E_kin, dger, gamma );
+    #else
     pr  = (Er - 0.5*dr*(vxr*vxr + vyr*vyr + vzr*vzr)) * (gamma - 1.0);
+    #endif //PRESSURE_DE
     pr  = fmax(pr, (Real) TINY_NUMBER);    
     #ifdef SCALAR
     for (int i=0; i<NSCALARS; i++) {

--- a/tests/3D/Spherical_Overpressure.txt
+++ b/tests/3D/Spherical_Overpressure.txt
@@ -1,0 +1,36 @@
+#
+# Parameter File for the 3D Sphere Overpressure.
+#
+
+######################################
+# number of grid cells in the x dimension
+nx=256
+# number of grid cells in the y dimension
+ny=256
+# number of grid cells in the z dimension
+nz=256
+# output time
+tout=0.1
+# how often to output
+outstep=0.01
+# value of gamma
+gamma=1.66666667
+# name of initial conditions
+init=Spherical_Overpressure_3D
+# domain properties
+xmin=0.0
+ymin=0.0
+zmin=0.0
+xlen=1.0
+ylen=1.0
+zlen=1.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=/raid/bruno/data/cosmo_sims/cholla_pm/sphere_explosion/
+#outdir=/gpfs/alpine/scratch/bvilasen/ast149/sphere_explosion/output_files/


### PR DESCRIPTION
Pressure Calculation:
When using Dual Energy, each time the pressure is computed I apply condition from Bryan+2013 eq 44 to select the internal energy from which the pressure is computed. This was added to the following functions:
- All cuda reconstructions: PLMP, PLMC, PPMP and PPMC
- All cuda Riemann solvers: HLLC, ROE and EXACT
- When adding the term p_div(v) to the advected internal energy update. ( Not applied on the half step update when using VL, We decided not to add the p_div(V) term for the half update, but I didn't change the implementation here )

Internal Energy Synchronization:
Now, there are two steps for the Internal Energy Synchronization:
-First I select wich internal energy to keep by applying the condition from Bryan+2013 eq 45 and write the selected internal energy ONLY to the GasEnergy array. This is because the condition for the Internal Energy selection depends on the neighboring values of the total energy, in order to avoid mixing updated and non-updated values of the total energy, the total energy is updated using the chosen internal energy in a separate kernel.
modified kernels: Select_Internal_Energy_3D   and  Sync_Energies_3D
I only applied this to the 3D versions, 2D and 1D use the original criteria for Dual Energy condition.

Aditional term for Advected Internal Energy:
The Advected Internal Energy is updated using an additional term: p_div(V), originally this term was computed and added on the Update_Conserved_Variables_3D kernel, the problem was that the value of div(V) was computed using the velocities on the conserved array and at the same time the conserved_array was being updated by the same kernel leading to mixing of updated and non-updated values of V for computing div(V). The solution was to add the term p_div(v) in a separate kernel ( Partial_Update_Advected_Internal_Energy_3D ) before the Update_Conserved_3D kernel.
Only implemented for 3D. Another possibility is to use the reconstructed velocities to compute div(V) 

Ghost Cells in PPMP:
For PPMP ( and PPMC ) n_ghost=4, 2 ghost cells on each side. The PPMP kernel is ignoring the first 3 cells and the last 3 cells on each direction, I changed the kernel so that it only ignores the first 2 and last 2 ghost cells, On this implementation FLATTENING is not allowed since it requires 3 ghost cells on each side. 
 
 