### PR TITLE
Changed Paris solver to use a 5-point approximation of second derivatives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,11 @@ ifeq ($(findstring -DPARIS,$(DFLAGS)),-DPARIS)
   else
     LIBS += -lcufft
   endif
+  ifeq ($(findstring -DGRAVITY_5_POINTS_GRADIENT,$(DFLAGS)),-DGRAVITY_5_POINTS_GRADIENT)
+    DFLAGS += -DPARIS_5PT
+  else
+    DFLAGS += -DPARIS_3PT
+  endif
 endif
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This options can use only one MPI task.
 This solver performs FFTs on GPUs, distributed with MPI.
 It currently supports only certain numbers of MPI tasks, depending on the problem size.
   - The number of elements in each dimension must be divisible by the number of MPI tasks in that dimension.
-  - The number of elements in an X-Y slab must be divisible by the total number of MPI tasks.
+  - The number of elements in an X-Y slab must be divisible by the total number of MPI tasks. Because of the real-to-complex transform, the number of elements in an X-Y slab is not NXxNY, but instead is (NX/2+1)xNY.
   - The number of elements in the Z dimension must be divisible by the total number of MPI tasks.
 The intent is to extend and tune the Paris solver to run efficiently on exascale computers.
 - `-DPFFT -DPARIS` or `-DCUFFT -DPARIS` uses the *PFFT* or *CuFFT* solver, respectively, and compares the result of each Poisson solve against the result of the *Paris* solver.

--- a/src/gravity/paris/PoissonPeriodic3DBlockedGPU.cu
+++ b/src/gravity/paris/PoissonPeriodic3DBlockedGPU.cu
@@ -13,9 +13,19 @@ static constexpr double pi = 3.1415926535897932384626433832795028841971693993751
 static inline __host__ __device__ double sqr(const double x) { return x*x; }
 
 PoissonPeriodic3DBlockedGPU::PoissonPeriodic3DBlockedGPU(const int n[3], const double lo[3], const double hi[3], const int m[3], const int id[3]):
+#ifdef PARIS_3PT
+  di_(2.0*double(n[0]-1)/(hi[0]-lo[0])),
+  dj_(2.0*double(n[1]-1)/(hi[1]-lo[1])),
+  dk_(2.0*double(n[2]-1)/(hi[2]-lo[2])),
+#elif defined PARIS_5PT
+  di_(sqr(double(n[0]-1)/(hi[0]-lo[0]))/6.0),
+  dj_(sqr(double(n[1]-1)/(hi[1]-lo[1]))/6.0),
+  dk_(sqr(double(n[2]-1)/(hi[2]-lo[2]))/6.0),
+#else
   di_{2.0*pi*double(n[0]-1)/(double(n[0])*(hi[0]-lo[0]))},
   dj_{2.0*pi*double(n[1]-1)/(double(n[1])*(hi[1]-lo[1]))},
   dk_{2.0*pi*double(n[2]-1)/(double(n[2])*(hi[2]-lo[2]))},
+#endif
   mi_(m[0]),
   mj_(m[1]),
   mk_(m[2]),
@@ -173,6 +183,16 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
   // Solve Poisson equation
 
   {
+#ifdef PARIS_3PT
+    const double si = pi/double(ni_);
+    const double sj = pi/double(nj_);
+    const double sk = pi/double(nk_);
+#elif defined PARIS_5PT
+    const double si = 2.0*pi/double(ni_);
+    const double sj = 2.0*pi/double(nj_);
+    const double sk = 2.0*pi/double(nk_);
+#endif
+
     int rank = MPI_PROC_NULL;
     MPI_Comm_rank(commWorld_,&rank);
     const long jkLo = rank*njhPencil;
@@ -183,12 +203,33 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
         if ((ijk == 0) && (jkLo == 0)) {
           cb[0].x = cb[0].y = 0;
         } else {
+#ifdef PARIS_3PT
+          const double ii = sqr(sin(double(min(i,ni-i))*si)*di);
+#elif defined PARIS_5PT
+          const double ci = cos(double(min(i,ni-i))*si);
+          const double ii = di*(2.0*ci*ci-16.0*ci+14.0);
+#else
           const double ii = sqr(double(min(i,ni-i))*di);
+#endif
           jk += jkLo;
           const int j = jk/nh;
+#ifdef PARIS_3PT
+          const double jj = sqr(sin(double(min(j,nj-j))*sj)*dj);
+#elif defined PARIS_5PT
+          const double cj = cos(double(min(j,nj-j))*sj);
+          const double jj = dj*(2.0*cj*cj-16.0*cj+14.0);
+#else
           const double jj = sqr(double(min(j,nj-j))*dj);
+#endif
           const int k = jk-j*nh;
+#ifdef PARIS_3PT
+          const double kk = sqr(sin(double(k)*sk)*dk);
+#elif defined PARIS_5PT
+          const double ck = cos(double(k)*sk);
+          const double kk = dk*(2.0*ck*ck-16.0*ck+14.0);
+#else
           const double kk = sqr(double(k)*dk);
+#endif
           const double d = -1.0/(ii+jj+kk);
           cb[ijk].x *= d;
           cb[ijk].y *= d;


### PR DESCRIPTION
Paris itself still defaults to spectral accuracy, but it can be compiled with `-DPARIS_5PT` to solve for a 5-point numerical second derivative, or with `-DPARIS_3PT` to solve for a 3-point numerical second derivative.

The Makefile adds `-DPARIS_5PT` to the standard build with Paris. If the addition of `-DGRAVITY_5_POINTS_GRADIENT` is commented out of the Makefile, the build will switch to `-DPARIS_3PT`.

I ran a small test problem comparing Paris with PFFT, and it showed the following results.

Using `-DGRAVITY_5_POINTS_GRADIENT` but spectral accuracy for Paris:
```
Analytic Test of Poisson Solvers:
Paris Poisson-Solver Diff: L1 6.01283e-06 L2 5.03036e-06 Linf 5.6077e-06
PFFT Poisson-Solver Diff: L1 0.000959536 L2 0.0010211 Linf 0.00112875
Paris vs PFFT Poisson-Solver Diff: L1 5.40453e-05 L2 7.10735e-05 Linf 7.91293e-05
```
Using `-DGRAVITY_5_POINTS_GRADIENT` but `-DPARIS_3PT` for Paris:
```
Analytic Test of Poisson Solvers:
Paris Poisson-Solver Diff: L1 0.000959542 L2 0.00102111 Linf 0.00112875
PFFT Poisson-Solver Diff: L1 0.000959536 L2 0.0010211 Linf 0.00112875
Paris vs PFFT Poisson-Solver Diff: L1 4.01237e-09 L2 3.15916e-09 Linf 2.91777e-09
```
Using `-DGRAVITY_5_POINTS_GRADIENT` with the new default of `-DPARIS_5PT` for Paris:
```
Analytic Test of Poisson Solvers:
Paris Poisson-Solver Diff: L1 7.90138e-06 L2 5.4632e-06 Linf 5.65343e-06
PFFT Poisson-Solver Diff: L1 0.000959536 L2 0.0010211 Linf 0.00112875
Paris vs PFFT Poisson-Solver Diff: L1 5.38722e-05 L2 7.05519e-05 Linf 6.48553e-05
```
The results show that the Paris and PFFT closely match when Paris uses the 3-point approximation. The 5-point approximation approaches the accuracy of the spectral solution for the test problem.

I also updated the README to better describe Paris constraints on MPI task counts.