### PR TITLE
minor change to avoid 'Unknown parameter/value pair' in output when, …

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <set>
 #include <ctype.h>
 #include"global.h"
 
@@ -94,6 +95,18 @@ char *trim (char * s)
   return s;
 }
 
+const std::set<const char*> optionalParams = {"flag_delta", "ddelta_dt", "n_delta",
+       "Lz" , "Lx" , "phi" , "theta", "delta", "nzr", "nxr", "H0", "Omega_M", "Omega_L",
+       "Init_redshift", "End_redshift", "tile_length", "n_proc_x", "n_proc_y", "n_proc_z" };
+
+/*! \fn int is_param_valid(char *name);
+ * \brief Verifies that a param is valid (even if not needed).  Avoids "warnings" in output. */
+int is_param_valid(const char* param_name) {
+  for (auto it=optionalParams.begin(); it != optionalParams.end(); ++it) {
+      if (strcmp(param_name, *it) == 0) return 1;
+  }
+  return 0;
+}
 
 /*! \fn void parse_params(char *param_file, struct parameters * parms);
  *  \brief Reads the parameters in the given file into a structure. */
@@ -271,9 +284,9 @@ parms->scale_outputs_file[0] = '\0';
     else if (strcmp(name, "n_proc_y")==0)
       parms->n_proc_y  = atoi(value);
     else if (strcmp(name, "n_proc_z")==0)
-  parms->n_proc_z  = atoi(value);
+      parms->n_proc_z  = atoi(value);
 #endif
-    else
+    else if (!is_param_valid(name)) 
       printf ("WARNING: %s/%s: Unknown parameter/value pair!\n",
         name, value);
   }

--- a/src/global.h
+++ b/src/global.h
@@ -242,5 +242,8 @@ struct parameters
  *  \brief Reads the parameters in the given file into a structure. */
 extern void parse_params (char *param_file, struct parameters * parms);
 
+/*! \fn int is_param_valid(char *name);
+ * \brief Verifies that a param is valid (even if not needed).  Avoids "warnings" in output. */
+extern int is_param_valid(const char *name);
 
 #endif //GLOBAL_H


### PR DESCRIPTION
…for example, compiling without the ROTATED_PROJECTION flag