### PR TITLE
Improve readability and conform to best practices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,60 @@
-## binaries
-*.o
-
-##executable
+# Files specific to this repo #
+##############################
 cholla
 
-##makefiles
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
+*.mod
+*.a
+a.out
+*.dSYM
+
+# Makefiles #
+#############
 Makefile
 makefile.summit
 
-## output files
+# Output files #
+################
 *.h5
 *.bin
 
-## dropbox file
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+
+# OS generated files #
+######################
 .DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE/Editor Files #
+####################
+.idea
+.vscode

--- a/makefile.template
+++ b/makefile.template
@@ -1,0 +1,104 @@
+EXEC   = cholla
+
+OPTIMIZE =  -O2  
+
+DIR = ./src
+CFILES = $(wildcard $(DIR)/*.c)
+CPPFILES = $(wildcard $(DIR)/*.cpp)
+CUDAFILES = $(wildcard $(DIR)/*.cu)
+
+
+OBJS   = $(subst .c,.o,$(CFILES)) $(subst .cpp,.o,$(CPPFILES)) $(subst .cu,.o,$(CUDAFILES)) 
+COBJS   = $(subst .c,.o,$(CFILES)) 
+CPPOBJS   = $(subst .cpp,.o,$(CPPFILES)) 
+CUOBJS   = $(subst .cu,.o,$(CUDAFILES)) 
+
+#To use GPUs, CUDA must be turned on here
+#Optional error checking can also be enabled
+CUDA = -DCUDA #-DCUDA_ERROR_CHECK
+
+#To use MPI, MPI_FLAGS must be set to -DMPI_CHOLLA
+#otherwise gcc/g++ will be used for serial compilation
+#MPI_FLAGS =  -DMPI_CHOLLA
+
+ifdef MPI_FLAGS
+  CC	= mpicc
+  CXX   = mpicxx
+
+  #MPI_FLAGS += -DSLAB
+  MPI_FLAGS += -DBLOCK
+
+else
+  CC	= gcc
+  CXX   = g++
+endif
+
+#define the NVIDIA CUDA compiler
+NVCC	= nvcc
+
+.SUFFIXES : .c .cpp .cu .o
+
+#FLOAT_TYPEDEF = -DFLOAT_TYPEDEF=float
+FLOAT_TYPEDEF = -DFLOAT_TYPEDEF=double
+
+#OUTPUT = -DBINARY
+OUTPUT = -DHDF5
+
+#RECONSTRUCTION = -DPCM
+#RECONSTRUCTION = -DPLMP
+#RECONSTRUCTION = -DPLMC
+#RECONSTRUCTION = -DPPMP
+RECONSTRUCTION = -DPPMC
+
+#SOLVER = -DEXACT
+#SOLVER = -DROE
+SOLVER = -DHLLC
+
+#INTEGRATOR = -DCTU
+INTEGRATOR = -DVL
+
+COOLING = -DCOOLING_GPU #-DCLOUDY_COOL
+
+
+ifdef CUDA
+CUDA_INCL = #-I/usr/local/cuda/include
+CUDA_LIBS = -lcuda -lcudart #-L/usr/local/cuda/lib64
+endif
+ifeq ($(OUTPUT),-DHDF5)
+HDF5_INCL = #-I/usr/local/hdf5/gcc/1.10.0/include
+HDF5_LIBS = -lhdf5 #-L/usr/local/hdf5/gcc/1.10.0/lib64
+endif
+
+INCL   = -I./ $(HDF5_INCL)
+NVINCL = $(INCL) $(CUDA_INCL)
+LIBS   = -lm $(HDF5_LIBS) $(CUDA_LIBS)
+
+
+FLAGS = $(CUDA) $(FLOAT_TYPEDEF) $(OUTPUT) $(RECONSTRUCTION) $(SOLVER) $(INTEGRATOR) $(COOLING) #-DSTATIC_GRAV #-DDE -DSCALAR -DSLICES -DPROJECTION -DROTATED_PROJECTION
+CFLAGS 	  = $(OPTIMIZE) $(FLAGS) $(MPI_FLAGS)
+CXXFLAGS  = $(OPTIMIZE) $(FLAGS) $(MPI_FLAGS)
+NVCCFLAGS = $(FLAGS) -fmad=false -arch=sm_60
+
+
+%.o:	%.c
+		$(CC) $(CFLAGS)  $(INCL)  -c $< -o $@ 
+
+%.o:	%.cpp
+		$(CXX) $(CXXFLAGS)  $(INCL) -c $< -o $@ 
+
+%.o:	%.cu
+		$(NVCC) $(NVCCFLAGS) --device-c $(NVINCL)  -c $< -o $@ 
+
+$(EXEC): $(OBJS) src/gpuCode.o
+	 	 $(CXX) $(OBJS) src/gpuCode.o $(LIBS) -o $(EXEC)
+
+src/gpuCode.o:	$(CUOBJS) 
+		$(NVCC) $(NVCCFLAGS) -dlink $(CUOBJS) -o src/gpuCode.o
+
+
+
+.PHONY : clean
+
+clean:
+	 rm -f $(OBJS) src/gpuCode.o $(EXEC)
+

--- a/python_scripts/README.md
+++ b/python_scripts/README.md
@@ -1,5 +1,5 @@
 # Visualizing results
-Here are some example scripts to illustrate how to do basic visualiztion of Cholla output.
+Here are some example scripts to illustrate how to do basic visualization of Cholla output.
 
 You will likely develop more customized, robust, and flexible scripts for your own usage.
 These simple scripts here are intended to help you understand the basics of the generated data from Cholla.

--- a/python_scripts/cat_dset_3D.py
+++ b/python_scripts/cat_dset_3D.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Example file for concatenating 3D hdf5 datasets
 
 import h5py
@@ -45,7 +46,7 @@ for n in range(ns, ne+1):
       if (DE):
         GE = fileout.create_dataset("GasEnergy", (nx, ny, nz), chunks=True)
 
-    # write data from indivual processor file to
+    # write data from individual processor file to
     # correct location in concatenated file
     nxl = head['dims_local'][0]
     nyl = head['dims_local'][1]

--- a/python_scripts/cat_projection.py
+++ b/python_scripts/cat_projection.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Example file for concatenating on-axis projection data
 # created when the -DPROJECTION flag is turned on
 
@@ -57,7 +58,7 @@ for n in range(ns, ne+1):
 
     filein.close()
 
-  # wrte out the new datasets
+  # write out the new datasets
   fileout.create_dataset('d_xy', data=dxy)
   fileout.create_dataset('d_xz', data=dxz)
   fileout.create_dataset('T_xy', data=Txy)

--- a/python_scripts/cat_rotated_projection.py
+++ b/python_scripts/cat_rotated_projection.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Example file for concatenating rotated projection data
 # created when the -DROTATED_PROJECTION flag is turned on
 

--- a/python_scripts/plot_sod.py
+++ b/python_scripts/plot_sod.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Example python plotting script for the 1D Sod Shock Tube test
 
 import h5py

--- a/src/exact.cpp
+++ b/src/exact.cpp
@@ -13,7 +13,7 @@
 
 /* \fn Calculate_Exact_Fluxes(Real cW[], Real fluxes[], Real gamma)
  * \brief Returns the density, momentum, and Energy fluxes at an interface.
-   Inputs are an array containg left and right density, momentum, and Energy. */
+   Inputs are an array containing left and right density, momentum, and Energy. */
 void Calculate_Exact_Fluxes(Real cW[], Real fluxes[], Real gamma)
 {
   Real dl, vxl, vyl, vzl, pl, cl; //density, velocity, pressure, sound speed (left)
@@ -24,7 +24,7 @@ void Calculate_Exact_Fluxes(Real cW[], Real fluxes[], Real gamma)
   Real gel, ger;
   #endif
 
-  // calculate primative variables from input array
+  // calculate primitive variables from input array
   dl = cW[0];
   dr = cW[1];
   vxl = cW[2] / dl;
@@ -59,7 +59,7 @@ void Calculate_Exact_Fluxes(Real cW[], Real fluxes[], Real gamma)
   }
   */
  
-  //find exact solution for pressvxre and velocity in star region
+  //find exact solution for pressure and velocity in star region
   starpu(&pm, &um, dl, vxl, pl, cl, dr, vxr, pr, cr, gamma);
  
   //sample the solution at the cell interface

--- a/src/global.h
+++ b/src/global.h
@@ -10,16 +10,10 @@
 #include <gsl/gsl_spline2d.h>
 #endif
 
-#if PRECISION == 1
-#ifndef FLOAT_TYPEDEF_DEFINED
-typedef float Real;
-#endif //FLOAT_TYPEDEF_DEFINED
-#endif //PRECISION == 1
-#if PRECISION == 2
-#ifndef FLOAT_TYPEDEF_DEFINED
-typedef double Real;
-#endif //FLOAT_TYPEDEF_DEFINED
-#endif //PRECISION == 2
+#ifndef FLOAT_TYPEDEF
+#error Float precision must be defined in the Makefile
+#endif
+typedef FLOAT_TYPEDEF Real;
 
 #define MAXLEN 100
 #define TINY_NUMBER 1.0e-20

--- a/src/grid3D.cpp
+++ b/src/grid3D.cpp
@@ -141,7 +141,7 @@ void Grid3D::Initialize(struct parameters *P)
     chexit(-1);
   }
 
