### PR TITLE
bug fix for analytic potential component

### DIFF
--- a/builds/machine.sh
+++ b/builds/machine.sh
@@ -14,7 +14,7 @@ case $FQDN in
   poplar.* | tulip.*)
     echo "poplar"
     exit 0 ;;
-  crc.*)
+  *crc.*)
     echo "crc"
     exit 0;;
   *spock* )

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -592,7 +592,7 @@ void Grid3D::Compute_Gravitational_Potential( struct parameters *P ){
   
 }
 
-#ifdef PARTICLES
+#if defined(PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
 void Grid3D::Add_Analytic_Potential(struct parameters *P) {
   #ifndef PARALLEL_OMP
   Add_Analytic_Galaxy_Potential(0, Grav.nz_local, Galaxies::MW);
@@ -670,6 +670,7 @@ void Grid3D::Copy_Hydro_Density_to_Gravity(){
 }
 
 
+#if defined(PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
 /**
  * Adds a specified potential function to the potential calculated from solving the Poisson equation.
  * The raison d'etre is to solve the evolution of a system where not all particles are simulated.
@@ -699,6 +700,7 @@ void Grid3D::Add_Analytic_Galaxy_Potential(int g_start, int g_end, DiskGalaxy& g
     }
   }
 }
+#endif
 
 
 //Extrapolate the potential to obtain phi_n+1/2

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -592,7 +592,7 @@ void Grid3D::Compute_Gravitational_Potential( struct parameters *P ){
   
 }
 
-#if defined(PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
+#ifdef GRAVITY_ANALYTIC_COMP
 void Grid3D::Add_Analytic_Potential(struct parameters *P) {
   #ifndef PARALLEL_OMP
   Add_Analytic_Galaxy_Potential(0, Grav.nz_local, Galaxies::MW);
@@ -670,7 +670,7 @@ void Grid3D::Copy_Hydro_Density_to_Gravity(){
 }
 
 
-#if defined(PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
+#ifdef GRAVITY_ANALYTIC_COMP
 /**
  * Adds a specified potential function to the potential calculated from solving the Poisson equation.
  * The raison d'etre is to solve the evolution of a system where not all particles are simulated.

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -22,8 +22,9 @@
 
 #ifdef PARTICLES
 #include "particles/particles_3D.h"
-#include "model/disk_galaxy.h"
 #endif
+
+#include "model/disk_galaxy.h"
 
 #ifdef COSMOLOGY
 #include"cosmology/cosmology.h"
@@ -678,6 +679,11 @@ class Grid3D
   #endif
   
   #endif//GRAVITY 
+
+  #ifdef GRAVITY_ANALYTIC_COMP
+  void Add_Analytic_Potential(struct parameters *P);
+  void Add_Analytic_Galaxy_Potential(int g_start, int g_end, DiskGalaxy& gal);
+  #endif //GRAVITY_ANALYTIC_COMP
   
   #ifdef PARTICLES
   void Initialize_Particles( struct parameters *P );
@@ -689,10 +695,6 @@ class Grid3D
   void Transfer_Particles_Boundaries( struct parameters P );
   Real Update_Grid_and_Particles_KDK( struct parameters P );
   void Set_Particles_Boundary( int dir, int side);
-  #ifdef GRAVITY_ANALYTIC_COMP
-  void Add_Analytic_Potential(struct parameters *P);
-  void Add_Analytic_Galaxy_Potential(int g_start, int g_end, DiskGalaxy& gal);
-  #endif //GRAVITY_ANALYTIC_COMP
   #ifdef MPI_CHOLLA
   int Load_Particles_Density_Boundary_to_Buffer( int direction, int side, Real *buffer );
   void Unload_Particles_Density_Boundary_From_Buffer( int direction, int side, Real *buffer );

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -689,8 +689,10 @@ class Grid3D
   void Transfer_Particles_Boundaries( struct parameters P );
   Real Update_Grid_and_Particles_KDK( struct parameters P );
   void Set_Particles_Boundary( int dir, int side);
+  #ifdef GRAVITY_ANALYTIC_COMP
   void Add_Analytic_Potential(struct parameters *P);
   void Add_Analytic_Galaxy_Potential(int g_start, int g_end, DiskGalaxy& gal);
+  #endif //GRAVITY_ANALYTIC_COMP
   #ifdef MPI_CHOLLA
   int Load_Particles_Density_Boundary_to_Buffer( int direction, int side, Real *buffer );
   void Unload_Particles_Density_Boundary_From_Buffer( int direction, int side, Real *buffer );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
   G.Set_Boundary_Conditions_Grid(P);
   chprintf("Boundary conditions set.\n");  
 
-  #ifdef GRAVITY_ANALYTIC_COMP
+  #if defined (PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
   // add analytic component to gravity potential.
   G.Add_Analytic_Potential(&P); 
   #endif 
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
     //Set the Grid boundary conditions for next time step 
     G.Set_Boundary_Conditions_Grid(P);
     
-    #ifdef GRAVITY_ANALYTIC_COMP
+    #if defined (PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
     // add analytic component to gravity potential.
     G.Add_Analytic_Potential(&P); 
     #endif 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
   G.Set_Boundary_Conditions_Grid(P);
   chprintf("Boundary conditions set.\n");  
 
-  #if defined (PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
+  #ifdef GRAVITY_ANALYTIC_COMP
   // add analytic component to gravity potential.
   G.Add_Analytic_Potential(&P); 
   #endif 
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
     //Set the Grid boundary conditions for next time step 
     G.Set_Boundary_Conditions_Grid(P);
     
-    #if defined (PARTICLES) && defined(GRAVITY_ANALYTIC_COMP)
+    #ifdef GRAVITY_ANALYTIC_COMP
     // add analytic component to gravity potential.
     G.Add_Analytic_Potential(&P); 
     #endif 

--- a/src/particles/io_particles.cpp
+++ b/src/particles/io_particles.cpp
@@ -253,7 +253,7 @@ void Particles_3D::Load_Particles_Data_HDF5(hid_t file_id, int nfile, struct par
     pID = dataset_buffer_IDs[pIndx];
     #endif
     #ifdef PARTICLE_AGE
-    pAge = dataset_buffer_IDs[pIndx];
+    pAge = dataset_buffer_age[pIndx];
     #endif
     
     #ifdef TILED_INITIAL_CONDITIONS


### PR DESCRIPTION
Avoids compilation errors when certain flags are not present.  Fixes a bug with reading in particle ages.  Enables building on ppc machines on CRC.