-  // check for initilization
+  // check for initialization
   if(flag_init)
   {
     chprintf("Already initialized. Please reset.\n");
@@ -162,7 +162,7 @@ void Grid3D::Initialize(struct parameters *P)
   H.n_step = 0;
   // and the wall time
   H.t_wall = 0.0;
-  // and inialize the timestep
+  // and initialize the timestep
   H.dt = 0.0;
 
 

--- a/src/h_correction_3D_cuda.cu
+++ b/src/h_correction_3D_cuda.cu
@@ -1,5 +1,5 @@
 /*! \file h_correction_3D_cuda.cu
- *  \brief Functions definitions for the H correciton kernels. 
+ *  \brief Functions definitions for the H correction kernels.
            Written following Sanders et al. 1998. */
 #ifdef CUDA
 

--- a/src/hllc.cpp
+++ b/src/hllc.cpp
@@ -30,7 +30,7 @@ void Calculate_HLLC_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah)
   Real gel, ger, gels, gers, f_ge_l, f_ge_r, f_ge;
   #endif
 
-  // calculate primative variables from input array
+  // calculate primitive variables from input array
   dl = cW[0];
   dr = cW[1];
   mxl = cW[2];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
   chprintf("Setting initial conditions...\n");
   G.Set_Initial_Conditions(P);
   chprintf("Initial conditions set.\n");
-  // set main variables for Read_Grid inital conditions
+  // set main variables for Read_Grid initial conditions
   if (strcmp(P.init, "Read_Grid") == 0) {
     dti = C_cfl / G.H.dt;
     outtime += G.H.t;

--- a/src/plmc.cpp
+++ b/src/plmc.cpp
@@ -1,5 +1,5 @@
 /*! \file plmc.cpp
- *  \brief Definitions of the piecewise linear reconstruction functions, as decribed
+ *  \brief Definitions of the piecewise linear reconstruction functions, as described
            in Stone et al., 2008. */
 #ifdef PLMC
 

--- a/src/plmc_cuda.cu
+++ b/src/plmc_cuda.cu
@@ -1,6 +1,6 @@
 /*! \file plmc_cuda.cu
  *  \brief Definitions of the piecewise linear reconstruction functions with 
-           limiting applied in the characteristic variables, as decribed
+           limiting applied in the characteristic variables, as described
            in Stone et al., 2008. */
 #ifdef CUDA
 #ifdef PLMC

--- a/src/plmp_cuda.cu
+++ b/src/plmp_cuda.cu
@@ -1,6 +1,6 @@
 /*! \file plmp_cuda.cu
  *  \brief Definitions of the piecewise linear reconstruction functions for  
-           with limiting in the primative variables. */
+           with limiting in the primitive variables. */
 #ifdef CUDA
 
 #include<cuda.h>

--- a/src/ppmp_cuda.cu
+++ b/src/ppmp_cuda.cu
@@ -1,6 +1,6 @@
 /*! \file ppmp_cuda.cu
  *  \brief Definitions of the piecewise parabolic reconstruction (Fryxell 2000) functions 
-           with limiting in the primative variables. */
+           with limiting in the primitive variables. */
 #ifdef CUDA
 #ifdef PPMP
 

--- a/src/roe.cpp
+++ b/src/roe.cpp
@@ -10,7 +10,7 @@
 
 /* \fn Calculate_Roe_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah)
  * \brief Returns the density, momentum, and Energy fluxes at an interface.
-   Inputs are an array containg left and right density, momentum, and Energy. */
+   Inputs are an array containing left and right density, momentum, and Energy. */
 void Calculate_Roe_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah)
 {
   Real dl, vxl, mxl, vyl, myl, vzl, mzl, pl, El;
@@ -32,7 +32,7 @@ void Calculate_Roe_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah)
   int hlle_flag = 0;
 
 
-  // calculate primative variables from input array
+  // calculate primitive variables from input array
   dl = cW[0];
   dr = cW[1];
   mxl = cW[2];

--- a/src/roe.h
+++ b/src/roe.h
@@ -9,7 +9,7 @@
 
 /* \fn Calculate_Roe_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah)
  * \brief Returns the density, momentum, and Energy fluxes at an interface.
-   Inputs are an array containg left and right density, momentum, and Energy. */
+   Inputs are an array containing left and right density, momentum, and Energy. */
 void Calculate_Roe_Fluxes(Real cW[], Real fluxes[], Real gamma, Real etah);
 
 

--- a/tests/2D/disk.txt
+++ b/tests/2D/disk.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for a 2D disk in keplarian rotation.
+# Parameter File for a 2D disk in keplerian rotation.
 #
 
 ######################################


### PR DESCRIPTION
Floating Point Number Precision
- NOTE: Single precision (32bit) floating point computations are
  currently broken. That issue predates this commit but it was found
  when testing this part of the commit.
- Make float precision choice cleaner
  Prior to this change, the way the float precision was chosen was hard
  to read and couldn't spawn an error message.
  Now it takes 1/3rd as many lines, is much clearer, and has a clear
  error message

Python Scripts
- Add platform agnostic shebangs to python scripts
- Make all python scripts executable

Makefile Tracking
- Move Makefile to makefile.template.
  Prior to this change, the template makefile was just named `Makefile`
  which could lead to unfortunate tracking issues when changing the
  make or moving between systems. Now the template makefile is named
  makefile.template and the file `Makefile` is no longer tracked.
  The user can now either make their own `<cholla-root>/Makefile` or
  create a Makefile elsewhere and link it to `<cholla-root>/Makefile`.

.gitigonore Updates
- Update .gitignore to ignore many more files
  Prior to this change, the gitignore only included a handful of file
  types and I kept having to add to it. Now it ignores a lot more file
  types that should be ignored.

Typos
- Fix 19 typos in comments