### PR TITLE
HYDRO_GPU and MPI_GPU flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,9 @@ TYPE    ?= hydro
 include builds/make.host.$(MACHINE)
 include builds/make.type.$(TYPE)
 
-DIRS     := src src/gravity src/particles src/cosmology src/cooling src/model src/cooling_grackle src/analysis
-ifeq ($(findstring -DPARIS,$(POISSON_SOLVER)),-DPARIS)
-  DIRS += src/gravity/paris
-  SUFFIX ?= .paris.$(MACHINE)
-endif
+DIRS     := src src/gravity src/particles src/cosmology \
+            src/cooling src/model src/cooling_grackle src/analysis \
+            src/gravity/paris
 
 SUFFIX ?= .$(TYPE).$(MACHINE)
 

--- a/builds/make.host.lux
+++ b/builds/make.host.lux
@@ -19,5 +19,3 @@ FFTW_ROOT    = /data/groups/comp-astro/bruno/code_mpi_local/fftw-3.3.8
 PFFT_ROOT    = /data/groups/comp-astro/bruno/code_mpi_local/pfft
 GRACKLE_ROOT = /home/brvillas/code/grackle
 
-#Paris does not do MPI_GPU transfers 
-PARIS_MPI_GPU = -DPARIS_NO_GPU_MPI

--- a/builds/make.host.shamrock
+++ b/builds/make.host.shamrock
@@ -19,6 +19,3 @@ FFTW_ROOT    = /home/bruno/code/fftw-3.3.8
 PFFT_ROOT    = /home/bruno/code/pfft
 GRACKLE_ROOT = /home/bruno/local
 
-#Paris does not do MPI_GPU transfers 
-PARIS_MPI_GPU = -DPARIS_NO_GPU_MPI
-

--- a/builds/make.host.spock
+++ b/builds/make.host.spock
@@ -20,6 +20,5 @@ MPI_ROOT     = ${CRAY_MPICH_DIR}
 FFTW_ROOT    = $(shell dirname $(FFTW_DIR))
 GRACKLE_ROOT = #/ccs/proj/ast149/code/grackle
 
-#Set the Hydro Conserved arrays to reside in the GPU
-#and MPI transfers are done from the GPU 
+#-- MPI calls accept GPU buffers (requires GPU-aware MPI)
 MPI_GPU = -DMPI_GPU

--- a/builds/make.host.summit
+++ b/builds/make.host.summit
@@ -21,6 +21,5 @@ FFTW_ROOT    = ${OLCF_FFTW_ROOT}
 PFFT_ROOT    = /ccs/proj/csc380/cholla/fom/code/pfft
 GRACKLE_ROOT = /ccs/home/bvilasen/code/grackle
 
-#Set the Hydro Conserved arrays to reside in the GPU
-#and MPI transfers are done from the GPU 
+#-- MPI calls accept GPU buffers (requires GPU-aware MPI)
 MPI_GPU = -DMPI_GPU

--- a/builds/make.type.hydro
+++ b/builds/make.type.hydro
@@ -3,8 +3,10 @@
 #-- separated output flag so that it can be overriden in target-specific 
 #   for make check
 OUTPUT    ?=  -DOUTPUT -DHDF5
-MPI_GPU   ?=  
 
+MPI_GPU   ?=
+
+DFLAGS	  += -DHYDRO_GPU
 DFLAGS    += -DCUDA
 DFLAGS    += -DMPI_CHOLLA 
 DFLAGS    += -DBLOCK

--- a/builds/setup.spock.cce.sh
+++ b/builds/setup.spock.cce.sh
@@ -3,7 +3,6 @@
 #-- This script needs to be source-d in the terminal, e.g.
 #   source ./setup.summit.xl.sh 
 
-module use /sw/spock/spack-envs/views/modules
 module load cray-python
 module load rocm/4.1.0
 module load craype-accel-amd-gfx908

--- a/builds/setup.summit.gcc.sh
+++ b/builds/setup.summit.gcc.sh
@@ -8,9 +8,11 @@
 #   on Summit
 module load gcc/10.2.0 cuda/11.2.0 fftw hdf5 python
 
-GCC_UMS_DIR=/sw/summit/ums/stf010/gcc
-latest=$(ls --color=never ${GCC_UMS_DIR} | tail -n1)
-export GCC_ROOT=$GCC_UMS_DIR/$latest
+GCC_UMS_DIR=/sw/summit/ums/stf010/gcc/10.2.1-20210504
+#latest=$(ls --color=never ${GCC_UMS_DIR} | tail -n1)
+#export GCC_ROOT=$GCC_UMS_DIR/$latest
+
+export GCC_ROOT=$GCC_UMS_DIR
 
 echo "Using GCC in $GCC_ROOT"
 

--- a/src/VL_2D_cuda.cu
+++ b/src/VL_2D_cuda.cu
@@ -127,7 +127,7 @@ Real VL_Algorithm_2D_CUDA ( Real *host_conserved0, Real *host_conserved1,
     get_offsets_2D(nx_s, ny_s, n_ghost, x_off, y_off, block, block1_tot, block2_tot, remainder1, remainder2, &x_off_s, &y_off_s);    
 
     // copy the conserved variables onto the GPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(dev_conserved, tmp1, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyHostToDevice) );
     #endif
 
@@ -223,7 +223,7 @@ Real VL_Algorithm_2D_CUDA ( Real *host_conserved0, Real *host_conserved1,
 
 
     // copy the conserved variable array back to the CPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(tmp2, dev_conserved, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyDeviceToHost) );
     #endif
 

--- a/src/VL_3D_cuda.cu
+++ b/src/VL_3D_cuda.cu
@@ -149,7 +149,7 @@ Real VL_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1,
     get_offsets_3D(nx_s, ny_s, nz_s, n_ghost, x_off, y_off, z_off, block, block1_tot, block2_tot, block3_tot, remainder1, remainder2, remainder3, &x_off_s, &y_off_s, &z_off_s);
 
     // copy the conserved variables onto the GPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(dev_conserved, tmp1, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyHostToDevice) );
     #endif
     
@@ -275,7 +275,7 @@ Real VL_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1,
     CudaCheckError();
 
     // copy the updated conserved variable array back to the CPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(tmp2, dev_conserved, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyDeviceToHost) );
     #endif
 

--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -11,7 +11,7 @@
 #include"error_handling.h"
 #include"mpi_routines.h"
 
-#ifdef MPI_GPU
+#ifdef HYDRO_GPU
 #include "omp.h"
 #endif
 
@@ -323,7 +323,7 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
     }
   }
   
-  #ifdef MPI_GPU
+  #ifdef HYDRO_GPU
   Set_Hydro_Boundaries_GPU ( a, iaBoundary, iaCell, nBoundaries, dir, flags );
   #else
   Set_Hydro_Boundaries_CPU ( a, iaBoundary, iaCell, nBoundaries, dir, flags );

--- a/src/cosmology/cosmology_functions.cpp
+++ b/src/cosmology/cosmology_functions.cpp
@@ -47,9 +47,9 @@ void Grid3D::Change_Cosmological_Frame_Sytem( bool forward ){
   
   Change_DM_Frame_System( forward );
   #ifndef ONLY_PARTICLES
-  #ifdef MPI_GPU
+  #ifdef HYDRO_GPU
   Change_GAS_Frame_System_GPU( forward );
-  #endif //MPI_GPU
+  #endif //HYDRO_GPU
   Change_GAS_Frame_System( forward );
   #endif//ONLY_PARTICLES
 }

--- a/src/global.h
+++ b/src/global.h
@@ -141,7 +141,6 @@ extern int N_DATA_PER_PARTICLE_TRANSFER;
 #define SIGN(a) ( ((a) < 0.) ? -1. : 1. )
 
 
-
 /* Global variables */
 extern Real gama; // Ratio of specific heats
 extern Real C_cfl; // CFL number (0 - 0.5)

--- a/src/gpu.hpp
+++ b/src/gpu.hpp
@@ -50,6 +50,7 @@ static void __attribute__((unused)) check(const hipfftResult err, const char *co
 #define cudaMemcpy hipMemcpy
 #define cudaMemcpyAsync hipMemcpyAsync
 #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
 #define cudaMemcpyHostToDevice hipMemcpyHostToDevice
 #define cudaMemGetInfo hipMemGetInfo
 #define cudaMemset hipMemset

--- a/src/gravity/grav3D.h
+++ b/src/gravity/grav3D.h
@@ -152,23 +152,6 @@ class Grav3D
     *  \brief Device Array containing the gravitational potential of each cell in the grid at the previous time step */
     Real *potential_1_d;
     
-    #if defined(MPI_CHOLLA) && !defined(MPI_GPU)
-    //Device buffers for potential transfers when the MPI_GPU is disabled
-    Real *send_buffer_potential_x0_d;
-    Real *send_buffer_potential_x1_d;
-    Real *send_buffer_potential_y0_d;
-    Real *send_buffer_potential_y1_d;
-    Real *send_buffer_potential_z0_d;
-    Real *send_buffer_potential_z1_d;
-    
-    Real *recv_buffer_potential_x0_d;
-    Real *recv_buffer_potential_x1_d;
-    Real *recv_buffer_potential_y0_d;
-    Real *recv_buffer_potential_y1_d;
-    Real *recv_buffer_potential_z0_d;
-    Real *recv_buffer_potential_z1_d;     
-    #endif//MPI_CHOLLA-MPI_GPU    
-    
     #endif //GRAVITY_GPU
     
     // Arrays for computing the potential values in isolated boundaries

--- a/src/gravity/gravity_functions_gpu.cu
+++ b/src/gravity/gravity_functions_gpu.cu
@@ -169,11 +169,11 @@ void Grid3D::Copy_Hydro_Density_to_Gravity_GPU(){
   cosmo_rho_0_gas = 1.0;
   #endif
   
-  #ifndef MPI_GPU
+  #ifndef HYDRO_GPU
   //Copy the hydro density from host to device
   int n_cells_total = ( nx_local + 2*n_ghost ) * ( ny_local + 2*n_ghost ) * ( nz_local + 2*n_ghost );
   CudaSafeCall( cudaMemcpy(C.d_density, C.density, n_cells_total*sizeof(Real), cudaMemcpyHostToDevice) ); 
-  #endif//MPI_GPU
+  #endif//HYDRO_GPU
    
   //Copy the density from the device array to the Poisson input density array
   hipLaunchKernelGGL(Copy_Hydro_Density_to_Gravity_Kernel, dim3dGrid, dim3dBlock, 0, 0,  C.d_density, Grav.F.density_d, nx_local, ny_local, nz_local, n_ghost, cosmo_rho_0_gas);

--- a/src/gravity/gravity_functions_gpu.cu
+++ b/src/gravity/gravity_functions_gpu.cu
@@ -13,35 +13,6 @@ void Grav3D::AllocateMemory_GPU(){
   CudaSafeCall( cudaMalloc((void**)&F.potential_d,   n_cells_potential*sizeof(Real)) );
   CudaSafeCall( cudaMalloc((void**)&F.potential_1_d, n_cells_potential*sizeof(Real)) );
   
-  #if defined(MPI_CHOLLA) && !defined(MPI_GPU)
-  //Device buffers for potential transfers when the MPI_GPU is disabled
-  int nGHST, nx_g, ny_g, nz_g;
-  nGHST = N_GHOST_POTENTIAL;
-  nx_g = nx_local + 2*nGHST;
-  ny_g = ny_local + 2*nGHST;
-  nz_g = nz_local + 2*nGHST;
-  
-  int buffer_size_x, buffer_size_y, buffer_size_z;
-  buffer_size_x = nGHST * nz_g * ny_g;
-  buffer_size_y = nGHST * nz_g * nx_g;
-  buffer_size_z = nGHST * nx_g * ny_g; 
-  
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_x0_d, buffer_size_x*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_x1_d, buffer_size_x*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_y0_d, buffer_size_y*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_y1_d, buffer_size_y*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_z0_d, buffer_size_z*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.send_buffer_potential_z1_d, buffer_size_z*sizeof(Real)) );
-
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_x0_d, buffer_size_x*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_x1_d, buffer_size_x*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_y0_d, buffer_size_y*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_y1_d, buffer_size_y*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_z0_d, buffer_size_z*sizeof(Real)) );
-  CudaSafeCall( cudaMalloc((void**)&F.recv_buffer_potential_z1_d, buffer_size_z*sizeof(Real)) );
-  chprintf( "Allocated Gravity GPU MPI Buffers  \n" );
-  #endif//MPI_CHOLLA-MPI_GPU    
-  
   #ifdef GRAVITY_GPU
 
   #ifdef GRAV_ISOLATED_BOUNDARY_X
@@ -69,21 +40,6 @@ void Grav3D::FreeMemory_GPU(void){
   cudaFree( F.potential_d );
   cudaFree( F.potential_1_d );
   
-  #if defined(MPI_CHOLLA) && !defined(MPI_GPU)  
-  cudaFree( F.send_buffer_potential_x0_d );
-  cudaFree( F.send_buffer_potential_x1_d );
-  cudaFree( F.send_buffer_potential_y0_d );
-  cudaFree( F.send_buffer_potential_y1_d );
-  cudaFree( F.send_buffer_potential_z0_d );
-  cudaFree( F.send_buffer_potential_z1_d );
-  
-  cudaFree( F.recv_buffer_potential_x0_d );
-  cudaFree( F.recv_buffer_potential_x1_d );
-  cudaFree( F.recv_buffer_potential_y0_d );
-  cudaFree( F.recv_buffer_potential_y1_d );
-  cudaFree( F.recv_buffer_potential_z0_d );
-  cudaFree( F.recv_buffer_potential_z1_d );
-  #endif//MPI_CHOLLA-MPI_GPU   
   
   #ifdef GRAVITY_GPU
   

--- a/src/gravity/paris/PoissonPeriodic3DBlockedGPU.cu
+++ b/src/gravity/paris/PoissonPeriodic3DBlockedGPU.cu
@@ -80,7 +80,7 @@ PoissonPeriodic3DBlockedGPU::PoissonPeriodic3DBlockedGPU(const int n[3], const d
     CHECK(cufftPlanMany(&zd2d_,2,njnk,njnh,1,njh,njnk,1,njk,CUFFT_Z2D,niSlab));
     CHECK(cufftPlanMany(&zz1d_,1,&ni_,&ni_,1,ni_,&ni_,1,ni_,CUFFT_Z2Z,njhPencil));
   }
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaHostAlloc(&ha_,bytes_+bytes_,cudaHostAllocDefault));
   assert(ha_);
   hb_ = ha_+nMax;
@@ -89,7 +89,7 @@ PoissonPeriodic3DBlockedGPU::PoissonPeriodic3DBlockedGPU(const int n[3], const d
 
 PoissonPeriodic3DBlockedGPU::~PoissonPeriodic3DBlockedGPU()
 {
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaFreeHost(ha_));
   ha_ = hb_ = nullptr;
 #endif
@@ -128,7 +128,7 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
 
   // Copy blocks to slabs
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,da,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,nBlockSlab,MPI_DOUBLE,hb_,nBlockSlab,MPI_DOUBLE,commSlab_);
   CHECK(cudaMemcpyAsync(db,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -163,7 +163,7 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
   const int njhPencil = (njh+m-1)/m;
   const int nSlabPencil = 2*njhPencil*niSlab;
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,da,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,nSlabPencil,MPI_DOUBLE,hb_,nSlabPencil,MPI_DOUBLE,MPI_COMM_WORLD);
   CHECK(cudaMemcpyAsync(db,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -257,7 +257,7 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
       cb[ib].y = ca[ia].y;
     });
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(hb_,db,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(hb_,nSlabPencil,MPI_DOUBLE,ha_,nSlabPencil,MPI_DOUBLE,commWorld_);
   CHECK(cudaMemcpyAsync(da,ha_,bytes_,cudaMemcpyHostToDevice,0));
@@ -290,7 +290,7 @@ void PoissonPeriodic3DBlockedGPU::solve(const long bytes, double *const da, doub
       db[ib] = divN*da[ia];
     });
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(hb_,db,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(hb_,nBlockSlab,MPI_DOUBLE,ha_,nBlockSlab,MPI_DOUBLE,commSlab_);
   CHECK(cudaMemcpyAsync(da,ha_,bytes_,cudaMemcpyHostToDevice,0));

--- a/src/gravity/paris/PoissonPeriodic3DBlockedGPU.hpp
+++ b/src/gravity/paris/PoissonPeriodic3DBlockedGPU.hpp
@@ -16,7 +16,7 @@ class PoissonPeriodic3DBlockedGPU {
     int ni_,nj_,nk_;
     long bytes_;
     cufftHandle dz2d_,zd2d_,zz1d_;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
     double *ha_, *hb_;
 #endif
 };

--- a/src/gravity/paris/PoissonPeriodic3x1DBlockedGPU.cu
+++ b/src/gravity/paris/PoissonPeriodic3x1DBlockedGPU.cu
@@ -90,7 +90,7 @@ PoissonPeriodic3x1DBlockedGPU::PoissonPeriodic3x1DBlockedGPU(const int n[3], con
   CHECK(cufftPlanMany(&c2rk_,1,&nk_,&nh_,1,nh_,&nk_,1,nk_,CUFFT_Z2D,dip_*djq_));
   CHECK(cufftPlanMany(&r2ck_,1,&nk_,&nk_,1,nk_,&nh_,1,nh_,CUFFT_D2Z,dip_*djq_));
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaHostAlloc(&ha_,bytes_+bytes_,cudaHostAllocDefault));
   assert(ha_);
   hb_ = ha_+nMax;
@@ -99,7 +99,7 @@ PoissonPeriodic3x1DBlockedGPU::PoissonPeriodic3x1DBlockedGPU(const int n[3], con
 
 PoissonPeriodic3x1DBlockedGPU::~PoissonPeriodic3x1DBlockedGPU()
 {
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaFreeHost(ha_));
   ha_ = hb_ = nullptr;
 #endif
@@ -146,7 +146,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
     });
 
   const int countK = dip*djq*dk;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countK,MPI_DOUBLE,hb_,countK,MPI_DOUBLE,commK_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));
@@ -191,7 +191,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
   }
 
   const int countJ = 2*dip*djq*dhq;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countJ,MPI_DOUBLE,hb_,countJ,MPI_DOUBLE,commJ_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));
@@ -238,7 +238,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
   }
  
   const int countI = 2*dip*djp*dhq;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countI,MPI_DOUBLE,hb_,countI,MPI_DOUBLE,commI_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));
@@ -333,7 +333,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
       });
   }
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countI,MPI_DOUBLE,hb_,countI,MPI_DOUBLE,commI_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));
@@ -379,7 +379,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
       });
   }
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countJ,MPI_DOUBLE,hb_,countJ,MPI_DOUBLE,commJ_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));
@@ -424,7 +424,7 @@ void PoissonPeriodic3x1DBlockedGPU::solve(const size_t bytes, double *const dens
       });
   }
 
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,a,bytes,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,countK,MPI_DOUBLE,hb_,countK,MPI_DOUBLE,commK_);
   CHECK(cudaMemcpy(b,hb_,bytes,cudaMemcpyHostToDevice));

--- a/src/gravity/paris/PoissonPeriodic3x1DBlockedGPU.hpp
+++ b/src/gravity/paris/PoissonPeriodic3x1DBlockedGPU.hpp
@@ -22,7 +22,7 @@ class PoissonPeriodic3x1DBlockedGPU {
     int dhq_,dip_,djp_,djq_;
     size_t bytes_;
     cufftHandle c2ci_,c2cj_,c2rk_,r2ck_;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
     double *ha_, *hb_;
 #endif
 };

--- a/src/gravity/paris/PoissonZero3DBlockedGPU.cu
+++ b/src/gravity/paris/PoissonZero3DBlockedGPU.cu
@@ -83,7 +83,7 @@ PoissonZero3DBlockedGPU::PoissonZero3DBlockedGPU(const int n[3], const double lo
   CHECK(cufftPlanMany(&d2zj_,1,&nj_,&nj_,1,nj_,&njh,1,njh,CUFFT_D2Z,dip_*dkq_));
   int nih = ni_/2+1;
   CHECK(cufftPlanMany(&d2zi_,1,&ni_,&ni_,1,ni_,&nih,1,nih,CUFFT_D2Z,dkq_*djp_));
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaHostAlloc(&ha_,bytes_+bytes_,cudaHostAllocDefault));
   assert(ha_);
   hb_ = ha_+nMax;
@@ -92,7 +92,7 @@ PoissonZero3DBlockedGPU::PoissonZero3DBlockedGPU(const int n[3], const double lo
 
 PoissonZero3DBlockedGPU::~PoissonZero3DBlockedGPU()
 {
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaFreeHost(ha_));
   ha_ = hb_ = nullptr;
 #endif
@@ -157,7 +157,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
       const int jLo = q*djq;
       if ((i+iLo < di) && (j+jLo < dj)) ua[(((p*mq+q)*dip+i)*djq+j)*dk+k] = ub[((i+iLo)*dj+j+jLo)*dk+k];
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dip*djq*dk,MPI_DOUBLE,hb_,dip*djq*dk,MPI_DOUBLE,commK_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -210,7 +210,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
         ua[((qb*dip+i)*dkq+kb)*djq+j] = wb*ak-wa*bk;
       }
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dip*dkq*djq,MPI_DOUBLE,hb_,dip*dkq*djq,MPI_DOUBLE,commJ_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -262,7 +262,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
         ua[((pb*dkq+k)*djp+jb)*dip+i] = wb*aj-wa*bj;
       }
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dkq*djp*dip,MPI_DOUBLE,hb_,dkq*djp*dip,MPI_DOUBLE,commI_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -386,7 +386,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
         ua[(((idb*mp+pb)*dkq+k)*dip+ib)*djp+j] = ai+bi;
       }
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dkq*djp*dip,MPI_DOUBLE,hb_,dkq*djp*dip,MPI_DOUBLE,commI_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -446,7 +446,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
         ua[(((idb*mq+qb)*dip+i)*djq+jb)*dkq+k] = aj+bj;
       }
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dip*djq*dkq,MPI_DOUBLE,hb_,dip*djq*dkq,MPI_DOUBLE,commJ_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));
@@ -504,7 +504,7 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
         ua[((pqb*dip+i)*djq+j)*dk+kb] = divN*(ak+bk);
       }
     });
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_,ua,bytes_,cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_,dip*djq*dk,MPI_DOUBLE,hb_,dip*djq*dk,MPI_DOUBLE,commK_);
   CHECK(cudaMemcpyAsync(ub,hb_,bytes_,cudaMemcpyHostToDevice,0));

--- a/src/gravity/paris/PoissonZero3DBlockedGPU.hpp
+++ b/src/gravity/paris/PoissonZero3DBlockedGPU.hpp
@@ -22,7 +22,7 @@ class PoissonZero3DBlockedGPU {
     int ni2_,nj2_,nk2_;
     long bytes_;
     cufftHandle d2zi_,d2zj_,d2zk_;
-#ifdef PARIS_NO_GPU_MPI
+#ifndef MPI_GPU
     double *ha_, *hb_;
 #endif
 };

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -819,6 +819,11 @@ class Grid3D
 
 };
 
+// typedef for Grid3D_PointerMemberFunction 
 typedef void (Grid3D::*Grid3D_PMF_UnloadHydroBuffer)(Real *);
+typedef void (Grid3D::*Grid3D_PMF_UnloadGravityPotential) 
+               (int, int, Real *, int);
+typedef void (Grid3D::*Grid3D_PMF_UnloadParticleDensity) 
+               (int, int, Real *);
 
 #endif //GRID3D_H

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -636,19 +636,32 @@ class Grid3D
     void Unload_MPI_Comm_Buffers(int index);
     void Unload_MPI_Comm_Buffers_SLAB(int index);
     void Unload_MPI_Comm_Buffers_BLOCK(int index);
-    void Unload_MPI_Comm_DeviceBuffers_BLOCK(int index);
-    int Load_Hydro_Buffer_X0();
-    int Load_Hydro_Buffer_X1();
-    int Load_Hydro_Buffer_Y0();
-    int Load_Hydro_Buffer_Y1();
-    int Load_Hydro_Buffer_Z0();
-    int Load_Hydro_Buffer_Z1();
-    int Load_Hydro_DeviceBuffer_X0();
-    int Load_Hydro_DeviceBuffer_X1();
-    int Load_Hydro_DeviceBuffer_Y0();
-    int Load_Hydro_DeviceBuffer_Y1();
-    int Load_Hydro_DeviceBuffer_Z0();
-    int Load_Hydro_DeviceBuffer_Z1();
+    
+    int Load_Hydro_Buffer_X0(Real *buffer);
+    int Load_Hydro_Buffer_X1(Real *buffer);
+    int Load_Hydro_Buffer_Y0(Real *buffer);
+    int Load_Hydro_Buffer_Y1(Real *buffer);
+    int Load_Hydro_Buffer_Z0(Real *buffer);
+    int Load_Hydro_Buffer_Z1(Real *buffer);
+    int Load_Hydro_DeviceBuffer_X0(Real *buffer);
+    int Load_Hydro_DeviceBuffer_X1(Real *buffer);
+    int Load_Hydro_DeviceBuffer_Y0(Real *buffer);
+    int Load_Hydro_DeviceBuffer_Y1(Real *buffer);
+    int Load_Hydro_DeviceBuffer_Z0(Real *buffer);
+    int Load_Hydro_DeviceBuffer_Z1(Real *buffer);
+    
+    void Unload_Hydro_Buffer_X0(Real *buffer);
+    void Unload_Hydro_Buffer_X1(Real *buffer);
+    void Unload_Hydro_Buffer_Y0(Real *buffer);
+    void Unload_Hydro_Buffer_Y1(Real *buffer);
+    void Unload_Hydro_Buffer_Z0(Real *buffer);
+    void Unload_Hydro_Buffer_Z1(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_X0(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_X1(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_Y0(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_Y1(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_Z0(Real *buffer);
+    void Unload_Hydro_DeviceBuffer_Z1(Real *buffer);
 #endif /*MPI_CHOLLA*/
 
   #ifdef GRAVITY
@@ -806,6 +819,6 @@ class Grid3D
 
 };
 
-
+typedef void (Grid3D::*Grid3D_PMF_UnloadHydroBuffer)(Real *);
 
 #endif //GRID3D_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
   if (strcmp(P.init, "Read_Grid") != 0 || G.H.Output_Now ) {
     // write the initial conditions to file
     chprintf("Writing initial conditions to file...\n");
-    #ifdef MPI_GPU
+    #ifdef HYDRO_GPU
     cudaMemcpy(G.C.density, G.C.device, 
              G.H.n_fields*G.H.n_cells*sizeof(Real), cudaMemcpyDeviceToHost);
     #endif
@@ -253,7 +253,7 @@ int main(int argc, char *argv[])
     {
       #ifdef OUTPUT
       /*output the grid data*/
-      #ifdef MPI_GPU
+      #ifdef HYDRO_GPU
       cudaMemcpy(G.C.density, G.C.device, 
                  G.H.n_fields*G.H.n_cells*sizeof(Real), cudaMemcpyDeviceToHost);
       #endif
@@ -272,7 +272,7 @@ int main(int argc, char *argv[])
     #ifdef N_STEPS_LIMIT
     // Exit the loop when reached the limit number of steps (optional)
     if ( G.H.n_step == N_STEPS_LIMIT) {
-      #ifdef MPI_GPU
+      #ifdef HYDRO_GPU
       cudaMemcpy(G.C.density, G.C.device, 
                  G.H.n_fields*G.H.n_cells*sizeof(Real), cudaMemcpyDeviceToHost);
       #endif

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -2337,11 +2337,10 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
                                Fptr_Unload_Hydro_Buffer_Y1,
                                Fptr_Unload_Hydro_Buffer_Z0,
                                Fptr_Unload_Hydro_Buffer_Z1;
+  
+  Grid3D_PMF_UnloadGravityPotential Fptr_Unload_Gravity_Potential;
+  Grid3D_PMF_UnloadParticleDensity Fptr_Unload_Particle_Density;
        
-  void (*Fptr_Unload_Gravity_Potential)(int, int, Real *, int),
-       (*Fptr_Unload_Particle_Density)(int, int, Real *);
-  
-  
   if ( H.TRANSFER_HYDRO_BOUNDARIES ) {
     #ifdef HYDRO_GPU
       #ifndef MPI_GPU
@@ -2403,7 +2402,8 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
     l_recv_buffer_z0 = d_recv_buffer_z0;
     l_recv_buffer_z1 = d_recv_buffer_z1;
     
-    Fptr_Unload_Gravity_Potential = &Unload_Gravity_Potential_from_Buffer_GPU
+    Fptr_Unload_Gravity_Potential 
+      = &Grid3D::Unload_Gravity_Potential_from_Buffer_GPU;
     
     #else
 
@@ -2414,16 +2414,17 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
     l_recv_buffer_z0 = h_recv_buffer_z0;
     l_recv_buffer_z1 = h_recv_buffer_z1;
     
-    Fptr_Unload_Gravity_Potential = &Unload_Gravity_Potential_from_Buffer
+    Fptr_Unload_Gravity_Potential 
+      = &Grid3D::Unload_Gravity_Potential_from_Buffer;
     
     #endif // GRAVITY_GPU
     
-    if ( index == 0 ) Fptr_Unload_Gravity_Potential( 0, 0, l_recv_buffer_x0, 0  );
-    if ( index == 1 ) Fptr_Unload_Gravity_Potential( 0, 1, l_recv_buffer_x1, 0  );
-    if ( index == 2 ) Fptr_Unload_Gravity_Potential( 1, 0, l_recv_buffer_y0, 0  );
-    if ( index == 3 ) Fptr_Unload_Gravity_Potential( 1, 1, l_recv_buffer_y1, 0  );
-    if ( index == 4 ) Fptr_Unload_Gravity_Potential( 2, 0, l_recv_buffer_z0, 0  );
-    if ( index == 5 ) Fptr_Unload_Gravity_Potential( 2, 1, l_recv_buffer_z1, 0  );
+    if ( index == 0 ) (this->*Fptr_Unload_Gravity_Potential)( 0, 0, l_recv_buffer_x0, 0  );
+    if ( index == 1 ) (this->*Fptr_Unload_Gravity_Potential)( 0, 1, l_recv_buffer_x1, 0  );
+    if ( index == 2 ) (this->*Fptr_Unload_Gravity_Potential)( 1, 0, l_recv_buffer_y0, 0  );
+    if ( index == 3 ) (this->*Fptr_Unload_Gravity_Potential)( 1, 1, l_recv_buffer_y1, 0  );
+    if ( index == 4 ) (this->*Fptr_Unload_Gravity_Potential)( 2, 0, l_recv_buffer_z0, 0  );
+    if ( index == 5 ) (this->*Fptr_Unload_Gravity_Potential)( 2, 1, l_recv_buffer_z1, 0  );
   }
   
   #ifdef SOR
@@ -2462,7 +2463,7 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
     l_recv_buffer_z1 = d_recv_buffer_z1;
     
     Fptr_Unload_Particle_Density 
-      = &Unload_Particles_Density_Boundary_From_Buffer_GPU
+      = &Grid3D::Unload_Particles_Density_Boundary_From_Buffer_GPU;
     
     #else
     
@@ -2474,16 +2475,16 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
     l_recv_buffer_z1 = d_recv_buffer_z1;
     
     Fptr_Unload_Particle_Density 
-      = &Unload_Particles_Density_Boundary_From_Buffer
+      = &Grid3D::Unload_Particles_Density_Boundary_From_Buffer;
     
     #endif // PARTICLES_GPU
     
-    if ( index == 0 ) Fptr_Unload_Particle_Density( 0, 0, l_recv_buffer_x0 );
-    if ( index == 1 ) Fptr_Unload_Particle_Density( 0, 1, l_recv_buffer_x1 );
-    if ( index == 2 ) Fptr_Unload_Particle_Density( 1, 0, l_recv_buffer_y0 );
-    if ( index == 3 ) Fptr_Unload_Particle_Density( 1, 1, l_recv_buffer_y1 );
-    if ( index == 4 ) Fptr_Unload_Particle_Density( 2, 0, l_recv_buffer_z0 );
-    if ( index == 5 ) Fptr_Unload_Particle_Density( 2, 1, l_recv_buffer_z1 );
+    if ( index == 0 ) (this->*Fptr_Unload_Particle_Density)( 0, 0, l_recv_buffer_x0 );
+    if ( index == 1 ) (this->*Fptr_Unload_Particle_Density)( 0, 1, l_recv_buffer_x1 );
+    if ( index == 2 ) (this->*Fptr_Unload_Particle_Density)( 1, 0, l_recv_buffer_y0 );
+    if ( index == 3 ) (this->*Fptr_Unload_Particle_Density)( 1, 1, l_recv_buffer_y1 );
+    if ( index == 4 ) (this->*Fptr_Unload_Particle_Density)( 2, 0, l_recv_buffer_z0 );
+    if ( index == 5 ) (this->*Fptr_Unload_Particle_Density)( 2, 1, l_recv_buffer_z1 );
   }
   
   #endif  //PARTICLES

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -1064,7 +1064,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // load left x communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_X0();
         #else
         buffer_length = Load_Hydro_Buffer_X0();
@@ -1119,7 +1119,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // load right x communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_X1();
         #else
         buffer_length = Load_Hydro_Buffer_X1();
@@ -1182,7 +1182,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // load left y communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Y0();
         #else
         buffer_length = Load_Hydro_Buffer_Y0();
@@ -1237,7 +1237,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // load right y communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Y1();
         #else
         buffer_length = Load_Hydro_Buffer_Y1();
@@ -1302,7 +1302,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // left z communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Z0();
         #else
         buffer_length = Load_Hydro_Buffer_Z0();
@@ -1357,7 +1357,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       // load right z communication buffer
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
-        #ifdef MPI_GPU
+        #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Z1();
         #else
         buffer_length = Load_Hydro_Buffer_Z1();
@@ -1495,7 +1495,7 @@ void Grid3D::Unload_MPI_Comm_Buffers(int index)
       Unload_MPI_Comm_Buffers_SLAB(index);
       break;
     case BLOCK_DECOMP:
-      #ifdef MPI_GPU
+      #ifdef HYDRO_GPU
       Unload_MPI_Comm_DeviceBuffers_BLOCK(index);
       #else
       Unload_MPI_Comm_Buffers_BLOCK(index);

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -491,7 +491,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_SLAB(int *flags)
 }
 
 // load left x communication buffer
-int Grid3D::Load_Hydro_Buffer_X0(){
+int Grid3D::Load_Hydro_Buffer_X0( Real * send_buffer_x0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -544,7 +544,7 @@ int Grid3D::Load_Hydro_Buffer_X0(){
 }
 
 
-int Grid3D::Load_Hydro_DeviceBuffer_X0(){
+int Grid3D::Load_Hydro_DeviceBuffer_X0 ( Real *send_buffer_x0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -613,7 +613,7 @@ int Grid3D::Load_Hydro_DeviceBuffer_X0(){
 
 
 // load right x communication buffer
-int Grid3D::Load_Hydro_Buffer_X1(){
+int Grid3D::Load_Hydro_Buffer_X1 ( Real *send_buffer_x1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -666,7 +666,7 @@ int Grid3D::Load_Hydro_Buffer_X1(){
 
 
 // load right x communication buffer
-int Grid3D::Load_Hydro_DeviceBuffer_X1(){
+int Grid3D::Load_Hydro_DeviceBuffer_X1 ( Real *send_buffer_x1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -734,7 +734,7 @@ int Grid3D::Load_Hydro_DeviceBuffer_X1(){
 }
 
 // load left y communication buffer
-int Grid3D::Load_Hydro_Buffer_Y0(){
+int Grid3D::Load_Hydro_Buffer_Y0 ( Real *send_buffer_y0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -775,7 +775,7 @@ int Grid3D::Load_Hydro_Buffer_Y0(){
 
 
 // load left y communication buffer
-int Grid3D::Load_Hydro_DeviceBuffer_Y0(){
+int Grid3D::Load_Hydro_DeviceBuffer_Y0 ( Real *send_buffer_y0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -828,7 +828,7 @@ int Grid3D::Load_Hydro_DeviceBuffer_Y0(){
 
 
 // load right y communication buffer
-int Grid3D::Load_Hydro_Buffer_Y1(){
+int Grid3D::Load_Hydro_Buffer_Y1 ( Real *send_buffer_y1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -868,7 +868,7 @@ int Grid3D::Load_Hydro_Buffer_Y1(){
 }
 
 
-int Grid3D::Load_Hydro_DeviceBuffer_Y1(){
+int Grid3D::Load_Hydro_DeviceBuffer_Y1 ( Real *send_buffer_y1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -920,7 +920,7 @@ int Grid3D::Load_Hydro_DeviceBuffer_Y1(){
 }
 
 // load left z communication buffer
-int Grid3D::Load_Hydro_Buffer_Z0(){
+int Grid3D::Load_Hydro_Buffer_Z0 ( Real *send_buffer_z0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -946,7 +946,7 @@ int Grid3D::Load_Hydro_Buffer_Z0(){
 }
 
 // load left z communication buffer
-int Grid3D::Load_Hydro_DeviceBuffer_Z0(){
+int Grid3D::Load_Hydro_DeviceBuffer_Z0 ( Real *send_buffer_z0 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -980,7 +980,7 @@ int Grid3D::Load_Hydro_DeviceBuffer_Z0(){
 }
 
 // load right z communication buffer
-int Grid3D::Load_Hydro_Buffer_Z1(){
+int Grid3D::Load_Hydro_Buffer_Z1 ( Real *send_buffer_z1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -1004,7 +1004,7 @@ int Grid3D::Load_Hydro_Buffer_Z1(){
 }
 
 
-int Grid3D::Load_Hydro_DeviceBuffer_Z1(){
+int Grid3D::Load_Hydro_DeviceBuffer_Z1 ( Real *send_buffer_z1 ){
   int i, j, k, ii;
   int gidx;
   int idx;
@@ -1035,6 +1035,636 @@ int Grid3D::Load_Hydro_DeviceBuffer_Z1(){
 }
 
 
+void Grid3D::Unload_Hydro_Buffer_X0 ( Real *recv_buffer_x0 ) {
+  
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+  
+  // 1D
+  if (ny == 1 && nz == 1) {
+    offset = n_ghost;
+    for(i=0;i<n_ghost;i++) {
+      idx  = i;
+      gidx = i;
+      for (ii=0; ii<n_fields; ii++) { 
+        c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+      }
+    }
+  }
+  // 2D
+  if (ny > 1 && nz == 1) {
+    offset = n_ghost*(ny-2*n_ghost);
+    for(i=0;i<n_ghost;i++) {
+      for (j=0;j<ny-2*n_ghost;j++) {
+        idx  = i + (j+n_ghost)*nx;
+        gidx = i + j*n_ghost;
+        for (ii=0; ii<n_fields; ii++) { 
+          c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
+    for(i=0;i<n_ghost;i++) {
+      for(j=0;j<ny-2*n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_X0 ( Real *recv_buffer_x0 ) {
+  
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+  
+  // 1D
+  if (ny == 1 && nz == 1) {
+    offset = n_ghost;
+    #pragma omp target teams distribute parallel for \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x0, c_head )
+    for(i=0;i<n_ghost;i++) {
+      idx  = i;
+      gidx = i;
+      for (ii=0; ii<n_fields; ii++) { 
+        c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+      }
+    }
+  }
+  // 2D
+  if (ny > 1 && nz == 1) {
+    offset = n_ghost*(ny-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 2 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x0, c_head )
+    for(i=0;i<n_ghost;i++) {
+      for (j=0;j<ny-2*n_ghost;j++) {
+        idx  = i + (j+n_ghost)*nx;
+        gidx = i + j*n_ghost;
+        for (ii=0; ii<n_fields; ii++) { 
+          c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 3 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x0, c_head )
+    for(i=0;i<n_ghost;i++) {
+      for(j=0;j<ny-2*n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_Buffer_X1 ( Real *recv_buffer_x1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+
+  // 1D
+  if (ny == 1 && nz == 1) {
+    offset = n_ghost;
+    for(i=0;i<n_ghost;i++) {
+      idx  = i+nx-n_ghost;
+      gidx = i;
+      for (ii=0; ii<n_fields; ii++) {
+        c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+      }
+    }
+  }
+  // 2D
+  if (ny > 1 && nz == 1) {
+    offset = n_ghost*(ny-2*n_ghost);
+    for(i=0;i<n_ghost;i++) {
+      for (j=0;j<ny-2*n_ghost;j++) {
+        idx  = i+nx-n_ghost + (j+n_ghost)*nx;
+        gidx = i + j*n_ghost;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
+    for(i=0;i<n_ghost;i++) {
+      for(j=0;j<ny-2*n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i+nx-n_ghost + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+            
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_X1 ( Real *recv_buffer_x1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+
+  // 1D
+  if (ny == 1 && nz == 1) {
+    offset = n_ghost;
+    #pragma omp target teams distribute parallel for \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x1, c_head )
+    for(i=0;i<n_ghost;i++) {
+      idx  = i+nx-n_ghost;
+      gidx = i;
+      for (ii=0; ii<n_fields; ii++) {
+        c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+      }
+    }
+  }
+  // 2D
+  if (ny > 1 && nz == 1) {
+    offset = n_ghost*(ny-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 2 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x1, c_head )
+    for(i=0;i<n_ghost;i++) {
+      for (j=0;j<ny-2*n_ghost;j++) {
+        idx  = i+nx-n_ghost + (j+n_ghost)*nx;
+        gidx = i + j*n_ghost;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 3 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_x1, c_head )
+    for(i=0;i<n_ghost;i++) {
+      for(j=0;j<ny-2*n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i+nx-n_ghost + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
+            
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_Buffer_Y0 ( Real *recv_buffer_y0 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+
+  // 2D
+  if (nz == 1) {
+    offset = n_ghost*nx;
+    for(i=0;i<nx;i++) {
+      for (j=0;j<n_ghost;j++) {
+        idx  = i + j*nx;
+        gidx = i + j*nx;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*nx*(nz-2*n_ghost);
+    for(i=0;i<nx;i++) {
+      for(j=0;j<n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + j*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*nx + k*nx*n_ghost;
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_Y0 ( Real *recv_buffer_y0 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+
+  // 2D
+  if (nz == 1) {
+    offset = n_ghost*nx;
+    #pragma omp target teams distribute parallel for collapse ( 2 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_y0, c_head )
+    for(i=0;i<nx;i++) {
+      for (j=0;j<n_ghost;j++) {
+        idx  = i + j*nx;
+        gidx = i + j*nx;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*nx*(nz-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 3 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_y0, c_head )
+    for(i=0;i<nx;i++) {
+      for(j=0;j<n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + j*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*nx + k*nx*n_ghost;
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_Buffer_Y1 ( Real *recv_buffer_y1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+
+  // 2D
+  if (nz == 1) {
+    offset = n_ghost*nx;
+    for(i=0;i<nx;i++) {
+      for (j=0;j<n_ghost;j++) {
+        idx  = i + (j+ny-n_ghost)*nx;
+        gidx = i + j*nx;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*nx*(nz-2*n_ghost);
+    for(i=0;i<nx;i++) {
+      for(j=0;j<n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + (j+ny-n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*nx + k*nx*n_ghost;
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+  
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_Y1 ( Real *recv_buffer_y1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+
+  // 2D
+  if (nz == 1) {
+    offset = n_ghost*nx;
+    #pragma omp target teams distribute parallel for collapse ( 2 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_y1, c_head )
+    for(i=0;i<nx;i++) {
+      for (j=0;j<n_ghost;j++) {
+        idx  = i + (j+ny-n_ghost)*nx;
+        gidx = i + j*nx;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+  // 3D
+  if (nz > 1) {
+    offset = n_ghost*nx*(nz-2*n_ghost);
+    #pragma omp target teams distribute parallel for collapse ( 3 ) \
+        private ( idx, gidx, ii ) \
+        firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+        is_device_ptr ( recv_buffer_y1, c_head )
+    for(i=0;i<nx;i++) {
+      for(j=0;j<n_ghost;j++) {
+        for(k=0;k<nz-2*n_ghost;k++) {
+          idx  = i + (j+ny-n_ghost)*nx + (k+n_ghost)*nx*ny;
+          gidx = i + j*nx + k*nx*n_ghost;
+          for (ii=0; ii<n_fields; ii++) {
+            c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
+          }
+        }
+      }
+    }
+  }
+  
+}
+
+
+void Grid3D::Unload_Hydro_Buffer_Z0 ( Real *recv_buffer_z0 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+
+  offset = n_ghost*nx*ny;
+  for(i=0;i<nx;i++) {
+    for(j=0;j<ny;j++) {
+      for(k=0;k<n_ghost;k++) {
+        idx  = i + j*nx + k*nx*ny;
+        gidx = i + j*nx + k*nx*ny;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_z0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_Z0 ( Real *recv_buffer_z0 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+
+  offset = n_ghost*nx*ny;
+  #pragma omp target teams distribute parallel for collapse ( 3 ) \
+      private ( idx, gidx, ii ) \
+      firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+      is_device_ptr ( recv_buffer_z0, c_head )
+  for(i=0;i<nx;i++) {
+    for(j=0;j<ny;j++) {
+      for(k=0;k<n_ghost;k++) {
+        idx  = i + j*nx + k*nx*ny;
+        gidx = i + j*nx + k*nx*ny;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_z0 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_Buffer_Z1 ( Real *recv_buffer_z1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.density;
+
+  offset = n_ghost*nx*ny;
+  for(i=0;i<nx;i++) {
+    for(j=0;j<ny;j++) {
+      for(k=0;k<n_ghost;k++) {
+        idx  = i + j*nx + (k+nz-n_ghost)*nx*ny;
+        gidx = i + j*nx + k*nx*ny;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_z1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+
+}
+
+
+void Grid3D::Unload_Hydro_DeviceBuffer_Z1 ( Real *recv_buffer_z1 ) {
+
+  int i, j, k, ii;
+  int idx;
+  int gidx;
+  int offset;
+  int n_ghost, nx, ny, nz, n_fields, n_cells;
+  Real *c_head;
+  
+  n_ghost   = H.n_ghost;
+  nx        = H.nx;
+  ny        = H.ny;
+  nz        = H.nz;
+  n_fields  = H.n_fields;	
+  n_cells   = H.n_cells;
+  
+  c_head = (Real *) C.device;
+
+  offset = n_ghost*nx*ny;
+  #pragma omp target teams distribute parallel for collapse ( 3 ) \
+      private ( idx, gidx, ii ) \
+      firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
+      is_device_ptr ( recv_buffer_z1, c_head )
+  for(i=0;i<nx;i++) {
+    for(j=0;j<ny;j++) {
+      for(k=0;k<n_ghost;k++) {
+        idx  = i + j*nx + (k+nz-n_ghost)*nx*ny;
+        gidx = i + j*nx + k*nx*ny;
+        for (ii=0; ii<n_fields; ii++) {
+          c_head[idx + ii*n_cells] = *(recv_buffer_z1 + gidx + ii*offset);
+        }
+      }
+    }
+  }
+
+}
+
+
 void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
 {
   
@@ -1047,9 +1677,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
   ireq_n_particles = 0;
   ireq_particles_transfer = 0;
   #endif
-
+  
   int ireq;
   ireq = 0;
+  
+  int xbsize = x_buffer_length,
+      ybsize = y_buffer_length,
+      zbsize = z_buffer_length;
 
   int buffer_length;
   
@@ -1065,32 +1699,44 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_X0();
+        buffer_length = Load_Hydro_DeviceBuffer_X0(d_send_buffer_x0);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x0, d_send_buffer_x0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_X0();
+        buffer_length = Load_Hydro_Buffer_X0(h_send_buffer_x0);
         #endif
         }
       
       #ifdef GRAVITY 
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 0, 0, send_buffer_x0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 0, 0, d_send_buffer_x0, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x0, d_send_buffer_x0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 0, 0, send_buffer_x0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 0, 0, h_send_buffer_x0, 0 );
         #endif
         
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 0, 0, send_buffer_x0 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 0, 0, h_send_buffer_x0 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 0, 0, send_buffer_x0  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 0, 0, d_send_buffer_x0  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x0, d_send_buffer_x0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 0, 0, send_buffer_x0  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 0, 0, h_send_buffer_x0  );
         #endif
       } 
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1102,11 +1748,29 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
    
       if ( transfer_main_buffer ){
+        #ifdef MPI_GPU
+        
         //post non-blocking receive left x communication buffer
-        MPI_Irecv(recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, 
+                  world, &recv_request[ireq]);
 
         //non-blocking send left x communication buffer
-        MPI_Isend(send_buffer_x0, buffer_length, MPI_CHREAL, dest[0],   1, world, &send_request[0]);
+        MPI_Isend(d_send_buffer_x0, buffer_length, MPI_CHREAL, dest[0], 1, 
+                  world, &send_request[0]);
+        
+        
+        #else
+        
+        //post non-blocking receive left x communication buffer
+        MPI_Irecv(h_recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, 
+                  world, &recv_request[ireq]);
+
+        //non-blocking send left x communication buffer
+        MPI_Isend(h_send_buffer_x0, buffer_length, MPI_CHREAL, dest[0], 1, 
+                  world, &send_request[0]);
+        
+        #endif
+        
         MPI_Request_free(send_request);
 
         //keep track of how many sends and receives are expected
@@ -1120,9 +1784,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_X1();
+        buffer_length = Load_Hydro_DeviceBuffer_X1(d_send_buffer_x1);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x1, d_send_buffer_x1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_X1();
+        buffer_length = Load_Hydro_Buffer_X1(h_send_buffer_x1);
         #endif
         //printf("X1 len: %d\n", buffer_length);
         }
@@ -1130,22 +1798,30 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #ifdef GRAVITY
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 0, 1, send_buffer_x1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 0, 1, d_send_buffer_x1, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x1, d_send_buffer_x1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 0, 1, send_buffer_x1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 0, 1, h_send_buffer_x1, 0 );
         #endif
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 0, 1, send_buffer_x1 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 0, 1, h_send_buffer_x1 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 0, 1, send_buffer_x1  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 0, 1, d_send_buffer_x1  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_x1, d_send_buffer_x1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 0, 1, send_buffer_x1  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 0, 1, h_send_buffer_x1  );
         #endif
       }
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1157,11 +1833,24 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
+        #ifdef MPI_GPU
+        
         //post non-blocking receive right x communication buffer
-        MPI_Irecv(recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
 
         //non-blocking send right x communication buffer
-        MPI_Isend(send_buffer_x1, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request[1]);
+        MPI_Isend(d_send_buffer_x1, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request[1]);
+        
+        #else
+        
+        //post non-blocking receive right x communication buffer
+        MPI_Irecv(h_recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
+
+        //non-blocking send right x communication buffer
+        MPI_Isend(h_send_buffer_x1, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request[1]);
+        
+        #endif
+        
         MPI_Request_free(send_request+1);
 
         //keep track of how many sends and receives are expected
@@ -1183,9 +1872,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_Y0();
+        buffer_length = Load_Hydro_DeviceBuffer_Y0(d_send_buffer_y0);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y0, d_send_buffer_y0, ybsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_Y0();
+        buffer_length = Load_Hydro_Buffer_Y0(h_send_buffer_y0);
         #endif
         //printf("Y0 len: %d\n", buffer_length);
         }
@@ -1193,22 +1886,30 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #ifdef GRAVITY
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 1, 0, send_buffer_y0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 1, 0, d_send_buffer_y0, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y0, d_send_buffer_y0, ybsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 1, 0, send_buffer_y0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 1, 0, h_send_buffer_y0, 0 );
         #endif
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 1, 0, send_buffer_y0 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 1, 0, h_send_buffer_y0 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 1, 0, send_buffer_y0  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 1, 0, d_send_buffer_y0  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y0, d_send_buffer_y0, ybsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 1, 0, send_buffer_y0  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 1, 0, h_send_buffer_y0  );
         #endif
       }
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1220,11 +1921,24 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
+        #ifdef MPI_GPU
+        
         //post non-blocking receive left y communication buffer
-        MPI_Irecv(recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
 
         //non-blocking send left y communication buffer
-        MPI_Isend(send_buffer_y0, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request[0]);
+        MPI_Isend(d_send_buffer_y0, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request[0]);
+        
+        #else
+        
+        //post non-blocking receive left y communication buffer
+        MPI_Irecv(h_recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
+
+        //non-blocking send left y communication buffer
+        MPI_Isend(h_send_buffer_y0, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request[0]);
+        
+        #endif
+        
         MPI_Request_free(send_request);
 
         //keep track of how many sends and receives are expected
@@ -1238,9 +1952,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_Y1();
+        buffer_length = Load_Hydro_DeviceBuffer_Y1(d_send_buffer_y1);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_Y1();
+        buffer_length = Load_Hydro_Buffer_Y1(h_send_buffer_y1);
         #endif
         //printf("Y1 len: %d\n", buffer_length);
         }
@@ -1249,22 +1967,30 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #ifdef GRAVITY
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 1, 1, send_buffer_y1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 1, 1, d_send_buffer_y1, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 1, 1, send_buffer_y1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 1, 1, h_send_buffer_y1, 0 );
         #endif
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 1, 1, send_buffer_y1 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 1, 1, h_send_buffer_y1 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 1, 1, send_buffer_y1  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 1, 1, d_send_buffer_y1  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 1, 1, send_buffer_y1  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 1, 1, h_send_buffer_y1  );
         #endif
       }
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1276,11 +2002,20 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){      
+        #ifdef MPI_GPU
         //post non-blocking receive right y communication buffer
-        MPI_Irecv(recv_buffer_y1, buffer_length, MPI_CHREAL, source[3], 3, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_y1, buffer_length, MPI_CHREAL, source[3], 3, world, &recv_request[ireq]);
 
         //non-blocking send right y communication buffer
-        MPI_Isend(send_buffer_y1, buffer_length, MPI_CHREAL, dest[3],   2, world, &send_request[1]);
+        MPI_Isend(d_send_buffer_y1, buffer_length, MPI_CHREAL, dest[3],   2, world, &send_request[1]);
+        #else
+        //post non-blocking receive right y communication buffer
+        MPI_Irecv(h_recv_buffer_y1, buffer_length, MPI_CHREAL, source[3], 3, world, &recv_request[ireq]);
+
+        //non-blocking send right y communication buffer
+        MPI_Isend(h_send_buffer_y1, buffer_length, MPI_CHREAL, dest[3],   2, world, &send_request[1]);
+        #endif
+        
         MPI_Request_free(send_request+1);
 
         //keep track of how many sends and receives are expected
@@ -1303,9 +2038,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_Z0();
+        buffer_length = Load_Hydro_DeviceBuffer_Z0(d_send_buffer_z0);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_Z0();
+        buffer_length = Load_Hydro_Buffer_Z0(h_send_buffer_z0);
         #endif
         //printf("Z0 len: %d\n", buffer_length);
         }
@@ -1313,22 +2052,30 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #ifdef GRAVITY
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 0, send_buffer_z0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 0, d_send_buffer_z0, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 2, 0, send_buffer_z0, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 2, 0, h_send_buffer_z0, 0 );
         #endif
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 2, 0, send_buffer_z0 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 2, 0, h_send_buffer_z0 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 0, send_buffer_z0  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 0, d_send_buffer_z0  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 2, 0, send_buffer_z0  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 2, 0, h_send_buffer_z0  );
         #endif
       }
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1339,12 +2086,22 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       }
       #endif
       
-      if ( transfer_main_buffer ){      
+      if ( transfer_main_buffer ){
+      
+        #ifdef MPI_GPU
         //post non-blocking receive left z communication buffer
-        MPI_Irecv(recv_buffer_z0, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_z0, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request[ireq]);
 
         //non-blocking send left z communication buffer
-        MPI_Isend(send_buffer_z0, buffer_length, MPI_CHREAL, dest[4],   5, world, &send_request[0]);
+        MPI_Isend(d_send_buffer_z0, buffer_length, MPI_CHREAL, dest[4],   5, world, &send_request[0]);
+        #else
+        //post non-blocking receive left z communication buffer
+        MPI_Irecv(h_recv_buffer_z0, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request[ireq]);
+
+        //non-blocking send left z communication buffer
+        MPI_Isend(h_send_buffer_z0, buffer_length, MPI_CHREAL, dest[4],   5, world, &send_request[0]);
+        #endif
+        
         MPI_Request_free(send_request);
 
         //keep track of how many sends and receives are expected
@@ -1358,9 +2115,13 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       if ( H.TRANSFER_HYDRO_BOUNDARIES ) 
         {
         #ifdef HYDRO_GPU
-        buffer_length = Load_Hydro_DeviceBuffer_Z1();
+        buffer_length = Load_Hydro_DeviceBuffer_Z1(d_send_buffer_z1);
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Hydro_Buffer_Z1();
+        buffer_length = Load_Hydro_Buffer_Z1(h_send_buffer_z1);
         #endif
         //printf("Z1 len: %d\n", buffer_length);
         }
@@ -1368,22 +2129,30 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #ifdef GRAVITY
       if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
         #ifdef GRAVITY_GPU
-        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 1, send_buffer_z1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 1, d_send_buffer_z1, 0 );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Gravity_Potential_To_Buffer( 2, 1, send_buffer_z1, 0 );
+        buffer_length = Load_Gravity_Potential_To_Buffer( 2, 1, h_send_buffer_z1, 0 );
         #endif
       }
       #ifdef SOR
-      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 2, 1, send_buffer_z1 );
+      if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES )  buffer_length = Load_Poisson_Boundary_To_Buffer( 2, 1, h_send_buffer_z1 );
       #endif //SOR
       #endif //GRAVITY
       
       #ifdef PARTICLES
       if ( Particles.TRANSFER_DENSITY_BOUNDARIES) {
-        #ifdef GRAVITY_GPU
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 1, send_buffer_z1  );
+        #ifdef PARTICLES_GPU
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 1, d_send_buffer_z1  );
+          #ifndef MPI_GPU
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+                     cudaMemcpyDeviceToHost);
+          #endif
         #else
-        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 2, 1, send_buffer_z1  );
+        buffer_length = Load_Particles_Density_Boundary_to_Buffer( 2, 1, h_send_buffer_z1  );
         #endif
       }
       else if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -1395,11 +2164,19 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
+        #ifdef MPI_GPU
         //post non-blocking receive right x communication buffer
-        MPI_Irecv(recv_buffer_z1, buffer_length, MPI_CHREAL, source[5], 5, world, &recv_request[ireq]);
+        MPI_Irecv(d_recv_buffer_z1, buffer_length, MPI_CHREAL, source[5], 5, world, &recv_request[ireq]);
 
         //non-blocking send right x communication buffer
-        MPI_Isend(send_buffer_z1, buffer_length, MPI_CHREAL, dest[5],   4, world, &send_request[1]);
+        MPI_Isend(d_send_buffer_z1, buffer_length, MPI_CHREAL, dest[5],   4, world, &send_request[1]);
+        #else
+        //post non-blocking receive right x communication buffer
+        MPI_Irecv(h_recv_buffer_z1, buffer_length, MPI_CHREAL, source[5], 5, world, &recv_request[ireq]);
+
+        //non-blocking send right x communication buffer
+        MPI_Isend(h_send_buffer_z1, buffer_length, MPI_CHREAL, dest[5],   4, world, &send_request[1]);
+        #endif
         MPI_Request_free(send_request+1);
 
         //keep track of how many sends and receives are expected
@@ -1495,11 +2272,7 @@ void Grid3D::Unload_MPI_Comm_Buffers(int index)
       Unload_MPI_Comm_Buffers_SLAB(index);
       break;
     case BLOCK_DECOMP:
-      #ifdef HYDRO_GPU
-      Unload_MPI_Comm_DeviceBuffers_BLOCK(index);
-      #else
       Unload_MPI_Comm_Buffers_BLOCK(index);
-      #endif
       break;
   }
 }
@@ -1554,538 +2327,161 @@ void Grid3D::Unload_MPI_Comm_Buffers_SLAB(int index)
 
 void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
 {
-  int i, j, k, ii;
-  int idx;
-  int gidx;
-  int offset;
   
-  if ( H.TRANSFER_HYDRO_BOUNDARIES ){
-    //unload left x communication buffer
-    if(index==0)
-    {
-      // 1D
-      if (H.ny == 1 && H.nz == 1) {
-        offset = H.n_ghost;
-        for(i=0;i<H.n_ghost;i++) {
-          idx  = i;
-          gidx = i;
-          for (ii=0; ii<H.n_fields; ii++) { 
-            C.density[idx + H.n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-          }
-        }
-      }
-      // 2D
-      if (H.ny > 1 && H.nz == 1) {
-        offset = H.n_ghost*(H.ny-2*H.n_ghost);
-        for(i=0;i<H.n_ghost;i++) {
-          for (j=0;j<H.ny-2*H.n_ghost;j++) {
-            idx  = i + (j+H.n_ghost)*H.nx;
-            gidx = i + j*H.n_ghost;
-            for (ii=0; ii<H.n_fields; ii++) { 
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (H.nz > 1) {
-        offset = H.n_ghost*(H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost);
-        for(i=0;i<H.n_ghost;i++) {
-          for(j=0;j<H.ny-2*H.n_ghost;j++) {
-            for(k=0;k<H.nz-2*H.n_ghost;k++) {
-              idx  = i + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
-              gidx = i + j*H.n_ghost + k*H.n_ghost*(H.ny-2*H.n_ghost);
-              for (ii=0; ii<H.n_fields; ii++) {
-                C.density[idx + ii*H.n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload right x communication buffer
-    if(index==1)
-    {
-      // 1D
-      if (H.ny == 1 && H.nz == 1) {
-        offset = H.n_ghost;
-        for(i=0;i<H.n_ghost;i++) {
-          idx  = i+H.nx-H.n_ghost;
-          gidx = i;
-          for (ii=0; ii<H.n_fields; ii++) {
-            C.density[idx + ii*H.n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-          }
-        }
-      }
-      // 2D
-      if (H.ny > 1 && H.nz == 1) {
-        offset = H.n_ghost*(H.ny-2*H.n_ghost);
-        for(i=0;i<H.n_ghost;i++) {
-          for (j=0;j<H.ny-2*H.n_ghost;j++) {
-            idx  = i+H.nx-H.n_ghost + (j+H.n_ghost)*H.nx;
-            gidx = i + j*H.n_ghost;
-            for (ii=0; ii<H.n_fields; ii++) {
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (H.nz > 1) {
-        offset = H.n_ghost*(H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost);
-        for(i=0;i<H.n_ghost;i++) {
-          for(j=0;j<H.ny-2*H.n_ghost;j++) {
-            for(k=0;k<H.nz-2*H.n_ghost;k++) {
-              idx  = i+H.nx-H.n_ghost + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
-              gidx = i + j*H.n_ghost + k*H.n_ghost*(H.ny-2*H.n_ghost);
-              for (ii=0; ii<H.n_fields; ii++) {
-                C.density[idx + ii*H.n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-
-    //unload left y communication buffer
-    if(index==2)
-    {
-      // 2D
-      if (H.nz == 1) {
-        offset = H.n_ghost*H.nx;
-        for(i=0;i<H.nx;i++) {
-          for (j=0;j<H.n_ghost;j++) {
-            idx  = i + j*H.nx;
-            gidx = i + j*H.nx;
-            for (ii=0; ii<H.n_fields; ii++) {
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (H.nz > 1) {
-        offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
-        for(i=0;i<H.nx;i++) {
-          for(j=0;j<H.n_ghost;j++) {
-            for(k=0;k<H.nz-2*H.n_ghost;k++) {
-              idx  = i + j*H.nx + (k+H.n_ghost)*H.nx*H.ny;
-              gidx = i + j*H.nx + k*H.nx*H.n_ghost;
-              for (ii=0; ii<H.n_fields; ii++) {
-                C.density[idx + ii*H.n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload right y communication buffer
-    if(index==3)
-    {
-      // 2D
-      if (H.nz == 1) {
-        offset = H.n_ghost*H.nx;
-        for(i=0;i<H.nx;i++) {
-          for (j=0;j<H.n_ghost;j++) {
-            idx  = i + (j+H.ny-H.n_ghost)*H.nx;
-            gidx = i + j*H.nx;
-            for (ii=0; ii<H.n_fields; ii++) {
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (H.nz > 1) {
-        offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
-        for(i=0;i<H.nx;i++) {
-          for(j=0;j<H.n_ghost;j++) {
-            for(k=0;k<H.nz-2*H.n_ghost;k++) {
-              idx  = i + (j+H.ny-H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
-              gidx = i + j*H.nx + k*H.nx*H.n_ghost;
-              for (ii=0; ii<H.n_fields; ii++) {
-                C.density[idx + ii*H.n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload left z communication buffer
-    if(index==4)
-    {
-      offset = H.n_ghost*H.nx*H.ny;
-      for(i=0;i<H.nx;i++) {
-        for(j=0;j<H.ny;j++) {
-          for(k=0;k<H.n_ghost;k++) {
-            idx  = i + j*H.nx + k*H.nx*H.ny;
-            gidx = i + j*H.nx + k*H.nx*H.ny;
-            for (ii=0; ii<H.n_fields; ii++) {
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_z0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-    }
-
-    //unload right z communication buffer
-    if(index==5)
-    {
-      offset = H.n_ghost*H.nx*H.ny;
-      for(i=0;i<H.nx;i++) {
-        for(j=0;j<H.ny;j++) {
-          for(k=0;k<H.n_ghost;k++) {
-            idx  = i + j*H.nx + (k+H.nz-H.n_ghost)*H.nx*H.ny;
-            gidx = i + j*H.nx + k*H.nx*H.ny;
-            for (ii=0; ii<H.n_fields; ii++) {
-              C.density[idx + ii*H.n_cells] = *(recv_buffer_z1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
+  // local recv buffers
+  Real *l_recv_buffer_x0, *l_recv_buffer_x1, *l_recv_buffer_y0,
+       *l_recv_buffer_y1, *l_recv_buffer_z0, *l_recv_buffer_z1;
+       
+  Grid3D_PMF_UnloadHydroBuffer Fptr_Unload_Hydro_Buffer_X0,
+                               Fptr_Unload_Hydro_Buffer_X1,
+                               Fptr_Unload_Hydro_Buffer_Y0,
+                               Fptr_Unload_Hydro_Buffer_Y1,
+                               Fptr_Unload_Hydro_Buffer_Z0,
+                               Fptr_Unload_Hydro_Buffer_Z1;
+       
+  void (*Fptr_Unload_Gravity_Potential)(int, int, Real *, int),
+       (*Fptr_Unload_Particle_Density)(int, int, Real *);
+  
+  
+  if ( H.TRANSFER_HYDRO_BOUNDARIES ) {
+    #ifdef HYDRO_GPU
+      #ifndef MPI_GPU
+      copyHostToDeviceReceiveBuffer ( index );
+      #endif
+    l_recv_buffer_x0 = d_recv_buffer_x0;
+    l_recv_buffer_x1 = d_recv_buffer_x1;
+    l_recv_buffer_y0 = d_recv_buffer_y0;
+    l_recv_buffer_y1 = d_recv_buffer_y1;
+    l_recv_buffer_z0 = d_recv_buffer_z0;
+    l_recv_buffer_z1 = d_recv_buffer_z1;
+    
+    Fptr_Unload_Hydro_Buffer_X0 = &Grid3D::Unload_Hydro_DeviceBuffer_X0;
+    Fptr_Unload_Hydro_Buffer_X1 = &Grid3D::Unload_Hydro_DeviceBuffer_X1;
+    Fptr_Unload_Hydro_Buffer_Y0 = &Grid3D::Unload_Hydro_DeviceBuffer_Y0;
+    Fptr_Unload_Hydro_Buffer_Y1 = &Grid3D::Unload_Hydro_DeviceBuffer_Y1;
+    Fptr_Unload_Hydro_Buffer_Z0 = &Grid3D::Unload_Hydro_DeviceBuffer_Z0;
+    Fptr_Unload_Hydro_Buffer_Z1 = &Grid3D::Unload_Hydro_DeviceBuffer_Z1;
+    
+    #else
+    
+    l_recv_buffer_x0 = h_recv_buffer_x0;
+    l_recv_buffer_x1 = h_recv_buffer_x1;
+    l_recv_buffer_y0 = h_recv_buffer_y0;
+    l_recv_buffer_y1 = h_recv_buffer_y1;
+    l_recv_buffer_z0 = h_recv_buffer_z0;
+    l_recv_buffer_z1 = h_recv_buffer_z1;    
+    
+    Fptr_Unload_Hydro_Buffer_X0 = &Grid3D::Unload_Hydro_Buffer_X0;
+    Fptr_Unload_Hydro_Buffer_X1 = &Grid3D::Unload_Hydro_Buffer_X1;
+    Fptr_Unload_Hydro_Buffer_Y0 = &Grid3D::Unload_Hydro_Buffer_Y0;
+    Fptr_Unload_Hydro_Buffer_Y1 = &Grid3D::Unload_Hydro_Buffer_Y1;
+    Fptr_Unload_Hydro_Buffer_Z0 = &Grid3D::Unload_Hydro_Buffer_Z0;
+    Fptr_Unload_Hydro_Buffer_Z1 = &Grid3D::Unload_Hydro_Buffer_Z1;
+    
+    #endif // HYDRO_GPU
+    
+    switch ( index ) {
+    case ( 0 ): (this->*Fptr_Unload_Hydro_Buffer_X0) ( l_recv_buffer_x0 ); break;
+    case ( 1 ): (this->*Fptr_Unload_Hydro_Buffer_X1) ( l_recv_buffer_x1 ); break;
+    case ( 2 ): (this->*Fptr_Unload_Hydro_Buffer_Y0) ( l_recv_buffer_y0 ); break;
+    case ( 3 ): (this->*Fptr_Unload_Hydro_Buffer_Y1) ( l_recv_buffer_y1 ); break;
+    case ( 4 ): (this->*Fptr_Unload_Hydro_Buffer_Z0) ( l_recv_buffer_z0 ); break;
+    case ( 5 ): (this->*Fptr_Unload_Hydro_Buffer_Z1) ( l_recv_buffer_z1 ); break;
     }
   }
   
   #ifdef GRAVITY
   if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
     #ifdef GRAVITY_GPU
-    if ( index == 0 ) Unload_Gravity_Potential_from_Buffer_GPU( 0, 0, recv_buffer_x0, 0  );
-    if ( index == 1 ) Unload_Gravity_Potential_from_Buffer_GPU( 0, 1, recv_buffer_x1, 0  );
-    if ( index == 2 ) Unload_Gravity_Potential_from_Buffer_GPU( 1, 0, recv_buffer_y0, 0  );
-    if ( index == 3 ) Unload_Gravity_Potential_from_Buffer_GPU( 1, 1, recv_buffer_y1, 0  );
-    if ( index == 4 ) Unload_Gravity_Potential_from_Buffer_GPU( 2, 0, recv_buffer_z0, 0  );
-    if ( index == 5 ) Unload_Gravity_Potential_from_Buffer_GPU( 2, 1, recv_buffer_z1, 0  );
-    #else    
-    if ( index == 0 ) Unload_Gravity_Potential_from_Buffer( 0, 0, recv_buffer_x0, 0  );
-    if ( index == 1 ) Unload_Gravity_Potential_from_Buffer( 0, 1, recv_buffer_x1, 0  );
-    if ( index == 2 ) Unload_Gravity_Potential_from_Buffer( 1, 0, recv_buffer_y0, 0  );
-    if ( index == 3 ) Unload_Gravity_Potential_from_Buffer( 1, 1, recv_buffer_y1, 0  );
-    if ( index == 4 ) Unload_Gravity_Potential_from_Buffer( 2, 0, recv_buffer_z0, 0  );
-    if ( index == 5 ) Unload_Gravity_Potential_from_Buffer( 2, 1, recv_buffer_z1, 0  );
-    #endif
+      #ifndef MPI_GPU
+      copyHostToDeviceReceiveBuffer ( index )
+      #endif // MPI_GPU
+    
+    l_recv_buffer_x0 = d_recv_buffer_x0;
+    l_recv_buffer_x1 = d_recv_buffer_x1;
+    l_recv_buffer_y0 = d_recv_buffer_y0;
+    l_recv_buffer_y1 = d_recv_buffer_y1;
+    l_recv_buffer_z0 = d_recv_buffer_z0;
+    l_recv_buffer_z1 = d_recv_buffer_z1;
+    
+    Fptr_Unload_Gravity_Potential = &Unload_Gravity_Potential_from_Buffer_GPU
+    
+    #else
+
+    l_recv_buffer_x0 = h_recv_buffer_x0;
+    l_recv_buffer_x1 = h_recv_buffer_x1;
+    l_recv_buffer_y0 = h_recv_buffer_y0;
+    l_recv_buffer_y1 = h_recv_buffer_y1;
+    l_recv_buffer_z0 = h_recv_buffer_z0;
+    l_recv_buffer_z1 = h_recv_buffer_z1;
+    
+    Fptr_Unload_Gravity_Potential = &Unload_Gravity_Potential_from_Buffer
+    
+    #endif // GRAVITY_GPU
+    
+    if ( index == 0 ) Fptr_Unload_Gravity_Potential( 0, 0, l_recv_buffer_x0, 0  );
+    if ( index == 1 ) Fptr_Unload_Gravity_Potential( 0, 1, l_recv_buffer_x1, 0  );
+    if ( index == 2 ) Fptr_Unload_Gravity_Potential( 1, 0, l_recv_buffer_y0, 0  );
+    if ( index == 3 ) Fptr_Unload_Gravity_Potential( 1, 1, l_recv_buffer_y1, 0  );
+    if ( index == 4 ) Fptr_Unload_Gravity_Potential( 2, 0, l_recv_buffer_z0, 0  );
+    if ( index == 5 ) Fptr_Unload_Gravity_Potential( 2, 1, l_recv_buffer_z1, 0  );
   }
+  
   #ifdef SOR
   if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES ){
-    if ( index == 0 ) Unload_Poisson_Boundary_From_Buffer( 0, 0, recv_buffer_x0 );
-    if ( index == 1 ) Unload_Poisson_Boundary_From_Buffer( 0, 1, recv_buffer_x1 );
-    if ( index == 2 ) Unload_Poisson_Boundary_From_Buffer( 1, 0, recv_buffer_y0 );
-    if ( index == 3 ) Unload_Poisson_Boundary_From_Buffer( 1, 1, recv_buffer_y1 );
-    if ( index == 4 ) Unload_Poisson_Boundary_From_Buffer( 2, 0, recv_buffer_z0 );
-    if ( index == 5 ) Unload_Poisson_Boundary_From_Buffer( 2, 1, recv_buffer_z1 );
+    if ( index == 0 ) Unload_Poisson_Boundary_From_Buffer( 0, 0, l_recv_buffer_x0 );
+    if ( index == 1 ) Unload_Poisson_Boundary_From_Buffer( 0, 1, l_recv_buffer_x1 );
+    if ( index == 2 ) Unload_Poisson_Boundary_From_Buffer( 1, 0, l_recv_buffer_y0 );
+    if ( index == 3 ) Unload_Poisson_Boundary_From_Buffer( 1, 1, l_recv_buffer_y1 );
+    if ( index == 4 ) Unload_Poisson_Boundary_From_Buffer( 2, 0, l_recv_buffer_z0 );
+    if ( index == 5 ) Unload_Poisson_Boundary_From_Buffer( 2, 1, l_recv_buffer_z1 );
   }
   #endif //SOR
-  #endif //GRAVITY
+  
+  #endif  //GRAVITY
+  
   
   #ifdef PARTICLES
   if (  Particles.TRANSFER_DENSITY_BOUNDARIES ){
-    #ifdef GRAVITY_GPU
-    if ( index == 0 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 0, 0, recv_buffer_x0 );
-    if ( index == 1 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 0, 1, recv_buffer_x1 );
-    if ( index == 2 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 1, 0, recv_buffer_y0 );
-    if ( index == 3 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 1, 1, recv_buffer_y1 );
-    if ( index == 4 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 2, 0, recv_buffer_z0 );
-    if ( index == 5 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 2, 1, recv_buffer_z1 );    
+    #ifdef PARTICLES_GPU
+      #ifndef MPI_GPU
+      copyHostToDeviceReceiveBuffer ( index )
+      #endif
+    
+    l_recv_buffer_x0 = d_recv_buffer_x0;
+    l_recv_buffer_x1 = d_recv_buffer_x1;
+    l_recv_buffer_y0 = d_recv_buffer_y0;
+    l_recv_buffer_y1 = d_recv_buffer_y1;
+    l_recv_buffer_z0 = d_recv_buffer_z0;
+    l_recv_buffer_z1 = d_recv_buffer_z1;
+    
+    Fptr_Unload_Particle_Density 
+      = &Unload_Particles_Density_Boundary_From_Buffer_GPU
+    
     #else
-    if ( index == 0 ) Unload_Particles_Density_Boundary_From_Buffer( 0, 0, recv_buffer_x0 );
-    if ( index == 1 ) Unload_Particles_Density_Boundary_From_Buffer( 0, 1, recv_buffer_x1 );
-    if ( index == 2 ) Unload_Particles_Density_Boundary_From_Buffer( 1, 0, recv_buffer_y0 );
-    if ( index == 3 ) Unload_Particles_Density_Boundary_From_Buffer( 1, 1, recv_buffer_y1 );
-    if ( index == 4 ) Unload_Particles_Density_Boundary_From_Buffer( 2, 0, recv_buffer_z0 );
-    if ( index == 5 ) Unload_Particles_Density_Boundary_From_Buffer( 2, 1, recv_buffer_z1 );
-    #endif
+    
+    l_recv_buffer_x0 = d_recv_buffer_x0;
+    l_recv_buffer_x1 = d_recv_buffer_x1;
+    l_recv_buffer_y0 = d_recv_buffer_y0;
+    l_recv_buffer_y1 = d_recv_buffer_y1;
+    l_recv_buffer_z0 = d_recv_buffer_z0;
+    l_recv_buffer_z1 = d_recv_buffer_z1;
+    
+    Fptr_Unload_Particle_Density 
+      = &Unload_Particles_Density_Boundary_From_Buffer
+    
+    #endif // PARTICLES_GPU
+    
+    if ( index == 0 ) Fptr_Unload_Particle_Density( 0, 0, l_recv_buffer_x0 );
+    if ( index == 1 ) Fptr_Unload_Particle_Density( 0, 1, l_recv_buffer_x1 );
+    if ( index == 2 ) Fptr_Unload_Particle_Density( 1, 0, l_recv_buffer_y0 );
+    if ( index == 3 ) Fptr_Unload_Particle_Density( 1, 1, l_recv_buffer_y1 );
+    if ( index == 4 ) Fptr_Unload_Particle_Density( 2, 0, l_recv_buffer_z0 );
+    if ( index == 5 ) Fptr_Unload_Particle_Density( 2, 1, l_recv_buffer_z1 );
   }
-  #endif
+  
+  #endif  //PARTICLES
 
 }
-
-
-void Grid3D::Unload_MPI_Comm_DeviceBuffers_BLOCK(int index)
-{
-  int i, j, k, ii;
-  int idx;
-  int gidx;
-  int offset;
-  int n_ghost, nx, ny, nz, n_fields, n_cells;
-  Real *c_head;
-  
-  n_ghost   = H.n_ghost;
-  nx        = H.nx;
-  ny        = H.ny;
-  nz        = H.nz;
-  n_fields  = H.n_fields;	
-  n_cells   = H.n_cells;
-  
-  c_head = (Real *) C.device;
-  
-  if ( H.TRANSFER_HYDRO_BOUNDARIES ){
-    //unload left x communication buffer
-    if(index==0)
-    {
-      // 1D
-      if (ny == 1 && nz == 1) {
-        offset = n_ghost;
-        #pragma omp target teams distribute parallel for \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x0, c_head )
-        for(i=0;i<n_ghost;i++) {
-          idx  = i;
-          gidx = i;
-          for (ii=0; ii<n_fields; ii++) { 
-            c_head[idx + n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-            //-- FIXME: Shouldn't it be: c_head[idx + ii*H.n_cells] = ...
-          }
-        }
-      }
-      // 2D
-      if (ny > 1 && nz == 1) {
-        offset = n_ghost*(ny-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 2 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x0, c_head )
-        for(i=0;i<n_ghost;i++) {
-          for (j=0;j<ny-2*n_ghost;j++) {
-            idx  = i + (j+n_ghost)*nx;
-            gidx = i + j*n_ghost;
-            for (ii=0; ii<n_fields; ii++) { 
-              c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (nz > 1) {
-        offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 3 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x0, c_head )
-        for(i=0;i<n_ghost;i++) {
-          for(j=0;j<ny-2*n_ghost;j++) {
-            for(k=0;k<nz-2*n_ghost;k++) {
-              idx  = i + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
-              gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
-              for (ii=0; ii<n_fields; ii++) {
-                c_head[idx + ii*n_cells] = *(recv_buffer_x0 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload right x communication buffer
-    if(index==1)
-    {
-  
-      // 1D
-      if (ny == 1 && nz == 1) {
-        offset = n_ghost;
-        #pragma omp target teams distribute parallel for \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x1, c_head )
-        for(i=0;i<n_ghost;i++) {
-          idx  = i+nx-n_ghost;
-          gidx = i;
-          for (ii=0; ii<n_fields; ii++) {
-            c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-          }
-        }
-      }
-      // 2D
-      if (ny > 1 && nz == 1) {
-        offset = n_ghost*(ny-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 2 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x1, c_head )
-        for(i=0;i<n_ghost;i++) {
-          for (j=0;j<ny-2*n_ghost;j++) {
-            idx  = i+nx-n_ghost + (j+n_ghost)*nx;
-            gidx = i + j*n_ghost;
-            for (ii=0; ii<n_fields; ii++) {
-              c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (nz > 1) {
-        offset = n_ghost*(ny-2*n_ghost)*(nz-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 3 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_x1, c_head )
-        for(i=0;i<n_ghost;i++) {
-          for(j=0;j<ny-2*n_ghost;j++) {
-            for(k=0;k<nz-2*n_ghost;k++) {
-              idx  = i+nx-n_ghost + (j+n_ghost)*nx + (k+n_ghost)*nx*ny;
-              gidx = i + j*n_ghost + k*n_ghost*(ny-2*n_ghost);
-              for (ii=0; ii<n_fields; ii++) {
-                c_head[idx + ii*n_cells] = *(recv_buffer_x1 + gidx + ii*offset);
-                
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload left y communication buffer
-    if(index==2)
-    {
-      // 2D
-      if (nz == 1) {
-        offset = n_ghost*nx;
-        #pragma omp target teams distribute parallel for collapse ( 2 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_y0, c_head )
-        for(i=0;i<nx;i++) {
-          for (j=0;j<n_ghost;j++) {
-            idx  = i + j*nx;
-            gidx = i + j*nx;
-            for (ii=0; ii<n_fields; ii++) {
-              c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (nz > 1) {
-        offset = n_ghost*nx*(nz-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 3 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_y0, c_head )
-        for(i=0;i<nx;i++) {
-          for(j=0;j<n_ghost;j++) {
-            for(k=0;k<nz-2*n_ghost;k++) {
-              idx  = i + j*nx + (k+n_ghost)*nx*ny;
-              gidx = i + j*nx + k*nx*n_ghost;
-              for (ii=0; ii<n_fields; ii++) {
-                c_head[idx + ii*n_cells] = *(recv_buffer_y0 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload right y communication buffer
-    if(index==3)
-    {
-      // 2D
-      if (nz == 1) {
-        offset = n_ghost*nx;
-        #pragma omp target teams distribute parallel for collapse ( 2 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_y1, c_head )
-        for(i=0;i<nx;i++) {
-          for (j=0;j<n_ghost;j++) {
-            idx  = i + (j+ny-n_ghost)*nx;
-            gidx = i + j*nx;
-            for (ii=0; ii<n_fields; ii++) {
-              c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-      // 3D
-      if (nz > 1) {
-        offset = n_ghost*nx*(nz-2*n_ghost);
-        #pragma omp target teams distribute parallel for collapse ( 3 ) \
-            private ( idx, gidx, ii ) \
-            firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-            is_device_ptr ( recv_buffer_y1, c_head )
-        for(i=0;i<nx;i++) {
-          for(j=0;j<n_ghost;j++) {
-            for(k=0;k<nz-2*n_ghost;k++) {
-              idx  = i + (j+ny-n_ghost)*nx + (k+n_ghost)*nx*ny;
-              gidx = i + j*nx + k*nx*n_ghost;
-              for (ii=0; ii<n_fields; ii++) {
-                c_head[idx + ii*n_cells] = *(recv_buffer_y1 + gidx + ii*offset);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    //unload left z communication buffer
-    if(index==4)
-    {
-      offset = n_ghost*nx*ny;
-      #pragma omp target teams distribute parallel for collapse ( 3 ) \
-          private ( idx, gidx, ii ) \
-          firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-          is_device_ptr ( recv_buffer_z0, c_head )
-      for(i=0;i<nx;i++) {
-        for(j=0;j<ny;j++) {
-          for(k=0;k<n_ghost;k++) {
-            idx  = i + j*nx + k*nx*ny;
-            gidx = i + j*nx + k*nx*ny;
-            for (ii=0; ii<n_fields; ii++) {
-              c_head[idx + ii*n_cells] = *(recv_buffer_z0 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-    }
-
-    //unload right z communication buffer
-    if(index==5)
-    {
-      offset = n_ghost*nx*ny;
-      #pragma omp target teams distribute parallel for collapse ( 3 ) \
-          private ( idx, gidx, ii ) \
-          firstprivate ( offset, n_ghost, nx, ny, nz, n_fields, n_cells ) \
-          is_device_ptr ( recv_buffer_z1, c_head )
-      for(i=0;i<nx;i++) {
-        for(j=0;j<ny;j++) {
-          for(k=0;k<n_ghost;k++) {
-            idx  = i + j*nx + (k+nz-n_ghost)*nx*ny;
-            gidx = i + j*nx + k*nx*ny;
-            for (ii=0; ii<n_fields; ii++) {
-              c_head[idx + ii*n_cells] = *(recv_buffer_z1 + gidx + ii*offset);
-            }
-          }
-        }
-      }
-    }
-  }
-  
-  #if( defined(GRAVITY) && defined(GRAVITY_GPU)  )
-  if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
-    if ( index == 0 ) Unload_Gravity_Potential_from_Buffer_GPU( 0, 0, recv_buffer_x0, 0  );
-    if ( index == 1 ) Unload_Gravity_Potential_from_Buffer_GPU( 0, 1, recv_buffer_x1, 0  );
-    if ( index == 2 ) Unload_Gravity_Potential_from_Buffer_GPU( 1, 0, recv_buffer_y0, 0  );
-    if ( index == 3 ) Unload_Gravity_Potential_from_Buffer_GPU( 1, 1, recv_buffer_y1, 0  );
-    if ( index == 4 ) Unload_Gravity_Potential_from_Buffer_GPU( 2, 0, recv_buffer_z0, 0  );
-    if ( index == 5 ) Unload_Gravity_Potential_from_Buffer_GPU( 2, 1, recv_buffer_z1, 0  );
-  }
-  #endif//GRAVITY_GPU
-  
-  #if defined(PARTICLES) && defined(GRAVITY_GPU)
-  if (  Particles.TRANSFER_DENSITY_BOUNDARIES ){
-    if ( index == 0 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 0, 0, recv_buffer_x0 );
-    if ( index == 1 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 0, 1, recv_buffer_x1 );
-    if ( index == 2 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 1, 0, recv_buffer_y0 );
-    if ( index == 3 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 1, 1, recv_buffer_y1 );
-    if ( index == 4 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 2, 0, recv_buffer_z0 );
-    if ( index == 5 ) Unload_Particles_Density_Boundary_From_Buffer_GPU( 2, 1, recv_buffer_z1 );
-  }
-  
-  #endif//DPARTICLES_GPU
-
-}
-
 
 #endif /*MPI_CHOLLA*/

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -1664,7 +1664,6 @@ void Grid3D::Unload_Hydro_DeviceBuffer_Z1 ( Real *recv_buffer_z1 ) {
 
 }
 
-
 void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
 {
   
@@ -2429,6 +2428,13 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
   
   #ifdef SOR
   if ( Grav.Poisson_solver.TRANSFER_POISSON_BOUNDARIES ){
+    l_recv_buffer_x0 = h_recv_buffer_x0;
+    l_recv_buffer_x1 = h_recv_buffer_x1;
+    l_recv_buffer_y0 = h_recv_buffer_y0;
+    l_recv_buffer_y1 = h_recv_buffer_y1;
+    l_recv_buffer_z0 = h_recv_buffer_z0;
+    l_recv_buffer_z1 = h_recv_buffer_z1;
+    
     if ( index == 0 ) Unload_Poisson_Boundary_From_Buffer( 0, 0, l_recv_buffer_x0 );
     if ( index == 1 ) Unload_Poisson_Boundary_From_Buffer( 0, 1, l_recv_buffer_x1 );
     if ( index == 2 ) Unload_Poisson_Boundary_From_Buffer( 1, 0, l_recv_buffer_y0 );

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -1748,7 +1748,6 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
    
       if ( transfer_main_buffer ){
         #ifdef MPI_GPU
-        
         //post non-blocking receive left x communication buffer
         MPI_Irecv(d_recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, 
                   world, &recv_request[ireq]);
@@ -1756,10 +1755,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         //non-blocking send left x communication buffer
         MPI_Isend(d_send_buffer_x0, buffer_length, MPI_CHREAL, dest[0], 1, 
                   world, &send_request[0]);
-        
-        
         #else
-        
         //post non-blocking receive left x communication buffer
         MPI_Irecv(h_recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, 
                   world, &recv_request[ireq]);
@@ -1767,9 +1763,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         //non-blocking send left x communication buffer
         MPI_Isend(h_send_buffer_x0, buffer_length, MPI_CHREAL, dest[0], 1, 
                   world, &send_request[0]);
-        
         #endif
-        
         MPI_Request_free(send_request);
 
         //keep track of how many sends and receives are expected
@@ -1833,21 +1827,17 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       
       if ( transfer_main_buffer ){
         #ifdef MPI_GPU
-        
         //post non-blocking receive right x communication buffer
         MPI_Irecv(d_recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
 
         //non-blocking send right x communication buffer
         MPI_Isend(d_send_buffer_x1, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request[1]);
-        
         #else
-        
         //post non-blocking receive right x communication buffer
         MPI_Irecv(h_recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
 
         //non-blocking send right x communication buffer
         MPI_Isend(h_send_buffer_x1, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request[1]);
-        
         #endif
         
         MPI_Request_free(send_request+1);
@@ -1921,21 +1911,17 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       
       if ( transfer_main_buffer ){
         #ifdef MPI_GPU
-        
         //post non-blocking receive left y communication buffer
         MPI_Irecv(d_recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
 
         //non-blocking send left y communication buffer
         MPI_Isend(d_send_buffer_y0, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request[0]);
-        
         #else
-        
         //post non-blocking receive left y communication buffer
         MPI_Irecv(h_recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
 
         //non-blocking send left y communication buffer
         MPI_Isend(h_send_buffer_y0, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request[0]);
-        
         #endif
         
         MPI_Request_free(send_request);
@@ -1953,7 +1939,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Y1(d_send_buffer_y1);
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, ybsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -1968,7 +1954,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef GRAVITY_GPU
         buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 1, 1, d_send_buffer_y1, 0 );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, ybsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -1985,7 +1971,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef PARTICLES_GPU
         buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 1, 1, d_send_buffer_y1  );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, ybsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2014,7 +2000,6 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         //non-blocking send right y communication buffer
         MPI_Isend(h_send_buffer_y1, buffer_length, MPI_CHREAL, dest[3],   2, world, &send_request[1]);
         #endif
-        
         MPI_Request_free(send_request+1);
 
         //keep track of how many sends and receives are expected
@@ -2039,7 +2024,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Z0(d_send_buffer_z0);
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2053,7 +2038,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef GRAVITY_GPU
         buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 0, d_send_buffer_z0, 0 );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2070,7 +2055,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef PARTICLES_GPU
         buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 0, d_send_buffer_z0  );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2090,7 +2075,6 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef MPI_GPU
         //post non-blocking receive left z communication buffer
         MPI_Irecv(d_recv_buffer_z0, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request[ireq]);
-
         //non-blocking send left z communication buffer
         MPI_Isend(d_send_buffer_z0, buffer_length, MPI_CHREAL, dest[4],   5, world, &send_request[0]);
         #else
@@ -2116,7 +2100,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef HYDRO_GPU
         buffer_length = Load_Hydro_DeviceBuffer_Z1(d_send_buffer_z1);
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z1, d_send_buffer_z1, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2130,7 +2114,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef GRAVITY_GPU
         buffer_length = Load_Gravity_Potential_To_Buffer_GPU( 2, 1, d_send_buffer_z1, 0 );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z1, d_send_buffer_z1, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2147,7 +2131,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
         #ifdef PARTICLES_GPU
         buffer_length = Load_Particles_Density_Boundary_to_Buffer_GPU( 2, 1, d_send_buffer_z1  );
           #ifndef MPI_GPU
-          cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, xbsize*sizeof(Real),
+          cudaMemcpy(h_send_buffer_z1, d_send_buffer_z1, zbsize*sizeof(Real),
                      cudaMemcpyDeviceToHost);
           #endif
         #else
@@ -2345,7 +2329,7 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
     #ifdef HYDRO_GPU
       #ifndef MPI_GPU
       copyHostToDeviceReceiveBuffer ( index );
-      #endif
+      #endif 
     l_recv_buffer_x0 = d_recv_buffer_x0;
     l_recv_buffer_x1 = d_recv_buffer_x1;
     l_recv_buffer_y0 = d_recv_buffer_y0;
@@ -2391,9 +2375,9 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
   #ifdef GRAVITY
   if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
     #ifdef GRAVITY_GPU
-      #ifndef MPI_GPU
-      copyHostToDeviceReceiveBuffer ( index )
-      #endif // MPI_GPU
+     #ifndef MPI_GPU
+     copyHostToDeviceReceiveBuffer ( index );
+     #endif // MPI_GPU
     
     l_recv_buffer_x0 = d_recv_buffer_x0;
     l_recv_buffer_x1 = d_recv_buffer_x1;
@@ -2452,7 +2436,7 @@ void Grid3D::Unload_MPI_Comm_Buffers_BLOCK(int index)
   if (  Particles.TRANSFER_DENSITY_BOUNDARIES ){
     #ifdef PARTICLES_GPU
       #ifndef MPI_GPU
-      copyHostToDeviceReceiveBuffer ( index )
+      copyHostToDeviceReceiveBuffer ( index );
       #endif
     
     l_recv_buffer_x0 = d_recv_buffer_x0;

--- a/src/mpi_routines.cpp
+++ b/src/mpi_routines.cpp
@@ -79,18 +79,32 @@ int z_buffer_length;
 
 #ifdef PARTICLES
 //Buffers for particles transfers
-Real *send_buffer_x0_particles;
-Real *send_buffer_x1_particles;
-Real *send_buffer_y0_particles;
-Real *send_buffer_y1_particles;
-Real *send_buffer_z0_particles;
-Real *send_buffer_z1_particles;
-Real *recv_buffer_x0_particles;
-Real *recv_buffer_x1_particles;
-Real *recv_buffer_y0_particles;
-Real *recv_buffer_y1_particles;
-Real *recv_buffer_z0_particles;
-Real *recv_buffer_z1_particles;
+Real *d_send_buffer_x0_particles;
+Real *d_send_buffer_x1_particles;
+Real *d_send_buffer_y0_particles;
+Real *d_send_buffer_y1_particles;
+Real *d_send_buffer_z0_particles;
+Real *d_send_buffer_z1_particles;
+Real *d_recv_buffer_x0_particles;
+Real *d_recv_buffer_x1_particles;
+Real *d_recv_buffer_y0_particles;
+Real *d_recv_buffer_y1_particles;
+Real *d_recv_buffer_z0_particles;
+Real *d_recv_buffer_z1_particles;
+
+//Buffers for particles transfers
+Real *h_send_buffer_x0_particles;
+Real *h_send_buffer_x1_particles;
+Real *h_send_buffer_y0_particles;
+Real *h_send_buffer_y1_particles;
+Real *h_send_buffer_z0_particles;
+Real *h_send_buffer_z1_particles;
+Real *h_recv_buffer_x0_particles;
+Real *h_recv_buffer_x1_particles;
+Real *h_recv_buffer_y0_particles;
+Real *h_recv_buffer_y1_particles;
+Real *h_recv_buffer_z0_particles;
+Real *h_recv_buffer_z1_particles;
 
 // Size of the buffers for particles transfers
 int buffer_length_particles_x0_send;
@@ -1085,44 +1099,44 @@ void Allocate_MPI_Buffers_BLOCK(struct Header *H)
   #ifdef PARTICLES
   //Allocate buffers for particles transfers
   chprintf("Allocating MPI communication buffers for particle transfers ( N_Particles: %d ).\n", N_PARTICLES_TRANSFER );
-  if(!( send_buffer_x0_particles = (Real *) malloc(buffer_length_particles_x0_send*sizeof(Real))))
+  if(!(h_send_buffer_x0_particles = (Real *) malloc(buffer_length_particles_x0_send*sizeof(Real))))
   {
-    chprintf("Error allocating send_buffer_x0_paricles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x0_send*sizeof(Real));
+    chprintf("Error allocating h_send_buffer_x0_paricles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x0_send*sizeof(Real));
     chexit(-1);
   }
-  if(!( send_buffer_x1_particles = (Real *) malloc(buffer_length_particles_x1_send*sizeof(Real))))
+  if(!(h_send_buffer_x1_particles = (Real *) malloc(buffer_length_particles_x1_send*sizeof(Real))))
   {
-    chprintf("Error allocating send_buffer_x1_paricles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x1_send*sizeof(Real));
+    chprintf("Error allocating h_send_buffer_x1_paricles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x1_send*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_x0_particles = (Real *) malloc(buffer_length_particles_x0_recv*sizeof(Real))))
+  if(!(h_recv_buffer_x0_particles = (Real *) malloc(buffer_length_particles_x0_recv*sizeof(Real))))
   {
-    chprintf("Error allocating recv_buffer_x0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x0_recv*sizeof(Real));
+    chprintf("Error allocating h_recv_buffer_x0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x0_recv*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_x1_particles = (Real *) malloc(buffer_length_particles_x1_recv*sizeof(Real))))
+  if(!(h_recv_buffer_x1_particles = (Real *) malloc(buffer_length_particles_x1_recv*sizeof(Real))))
   {
-    chprintf("Error allocating recv_buffer_x1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x1_recv*sizeof(Real));
+    chprintf("Error allocating h_recv_buffer_x1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_x1_recv*sizeof(Real));
     chexit(-1);
   }
-  if(!(send_buffer_y0_particles = (Real *) malloc(buffer_length_particles_y0_send*sizeof(Real))))
+  if(!(h_send_buffer_y0_particles = (Real *) malloc(buffer_length_particles_y0_send*sizeof(Real))))
   {
-    chprintf("Error allocating send_buffer_y0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y0_send*sizeof(Real));
+    chprintf("Error allocating h_send_buffer_y0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y0_send*sizeof(Real));
     chexit(-1);
   }
-  if(!(send_buffer_y1_particles = (Real *) malloc(buffer_length_particles_y1_send*sizeof(Real))))
+  if(!(h_send_buffer_y1_particles = (Real *) malloc(buffer_length_particles_y1_send*sizeof(Real))))
   {
-    chprintf("Error allocating send_buffer_y1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y1_send*sizeof(Real));
+    chprintf("Error allocating h_send_buffer_y1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y1_send*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_y0_particles = (Real *) malloc(buffer_length_particles_y0_recv*sizeof(Real))))
+  if(!(h_recv_buffer_y0_particles = (Real *) malloc(buffer_length_particles_y0_recv*sizeof(Real))))
   {
-    chprintf("Error allocating recv_buffer_y0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y0_recv*sizeof(Real));
+    chprintf("Error allocating h_recv_buffer_y0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y0_recv*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_y1_particles = (Real *) malloc(buffer_length_particles_y1_recv*sizeof(Real))))
+  if(!(h_recv_buffer_y1_particles = (Real *) malloc(buffer_length_particles_y1_recv*sizeof(Real))))
   {
-    chprintf("Error allocating recv_buffer_y1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y1_recv*sizeof(Real));
+    chprintf("Error allocating h_recv_buffer_y1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_y1_recv*sizeof(Real));
     chexit(-1);
   }
   #endif//PARTICLES
@@ -1150,24 +1164,24 @@ void Allocate_MPI_Buffers_BLOCK(struct Header *H)
       chexit(-1);
     }
     #ifdef PARTICLES
-    if(!(send_buffer_z0_particles = (Real *) malloc(buffer_length_particles_z0_send*sizeof(Real))))
+    if(!(h_send_buffer_z0_particles = (Real *) malloc(buffer_length_particles_z0_send*sizeof(Real))))
     {
-      chprintf("Error allocating send_buffer_z0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z0_send*sizeof(Real));
+      chprintf("Error allocating h_send_buffer_z0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z0_send*sizeof(Real));
       chexit(-1);
     }
-    if(!(send_buffer_z1_particles = (Real *) malloc(buffer_length_particles_z1_send*sizeof(Real))))
+    if(!(h_send_buffer_z1_particles = (Real *) malloc(buffer_length_particles_z1_send*sizeof(Real))))
     {
-      chprintf("Error allocating send_buffer_z1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z1_send*sizeof(Real));
+      chprintf("Error allocating h_send_buffer_z1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z1_send*sizeof(Real));
       chexit(-1);
     }
-    if(!(recv_buffer_z0_particles = (Real *) malloc(buffer_length_particles_z0_recv*sizeof(Real))))
+    if(!(h_recv_buffer_z0_particles = (Real *) malloc(buffer_length_particles_z0_recv*sizeof(Real))))
     {
-      chprintf("Error allocating recv_buffer_z0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z0_recv*sizeof(Real));
+      chprintf("Error allocating h_recv_buffer_z0_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z0_recv*sizeof(Real));
       chexit(-1);
     }
-    if(!(recv_buffer_z1_particles = (Real *) malloc(buffer_length_particles_z1_recv*sizeof(Real))))
+    if(!(h_recv_buffer_z1_particles = (Real *) malloc(buffer_length_particles_z1_recv*sizeof(Real))))
     {
-      chprintf("Error allocating recv_buffer_z1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z1_recv*sizeof(Real));
+      chprintf("Error allocating h_recv_buffer_z1_particles in Allocate_MPI_Buffers_BLOCK (size = %ld).\n",buffer_length_particles_z1_recv*sizeof(Real));
       chexit(-1);
     }
     #endif
@@ -1266,18 +1280,35 @@ void Allocate_MPI_DeviceBuffers_BLOCK(struct Header *H)
   
   #if defined(PARTICLES) && defined(PARTICLES_GPU)
   chprintf("Allocating MPI communication buffers on GPU for particle transfers ( N_Particles: %d ).\n", N_PARTICLES_TRANSFER );
-  CudaSafeCall ( cudaMalloc (&send_buffer_x0_particles, buffer_length_particles_x0_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_x1_particles, buffer_length_particles_x1_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_y0_particles, buffer_length_particles_y0_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_y1_particles, buffer_length_particles_y1_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_z0_particles, buffer_length_particles_z0_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_z1_particles, buffer_length_particles_z1_send*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_x0_particles, buffer_length_particles_x0_recv*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_x1_particles, buffer_length_particles_x1_recv*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_y0_particles, buffer_length_particles_y0_recv*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_y1_particles, buffer_length_particles_y1_recv*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_z0_particles, buffer_length_particles_z0_recv*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_z1_particles, buffer_length_particles_z1_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_x0_particles, buffer_length_particles_x0_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_x1_particles, buffer_length_particles_x1_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_y0_particles, buffer_length_particles_y0_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_y1_particles, buffer_length_particles_y1_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_z0_particles, buffer_length_particles_z0_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_z1_particles, buffer_length_particles_z1_send*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_x0_particles, buffer_length_particles_x0_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_x1_particles, buffer_length_particles_x1_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_y0_particles, buffer_length_particles_y0_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_y1_particles, buffer_length_particles_y1_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_z0_particles, buffer_length_particles_z0_recv*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_z1_particles, buffer_length_particles_z1_recv*sizeof(Real)) );
+  
+  #if !defined(MPI_GPU)
+  chprintf("Allocating MPI communication buffers on GPU for particle transfers ( N_Particles: %d ).\n", N_PARTICLES_TRANSFER );
+  h_send_buffer_x0_particles = (Real *) malloc ( buffer_length_particles_x0_send*sizeof(Real) );
+  h_send_buffer_x1_particles = (Real *) malloc ( buffer_length_particles_x1_send*sizeof(Real) );
+  h_send_buffer_y0_particles = (Real *) malloc ( buffer_length_particles_y0_send*sizeof(Real) );
+  h_send_buffer_y1_particles = (Real *) malloc ( buffer_length_particles_y1_send*sizeof(Real) );
+  h_send_buffer_z0_particles = (Real *) malloc ( buffer_length_particles_z0_send*sizeof(Real) );
+  h_send_buffer_z1_particles = (Real *) malloc ( buffer_length_particles_z1_send*sizeof(Real) );
+  h_recv_buffer_x0_particles = (Real *) malloc ( buffer_length_particles_x0_recv*sizeof(Real) );
+  h_recv_buffer_x1_particles = (Real *) malloc ( buffer_length_particles_x1_recv*sizeof(Real) );
+  h_recv_buffer_y0_particles = (Real *) malloc ( buffer_length_particles_y0_recv*sizeof(Real) );
+  h_recv_buffer_y1_particles = (Real *) malloc ( buffer_length_particles_y1_recv*sizeof(Real) );
+  h_recv_buffer_z0_particles = (Real *) malloc ( buffer_length_particles_z0_recv*sizeof(Real) );
+  h_recv_buffer_z1_particles = (Real *) malloc ( buffer_length_particles_z1_recv*sizeof(Real) );
+  #endif
+  
   #endif//PARTICLES_GPU
   
 }

--- a/src/mpi_routines.cpp
+++ b/src/mpi_routines.cpp
@@ -315,7 +315,7 @@ void Allocate_MPI_Buffers(struct Header *H)
       break;
     case BLOCK_DECOMP:
       #if defined(HYDRO_GPU) || defined(GRAVITY_GPU) \
-          || defined(PARTICLES_GPU) || defined(MPI_GPU) 
+          || defined(PARTICLES_GPU)
       Allocate_MPI_DeviceBuffers_BLOCK(H);
       #else
       Allocate_MPI_Buffers_BLOCK(H);

--- a/src/mpi_routines.cpp
+++ b/src/mpi_routines.cpp
@@ -45,18 +45,31 @@ Real *send_buffer_1;
 Real *recv_buffer_0;
 Real *recv_buffer_1;
 // For BLOCK 
-Real *send_buffer_x0;
-Real *send_buffer_x1;
-Real *send_buffer_y0;
-Real *send_buffer_y1;
-Real *send_buffer_z0;
-Real *send_buffer_z1;
-Real *recv_buffer_x0;
-Real *recv_buffer_x1;
-Real *recv_buffer_y0;
-Real *recv_buffer_y1;
-Real *recv_buffer_z0;
-Real *recv_buffer_z1;
+Real *d_send_buffer_x0;
+Real *d_send_buffer_x1;
+Real *d_send_buffer_y0;
+Real *d_send_buffer_y1;
+Real *d_send_buffer_z0;
+Real *d_send_buffer_z1;
+Real *d_recv_buffer_x0;
+Real *d_recv_buffer_x1;
+Real *d_recv_buffer_y0;
+Real *d_recv_buffer_y1;
+Real *d_recv_buffer_z0;
+Real *d_recv_buffer_z1;
+
+Real *h_send_buffer_x0;
+Real *h_send_buffer_x1;
+Real *h_send_buffer_y0;
+Real *h_send_buffer_y1;
+Real *h_send_buffer_z0;
+Real *h_send_buffer_z1;
+Real *h_recv_buffer_x0;
+Real *h_recv_buffer_x1;
+Real *h_recv_buffer_y0;
+Real *h_recv_buffer_y1;
+Real *h_recv_buffer_z0;
+Real *h_recv_buffer_z1;
 
 int send_buffer_length;
 int recv_buffer_length;
@@ -301,7 +314,8 @@ void Allocate_MPI_Buffers(struct Header *H)
       Allocate_MPI_Buffers_SLAB(H);
       break;
     case BLOCK_DECOMP:
-      #ifdef MPI_GPU
+      #if defined(HYDRO_GPU) || defined(GRAVITY_GPU) \
+          || defined(PARTICLES_GPU) || defined(MPI_GPU) 
       Allocate_MPI_DeviceBuffers_BLOCK(H);
       #else
       Allocate_MPI_Buffers_BLOCK(H);
@@ -1027,42 +1041,42 @@ void Allocate_MPI_Buffers_BLOCK(struct Header *H)
   
   chprintf("Allocating MPI communication buffers (nx = %ld, ny = %ld, nz = %ld).\n", xbsize, ybsize, zbsize);
 
-  if(!(send_buffer_x0 = (Real *) malloc(xbsize*sizeof(Real))))
+  if(!(h_send_buffer_x0 = (Real *) malloc(xbsize*sizeof(Real))))
   {
     chprintf("Error allocating send_buffer_x0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",xbsize,xbsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(send_buffer_x1 = (Real *) malloc(xbsize*sizeof(Real))))
+  if(!(h_send_buffer_x1 = (Real *) malloc(xbsize*sizeof(Real))))
   {
     chprintf("Error allocating send_buffer_x1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",xbsize,xbsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_x0 = (Real *) malloc(xbsize*sizeof(Real))))
+  if(!(h_recv_buffer_x0 = (Real *) malloc(xbsize*sizeof(Real))))
   {
     chprintf("Error allocating recv_buffer_x0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",xbsize,xbsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_x1 = (Real *) malloc(xbsize*sizeof(Real))))
+  if(!(h_recv_buffer_x1 = (Real *) malloc(xbsize*sizeof(Real))))
   {
     chprintf("Error allocating recv_buffer_x1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",xbsize,xbsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(send_buffer_y0 = (Real *) malloc(ybsize*sizeof(Real))))
+  if(!(h_send_buffer_y0 = (Real *) malloc(ybsize*sizeof(Real))))
   {
     chprintf("Error allocating send_buffer_y0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",ybsize,ybsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(send_buffer_y1 = (Real *) malloc(ybsize*sizeof(Real))))
+  if(!(h_send_buffer_y1 = (Real *) malloc(ybsize*sizeof(Real))))
   {
     chprintf("Error allocating send_buffer_y1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",ybsize,ybsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_y0 = (Real *) malloc(ybsize*sizeof(Real))))
+  if(!(h_recv_buffer_y0 = (Real *) malloc(ybsize*sizeof(Real))))
   {
     chprintf("Error allocating recv_buffer_y0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",ybsize,ybsize*sizeof(Real));
     chexit(-1);
   }
-  if(!(recv_buffer_y1 = (Real *) malloc(ybsize*sizeof(Real))))
+  if(!(h_recv_buffer_y1 = (Real *) malloc(ybsize*sizeof(Real))))
   {
     chprintf("Error allocating recv_buffer_y1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",ybsize,ybsize*sizeof(Real));
     chexit(-1);
@@ -1115,22 +1129,22 @@ void Allocate_MPI_Buffers_BLOCK(struct Header *H)
   
   // 3D
   if (H->nz > 1) {
-    if(!(send_buffer_z0 = (Real *) malloc(zbsize*sizeof(Real))))
+    if(!(h_send_buffer_z0 = (Real *) malloc(zbsize*sizeof(Real))))
     {
       chprintf("Error allocating send_buffer_z0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",zbsize,zbsize*sizeof(Real));
       chexit(-1);
     }
-    if(!(send_buffer_z1 = (Real *) malloc(zbsize*sizeof(Real))))
+    if(!(h_send_buffer_z1 = (Real *) malloc(zbsize*sizeof(Real))))
     {
       chprintf("Error allocating send_buffer_z1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",zbsize,zbsize*sizeof(Real));
       chexit(-1);
     }
-    if(!(recv_buffer_z0 = (Real *) malloc(zbsize*sizeof(Real))))
+    if(!(h_recv_buffer_z0 = (Real *) malloc(zbsize*sizeof(Real))))
     {
       chprintf("Error allocating recv_buffer_z0 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",zbsize,zbsize*sizeof(Real));
       chexit(-1);
     }
-    if(!(recv_buffer_z1 = (Real *) malloc(zbsize*sizeof(Real))))
+    if(!(h_recv_buffer_z1 = (Real *) malloc(zbsize*sizeof(Real))))
     {
       chprintf("Error allocating recv_buffer_z1 in Allocate_MPI_Buffers_BLOCK (n = %ld, size = %ld).\n",zbsize,zbsize*sizeof(Real));
       chexit(-1);
@@ -1222,20 +1236,35 @@ void Allocate_MPI_DeviceBuffers_BLOCK(struct Header *H)
   chprintf("Allocating MPI communication buffers on GPU ");
   chprintf("(nx = %ld, ny = %ld, nz = %ld).\n", xbsize, ybsize, zbsize);
   
-  CudaSafeCall ( cudaMalloc (&send_buffer_x0, xbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_x1, xbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_x0, xbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_x1, xbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_y0, ybsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_y1, ybsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_y0, ybsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_y1, ybsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_z0, zbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&send_buffer_z1, zbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_z0, zbsize*sizeof(Real)) );
-  CudaSafeCall ( cudaMalloc (&recv_buffer_z1, zbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_x0, xbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_x1, xbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_x0, xbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_x1, xbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_y0, ybsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_y1, ybsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_y0, ybsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_y1, ybsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_z0, zbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_send_buffer_z1, zbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_z0, zbsize*sizeof(Real)) );
+  CudaSafeCall ( cudaMalloc (&d_recv_buffer_z1, zbsize*sizeof(Real)) );
   
-  #if defined(PARTICLES) && defined(PARTICLES_GPU) 
+  #if !defined(MPI_GPU)
+  h_send_buffer_x0 = (Real *) malloc ( xbsize*sizeof(Real) );
+  h_send_buffer_x1 = (Real *) malloc ( xbsize*sizeof(Real) );
+  h_recv_buffer_x0 = (Real *) malloc ( xbsize*sizeof(Real) );
+  h_recv_buffer_x1 = (Real *) malloc ( xbsize*sizeof(Real) );
+  h_send_buffer_y0 = (Real *) malloc ( ybsize*sizeof(Real) );
+  h_send_buffer_y1 = (Real *) malloc ( ybsize*sizeof(Real) );
+  h_recv_buffer_y0 = (Real *) malloc ( ybsize*sizeof(Real) );
+  h_recv_buffer_y1 = (Real *) malloc ( ybsize*sizeof(Real) );
+  h_send_buffer_z0 = (Real *) malloc ( zbsize*sizeof(Real) );
+  h_send_buffer_z1 = (Real *) malloc ( zbsize*sizeof(Real) );
+  h_recv_buffer_z0 = (Real *) malloc ( zbsize*sizeof(Real) );
+  h_recv_buffer_z1 = (Real *) malloc ( zbsize*sizeof(Real) );
+  #endif
+  
+  #if defined(PARTICLES) && defined(PARTICLES_GPU)
   chprintf("Allocating MPI communication buffers on GPU for particle transfers ( N_Particles: %d ).\n", N_PARTICLES_TRANSFER );
   CudaSafeCall ( cudaMalloc (&send_buffer_x0_particles, buffer_length_particles_x0_send*sizeof(Real)) );
   CudaSafeCall ( cudaMalloc (&send_buffer_x1_particles, buffer_length_particles_x1_send*sizeof(Real)) );
@@ -1434,4 +1463,36 @@ void deallocate_three_dimensional_int_array(int ***x, int n, int l, int m)
   }
   delete x;
 }
+
+
+void copyHostToDeviceReceiveBuffer ( int direction )
+{
+
+  int xbsize = x_buffer_length,
+      ybsize = y_buffer_length,
+      zbsize = z_buffer_length;
+  
+  switch ( direction ) {
+  case ( 0 ): cudaMemcpy(d_recv_buffer_x0, h_recv_buffer_x0,
+                         xbsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  case ( 1 ): cudaMemcpy(d_recv_buffer_x1, h_recv_buffer_x1,
+                         xbsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  case ( 2 ): cudaMemcpy(d_recv_buffer_y0, h_recv_buffer_y0,
+                         ybsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  case ( 3 ): cudaMemcpy(d_recv_buffer_y1, h_recv_buffer_y1,
+                         ybsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  case ( 4 ): cudaMemcpy(d_recv_buffer_z0, h_recv_buffer_z0,
+                         zbsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  case ( 5 ): cudaMemcpy(d_recv_buffer_z1, h_recv_buffer_z1,
+                         zbsize*sizeof(Real), cudaMemcpyHostToDevice);
+              break;
+  }
+
+}
+
 #endif /*MPI_CHOLLA*/

--- a/src/mpi_routines.h
+++ b/src/mpi_routines.h
@@ -48,19 +48,33 @@ extern Real *send_buffer_0;
 extern Real *send_buffer_1;
 extern Real *recv_buffer_0;
 extern Real *recv_buffer_1;
+
 // For BLOCK
-extern Real *send_buffer_x0;
-extern Real *send_buffer_x1;
-extern Real *send_buffer_y0;
-extern Real *send_buffer_y1;
-extern Real *send_buffer_z0;
-extern Real *send_buffer_z1;
-extern Real *recv_buffer_x0;
-extern Real *recv_buffer_x1;
-extern Real *recv_buffer_y0;
-extern Real *recv_buffer_y1;
-extern Real *recv_buffer_z0;
-extern Real *recv_buffer_z1;
+extern Real *d_send_buffer_x0;
+extern Real *d_send_buffer_x1;
+extern Real *d_send_buffer_y0;
+extern Real *d_send_buffer_y1;
+extern Real *d_send_buffer_z0;
+extern Real *d_send_buffer_z1;
+extern Real *d_recv_buffer_x0;
+extern Real *d_recv_buffer_x1;
+extern Real *d_recv_buffer_y0;
+extern Real *d_recv_buffer_y1;
+extern Real *d_recv_buffer_z0;
+extern Real *d_recv_buffer_z1;
+
+extern Real *h_send_buffer_x0;
+extern Real *h_send_buffer_x1;
+extern Real *h_send_buffer_y0;
+extern Real *h_send_buffer_y1;
+extern Real *h_send_buffer_z0;
+extern Real *h_send_buffer_z1;
+extern Real *h_recv_buffer_x0;
+extern Real *h_recv_buffer_x1;
+extern Real *h_recv_buffer_y0;
+extern Real *h_recv_buffer_y1;
+extern Real *h_recv_buffer_z0;
+extern Real *h_recv_buffer_z1;
 
 #ifdef PARTICLES
 //Buffers for particles transfers
@@ -189,6 +203,8 @@ int ***three_dimensional_int_array(int n, int l, int m);
  *   */
 void deallocate_three_dimensional_int_array(int ***x, int n, int l, int m);
 
+/* Copy MPI receive buffers on Host to their device locations */
+void copyHostToDeviceReceiveBuffer ( int direction );
 
 #endif /*MPI_ROUTINES_H*/
 #endif /*MPI_CHOLLA*/

--- a/src/mpi_routines.h
+++ b/src/mpi_routines.h
@@ -78,18 +78,31 @@ extern Real *h_recv_buffer_z1;
 
 #ifdef PARTICLES
 //Buffers for particles transfers
-extern Real *send_buffer_x0_particles;
-extern Real *send_buffer_x1_particles;
-extern Real *send_buffer_y0_particles;
-extern Real *send_buffer_y1_particles;
-extern Real *send_buffer_z0_particles;
-extern Real *send_buffer_z1_particles;
-extern Real *recv_buffer_x0_particles;
-extern Real *recv_buffer_x1_particles;
-extern Real *recv_buffer_y0_particles;
-extern Real *recv_buffer_y1_particles;
-extern Real *recv_buffer_z0_particles;
-extern Real *recv_buffer_z1_particles;
+extern Real *d_send_buffer_x0_particles;
+extern Real *d_send_buffer_x1_particles;
+extern Real *d_send_buffer_y0_particles;
+extern Real *d_send_buffer_y1_particles;
+extern Real *d_send_buffer_z0_particles;
+extern Real *d_send_buffer_z1_particles;
+extern Real *d_recv_buffer_x0_particles;
+extern Real *d_recv_buffer_x1_particles;
+extern Real *d_recv_buffer_y0_particles;
+extern Real *d_recv_buffer_y1_particles;
+extern Real *d_recv_buffer_z0_particles;
+extern Real *d_recv_buffer_z1_particles;
+
+extern Real *h_send_buffer_x0_particles;
+extern Real *h_send_buffer_x1_particles;
+extern Real *h_send_buffer_y0_particles;
+extern Real *h_send_buffer_y1_particles;
+extern Real *h_send_buffer_z0_particles;
+extern Real *h_send_buffer_z1_particles;
+extern Real *h_recv_buffer_x0_particles;
+extern Real *h_recv_buffer_x1_particles;
+extern Real *h_recv_buffer_y0_particles;
+extern Real *h_recv_buffer_y1_particles;
+extern Real *h_recv_buffer_z0_particles;
+extern Real *h_recv_buffer_z1_particles;
 
 // Size of the buffers for particles transfers
 extern int buffer_length_particles_x0_send;

--- a/src/particles/density_boundaries_gpu.cu
+++ b/src/particles/density_boundaries_gpu.cu
@@ -80,29 +80,10 @@ int Grid3D::Load_Particles_Density_Boundary_to_Buffer_GPU( int direction, int si
   density_d = (Real *)Particles.G.density_dev;
   
   Real *send_buffer_d;
-  #ifdef MPI_GPU
   send_buffer_d = buffer;
-  #else
-  if ( direction == 0 ){
-    if ( side == 0 ) send_buffer_d = (Real *)Particles.G.send_buffer_x0_d;
-    if ( side == 1 ) send_buffer_d = (Real *)Particles.G.send_buffer_x1_d;
-  }
-  if ( direction == 1 ){
-    if ( side == 0 ) send_buffer_d = (Real *)Particles.G.send_buffer_y0_d;
-    if ( side == 1 ) send_buffer_d = (Real *)Particles.G.send_buffer_y1_d;
-  }
-  if ( direction == 2 ){
-    if ( side == 0 ) send_buffer_d = (Real *)Particles.G.send_buffer_z0_d;
-    if ( side == 1 ) send_buffer_d = (Real *)Particles.G.send_buffer_z1_d;
-  }
-  #endif  
   
   hipLaunchKernelGGL( Load_Particles_Density_Boundary_to_Buffer_kernel, dim1dGrid, dim1dBlock, 0, 0, direction, side, n_i, n_j, nx_g, ny_g, nz_g, n_ghost, density_d, send_buffer_d  );
   
-  #ifndef MPI_GPU
-  //Copy the device buffer back to the host send buffer
-  cudaMemcpy( buffer, send_buffer_d, size_buffer*sizeof(Real), cudaMemcpyDeviceToHost );
-  #endif
   cudaDeviceSynchronize();
   
   return size_buffer;
@@ -177,29 +158,8 @@ void Grid3D::Unload_Particles_Density_Boundary_From_Buffer_GPU( int direction, i
   density_d = (Real *)Particles.G.density_dev;
   
   Real *recv_buffer_d;
-  #ifdef MPI_GPU
   recv_buffer_d = buffer;
-  #else
-  if ( direction == 0 ){
-    if ( side == 0 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_x0_d;
-    if ( side == 1 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_x1_d;
-  }
-  if ( direction == 1 ){
-    if ( side == 0 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_y0_d;
-    if ( side == 1 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_y1_d;
-  }
-  if ( direction == 2 ){
-    if ( side == 0 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_z0_d;
-    if ( side == 1 ) recv_buffer_d = (Real *)Particles.G.recv_buffer_z1_d;
-  }
-  #endif
-    
-  #ifndef MPI_GPU
-  //Copy the device buffer back to the host recv buffer
-  cudaMemcpy( recv_buffer_d, buffer, size_buffer*sizeof(Real), cudaMemcpyHostToDevice );
-  #endif
-  cudaDeviceSynchronize();
-  
+
   hipLaunchKernelGGL( Unload_Particles_Density_Boundary_to_Buffer_kernel, dim1dGrid, dim1dBlock, 0, 0, direction, side, n_i, n_j, nx_g, ny_g, nz_g, n_ghost, density_d, recv_buffer_d  );
   
 }

--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -299,8 +299,6 @@ void Particles_3D::Allocate_Memory_GPU_MPI(){
   
   G.n_transfer_h = (int *) malloc(sizeof(int));
   
-  
-  # ifdef MPI_GPU
   // Used the global partivcles send/recv buffers that already have been alloctaed in Allocate_MPI_DeviceBuffers_BLOCK
   G.send_buffer_size_x0 = buffer_length_particles_x0_send;
   G.send_buffer_size_x1 = buffer_length_particles_x1_send;
@@ -329,44 +327,7 @@ void Particles_3D::Allocate_Memory_GPU_MPI(){
   G.recv_buffer_y1_d = recv_buffer_y1_particles;
   G.recv_buffer_z0_d = recv_buffer_z0_particles;
   G.recv_buffer_z1_d = recv_buffer_z1_particles;
-  
-  #else
-  
-  int n_max, transfer_buffer_size;
-  n_max = std::max( std::max( nx_local, ny_local), nz_local );
-  transfer_buffer_size = Compute_Particles_GPU_Array_Size( n_max * n_max * N_DATA_PER_PARTICLE_TRANSFER );
-  
-  G.send_buffer_size_x0 = transfer_buffer_size;
-  G.send_buffer_size_x1 = transfer_buffer_size;
-  G.send_buffer_size_y0 = transfer_buffer_size;
-  G.send_buffer_size_y1 = transfer_buffer_size;
-  G.send_buffer_size_z0 = transfer_buffer_size;
-  G.send_buffer_size_z1 = transfer_buffer_size;
-  
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_x0_d, G.send_buffer_size_x0 );
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_x1_d, G.send_buffer_size_x1 );
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_y0_d, G.send_buffer_size_y0 );
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_y1_d, G.send_buffer_size_y1 );
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_z0_d, G.send_buffer_size_z0 );
-  Allocate_Particles_GPU_Array_Real( &G.send_buffer_z1_d, G.send_buffer_size_z1 );
-  
-  G.recv_buffer_size_x0 = transfer_buffer_size;
-  G.recv_buffer_size_x1 = transfer_buffer_size;
-  G.recv_buffer_size_y0 = transfer_buffer_size;
-  G.recv_buffer_size_y1 = transfer_buffer_size;
-  G.recv_buffer_size_z0 = transfer_buffer_size;
-  G.recv_buffer_size_z1 = transfer_buffer_size;
-  
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_x0_d, G.recv_buffer_size_x0 );
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_x1_d, G.recv_buffer_size_x1 );
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_y0_d, G.recv_buffer_size_y0 );
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_y1_d, G.recv_buffer_size_y1 );
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_z0_d, G.recv_buffer_size_z0 );
-  Allocate_Particles_GPU_Array_Real( &G.recv_buffer_z1_d, G.recv_buffer_size_z1 );
-  chprintf( " Allocated GPU memory for MPI transfers.\n"); 
-  
-  #endif//MPI_GPU
-  
+
 }
 #endif //MPI_CHOLLA
 
@@ -815,23 +776,6 @@ void Particles_3D::Free_Memory(void){
 
   #endif //PARTICLES_CPU
 
-  #ifdef MPI_CHOLLA
-  //Free the particles arrays for MPI transfers
-  #ifndef MPI_GPU // If MPI_GPU the arrays are freed from the device
-  free(send_buffer_x0_particles);
-  free(send_buffer_x1_particles);
-  free(recv_buffer_x0_particles);
-  free(recv_buffer_x1_particles);
-  free(send_buffer_y0_particles);
-  free(send_buffer_y1_particles);
-  free(recv_buffer_y0_particles);
-  free(recv_buffer_y1_particles);
-  free(send_buffer_z0_particles);
-  free(send_buffer_z1_particles);
-  free(recv_buffer_z0_particles);
-  free(recv_buffer_z1_particles);
-  #endif//MPI_GPU
-  #endif//MPI_CHOLLA
 }
 
 void Particles_3D::Reset( void ){

--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -307,12 +307,12 @@ void Particles_3D::Allocate_Memory_GPU_MPI(){
   G.send_buffer_size_z0 = buffer_length_particles_z0_send;
   G.send_buffer_size_z1 = buffer_length_particles_z1_send;
   
-  G.send_buffer_x0_d = send_buffer_x0_particles;
-  G.send_buffer_x1_d = send_buffer_x1_particles;
-  G.send_buffer_y0_d = send_buffer_y0_particles;
-  G.send_buffer_y1_d = send_buffer_y1_particles;
-  G.send_buffer_z0_d = send_buffer_z0_particles;
-  G.send_buffer_z1_d = send_buffer_z1_particles;
+  G.send_buffer_x0_d = d_send_buffer_x0_particles;
+  G.send_buffer_x1_d = d_send_buffer_x1_particles;
+  G.send_buffer_y0_d = d_send_buffer_y0_particles;
+  G.send_buffer_y1_d = d_send_buffer_y1_particles;
+  G.send_buffer_z0_d = d_send_buffer_z0_particles;
+  G.send_buffer_z1_d = d_send_buffer_z1_particles;
   
   G.recv_buffer_size_x0 = buffer_length_particles_x0_recv;
   G.recv_buffer_size_x1 = buffer_length_particles_x1_recv;
@@ -321,12 +321,12 @@ void Particles_3D::Allocate_Memory_GPU_MPI(){
   G.recv_buffer_size_z0 = buffer_length_particles_z0_recv;
   G.recv_buffer_size_z1 = buffer_length_particles_z1_recv;
   
-  G.recv_buffer_x0_d = recv_buffer_x0_particles;
-  G.recv_buffer_x1_d = recv_buffer_x1_particles;
-  G.recv_buffer_y0_d = recv_buffer_y0_particles;
-  G.recv_buffer_y1_d = recv_buffer_y1_particles;
-  G.recv_buffer_z0_d = recv_buffer_z0_particles;
-  G.recv_buffer_z1_d = recv_buffer_z1_particles;
+  G.recv_buffer_x0_d = d_recv_buffer_x0_particles;
+  G.recv_buffer_x1_d = d_recv_buffer_x1_particles;
+  G.recv_buffer_y0_d = d_recv_buffer_y0_particles;
+  G.recv_buffer_y1_d = d_recv_buffer_y1_particles;
+  G.recv_buffer_z0_d = d_recv_buffer_z0_particles;
+  G.recv_buffer_z1_d = d_recv_buffer_z1_particles;
 
 }
 #endif //MPI_CHOLLA

--- a/src/particles/particles_boundaries.cpp
+++ b/src/particles/particles_boundaries.cpp
@@ -533,12 +533,6 @@ void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int dir
   Load_Particles_to_Transfer_GPU_function( n_transfer, 4, n_fields_to_transfer, vel_y_dev, G.transfer_particles_indices_d, send_buffer_d, domainMin, domainMax, bt_non_pos ); 
   Load_Particles_to_Transfer_GPU_function( n_transfer, 5, n_fields_to_transfer, vel_z_dev, G.transfer_particles_indices_d, send_buffer_d, domainMin, domainMax, bt_non_pos ); 
   
-  #ifndef MPI_GPU
-  // Copy the particles transfer buffer to the host
-  int transfer_size;
-  transfer_size = n_transfer * N_DATA_PER_PARTICLE_TRANSFER;  
-  Copy_Particles_GPU_Buffer_to_Host_Buffer( n_transfer, send_buffer_h, send_buffer_d );
-  #endif
   CudaCheckError();
   
   *n_send += n_transfer;
@@ -653,12 +647,6 @@ void Particles_3D::Unload_Particles_from_Buffer_GPU( int direction, int side , R
     }
   }
   
-  #ifndef MPI_GPU
-  // Copy the particles transfer buffer from the host
-  int transfer_size;
-  transfer_size = n_recv * N_DATA_PER_PARTICLE_TRANSFER;  
-  Copy_Particles_Host_Buffer_to_GPU_Buffer( n_recv, recv_buffer_h, recv_buffer_d );
-  #endif
   CudaCheckError();
   
   Copy_Transfer_Particles_from_Buffer_GPU( n_recv, recv_buffer_d );

--- a/src/particles/particles_boundaries.cpp
+++ b/src/particles/particles_boundaries.cpp
@@ -148,6 +148,33 @@ void Grid3D::Load_NTtransfer_and_Request_Receive_Particles_Transfer(int index, i
 
   int buffer_length;
   
+  #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU
+    Real *recv_buffer_x0_particles = d_recv_buffer_x0_particles;
+    Real *recv_buffer_x1_particles = d_recv_buffer_x1_particles;
+    Real *recv_buffer_y0_particles = d_recv_buffer_y0_particles;
+    Real *recv_buffer_y1_particles = d_recv_buffer_y1_particles;
+    Real *recv_buffer_z0_particles = d_recv_buffer_z0_particles;
+    Real *recv_buffer_z1_particles = d_recv_buffer_z1_particles;
+    #else
+    Real *recv_buffer_x0_particles = h_recv_buffer_x0_particles;
+    Real *recv_buffer_x1_particles = h_recv_buffer_x1_particles;
+    Real *recv_buffer_y0_particles = h_recv_buffer_y0_particles;
+    Real *recv_buffer_y1_particles = h_recv_buffer_y1_particles;
+    Real *recv_buffer_z0_particles = h_recv_buffer_z0_particles;
+    Real *recv_buffer_z1_particles = h_recv_buffer_z1_particles;
+    #endif
+  #endif
+  
+  #ifdef PARTICLES_CPU
+  Real *recv_buffer_x0_particles = h_recv_buffer_x0_particles;
+  Real *recv_buffer_x1_particles = h_recv_buffer_x1_particles;
+  Real *recv_buffer_y0_particles = h_recv_buffer_y0_particles;
+  Real *recv_buffer_y1_particles = h_recv_buffer_y1_particles;
+  Real *recv_buffer_z0_particles = h_recv_buffer_z0_particles;
+  Real *recv_buffer_z1_particles = h_recv_buffer_z1_particles;
+  #endif
+  
   if ( index == 0){
     buffer_length = Particles.n_recv_x0 * N_DATA_PER_PARTICLE_TRANSFER;
     Check_and_Grow_Particles_Buffer( &recv_buffer_x0_particles , &buffer_length_particles_x0_recv, buffer_length );
@@ -192,8 +219,10 @@ void Grid3D::Load_NTtransfer_and_Request_Receive_Particles_Transfer(int index, i
 //Make Send and Recieve request for the number of particles that will be transfered, and then load and send the transfer particles
 void Grid3D::Load_and_Send_Particles_X0( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_x0_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_x0_particles = d_send_buffer_x0_particles;
   Particles.Load_Particles_to_Buffer_GPU(0, 0, send_buffer_x0_particles,  buffer_length_particles_x0_send );
   #endif //PARTICLES_GPU
 
@@ -204,16 +233,26 @@ void Grid3D::Load_and_Send_Particles_X0( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_x0 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_x0_particles , &buffer_length_particles_x0_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_x0_particles = h_send_buffer_x0_particles;
   Particles.Load_Particles_to_Buffer_CPU( 0, 0, send_buffer_x0_particles,  buffer_length_particles_x0_send );
   #endif //PARTICLES_CPU
+
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_x0_particles, d_send_buffer_x0_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_x0_particles = h_send_buffer_x0_particles;
+  #endif
+  
   MPI_Isend(send_buffer_x0_particles, buffer_length, MPI_CHREAL, dest[0],   1, world, &send_request_particles_transfer[ireq_particles_transfer]);
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
 
 void Grid3D::Load_and_Send_Particles_X1( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_x1_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_x1_particles = d_send_buffer_x1_particles;
   Particles.Load_Particles_to_Buffer_GPU(0, 1, send_buffer_x1_particles,  buffer_length_particles_x1_send );
   #endif //PARTICLES_GPU
 
@@ -224,16 +263,26 @@ void Grid3D::Load_and_Send_Particles_X1( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_x1 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_x1_particles , &buffer_length_particles_x1_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_x1_particles = h_send_buffer_x1_particles;
   Particles.Load_Particles_to_Buffer_CPU( 0, 1, send_buffer_x1_particles,  buffer_length_particles_x1_send  );
   #endif //PARTICLES_CPU
+  
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_x1_particles, d_send_buffer_x1_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_x1_particles = h_send_buffer_x1_particles;
+  #endif
+  
   MPI_Isend(send_buffer_x1_particles, buffer_length, MPI_CHREAL, dest[1],   0, world, &send_request_particles_transfer[ireq_particles_transfer]);\
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
 
 void Grid3D::Load_and_Send_Particles_Y0( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_y0_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_y0_particles = d_send_buffer_y0_particles;
   Particles.Load_Particles_to_Buffer_GPU(1, 0, send_buffer_y0_particles,  buffer_length_particles_y0_send );
   #endif //PARTICLES_GPU
 
@@ -244,16 +293,26 @@ void Grid3D::Load_and_Send_Particles_Y0( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_y0 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_y0_particles , &buffer_length_particles_y0_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_y0_particles = h_send_buffer_y0_particles;
   Particles.Load_Particles_to_Buffer_CPU( 1, 0, send_buffer_y0_particles,  buffer_length_particles_y0_send  );
   #endif //PARTICLES_CPU
+  
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_y0_particles, d_send_buffer_y0_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_y0_particles = h_send_buffer_y0_particles;
+  #endif
+  
   MPI_Isend(send_buffer_y0_particles, buffer_length, MPI_CHREAL, dest[2],   3, world, &send_request_particles_transfer[ireq_particles_transfer]);
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
 
 void Grid3D::Load_and_Send_Particles_Y1( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_y1_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_y1_particles = d_send_buffer_y1_particles;
   Particles.Load_Particles_to_Buffer_GPU(1, 1, send_buffer_y1_particles,  buffer_length_particles_y1_send );
   #endif //PARTICLES_GPU
 
@@ -264,16 +323,26 @@ void Grid3D::Load_and_Send_Particles_Y1( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_y1 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_y1_particles , &buffer_length_particles_y1_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_y1_particles = h_send_buffer_y1_particles;
   Particles.Load_Particles_to_Buffer_CPU( 1, 1, send_buffer_y1_particles,  buffer_length_particles_y1_send  );
   #endif //PARTICLES_CPU
+  
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_y1_particles, d_send_buffer_y1_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_y1_particles = h_send_buffer_y1_particles;
+  #endif
+  
   MPI_Isend(send_buffer_y1_particles, buffer_length, MPI_CHREAL, dest[3],   2, world, &send_request_particles_transfer[ireq_particles_transfer]);
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
 
 void Grid3D::Load_and_Send_Particles_Z0( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_z0_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_z0_particles = d_send_buffer_z0_particles;
   Particles.Load_Particles_to_Buffer_GPU(2, 0, send_buffer_z0_particles,  buffer_length_particles_z0_send );
   #endif //PARTICLES_GPU
 
@@ -284,16 +353,26 @@ void Grid3D::Load_and_Send_Particles_Z0( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_z0 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_z0_particles , &buffer_length_particles_z0_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_z0_particles = h_send_buffer_z0_particles;
   Particles.Load_Particles_to_Buffer_CPU( 2, 0, send_buffer_z0_particles,  buffer_length_particles_z0_send  );
   #endif //PARTICLES_CPU
+  
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_z0_particles, d_send_buffer_z0_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_z0_particles = h_send_buffer_z0_particles;
+  #endif
+  
   MPI_Isend(send_buffer_z0_particles, buffer_length, MPI_CHREAL, dest[4],   5, world, &send_request_particles_transfer[ireq_particles_transfer]);
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
 
 void Grid3D::Load_and_Send_Particles_Z1( int ireq_n_particles, int ireq_particles_transfer ){
   int buffer_length;
+  Real *send_buffer_z1_particles;
   
   #ifdef PARTICLES_GPU
+  send_buffer_z1_particles = d_send_buffer_z1_particles;
   Particles.Load_Particles_to_Buffer_GPU(2, 1, send_buffer_z1_particles,  buffer_length_particles_z1_send );
   #endif //PARTICLES_GPU
 
@@ -304,8 +383,16 @@ void Grid3D::Load_and_Send_Particles_Z1( int ireq_n_particles, int ireq_particle
   buffer_length = Particles.n_send_z1 * N_DATA_PER_PARTICLE_TRANSFER;
   Check_and_Grow_Particles_Buffer( &send_buffer_z1_particles , &buffer_length_particles_z1_send, buffer_length );
   #ifdef PARTICLES_CPU
+  send_buffer_z1_particles = h_send_buffer_z1_particles;
   Particles.Load_Particles_to_Buffer_CPU( 2, 1, send_buffer_z1_particles,  buffer_length_particles_z1_send  );
   #endif //PARTICLES_CPU
+  
+  #if defined(PARTICLES_GPU) && !defined(MPI_GPU)
+  cudaMemcpy(h_send_buffer_z1_particles, d_send_buffer_z1_particles, 
+             buffer_length*sizeof(Real), cudaMemcpyDeviceToHost);
+  send_buffer_z1_particles = h_send_buffer_z1_particles;
+  #endif
+  
   MPI_Isend(send_buffer_z1_particles, buffer_length, MPI_CHREAL, dest[5],   4, world, &send_request_particles_transfer[ireq_particles_transfer]);
   MPI_Request_free(send_request_particles_transfer+ireq_particles_transfer);
 }
@@ -313,55 +400,103 @@ void Grid3D::Load_and_Send_Particles_Z1( int ireq_n_particles, int ireq_particle
 //Unload the Transfered particles from the MPI_buffer, after buffer was received
 void Grid3D::Unload_Particles_from_Buffer_X0( int *flags ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 0, 0, recv_buffer_x0_particles, Particles.n_recv_x0, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 0, 0, h_recv_buffer_x0_particles, Particles.n_recv_x0, 
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles,
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send, buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 0, 0, recv_buffer_x0_particles, Particles.n_recv_x0 );
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_x0_particles, h_recv_buffer_x0_particles, 
+             buffer_length_particles_x0_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 0, 0, d_recv_buffer_x0_particles, Particles.n_recv_x0 );
   #endif//PARTICLES_GPU
 }
 
 void Grid3D::Unload_Particles_from_Buffer_X1( int *flags  ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 0, 1, recv_buffer_x1_particles, Particles.n_recv_x1, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 0, 1, h_recv_buffer_x1_particles, Particles.n_recv_x1,
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles, 
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send, buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 0, 1, recv_buffer_x1_particles, Particles.n_recv_x1 );
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_x1_particles, h_recv_buffer_x1_particles, 
+             buffer_length_particles_x1_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 0, 1, d_recv_buffer_x1_particles, Particles.n_recv_x1 );
   #endif//PARTICLES_GPU
 }
 
 void Grid3D::Unload_Particles_from_Buffer_Y0( int *flags ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 1, 0, recv_buffer_y0_particles, Particles.n_recv_y0, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 1, 0, h_recv_buffer_y0_particles, Particles.n_recv_y0, 
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles, 
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 1, 0, recv_buffer_y0_particles, Particles.n_recv_y0 );
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_y0_particles, h_recv_buffer_y0_particles, 
+             buffer_length_particles_y0_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 1, 0, d_recv_buffer_y0_particles, Particles.n_recv_y0 );
   #endif//PARTICLES_GPU
 }
 
 void Grid3D::Unload_Particles_from_Buffer_Y1( int *flags  ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 1, 1, recv_buffer_y1_particles, Particles.n_recv_y1, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 1, 1, h_recv_buffer_y1_particles, Particles.n_recv_y1, 
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles,
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 1, 1, recv_buffer_y1_particles, Particles.n_recv_y1 );  
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_y1_particles, h_recv_buffer_y1_particles, 
+             buffer_length_particles_y1_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 1, 1, d_recv_buffer_y1_particles, Particles.n_recv_y1 );  
   #endif//PARTICLES_GPU
 }
 
 void Grid3D::Unload_Particles_from_Buffer_Z0( int *flags ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 2, 0, recv_buffer_z0_particles, Particles.n_recv_z0, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 2, 0, h_recv_buffer_z0_particles, Particles.n_recv_z0, 
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles, 
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 2, 0, recv_buffer_z0_particles, Particles.n_recv_z0 );
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_z0_particles, h_recv_buffer_z0_particles, 
+             buffer_length_particles_z0_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 2, 0, d_recv_buffer_z0_particles, Particles.n_recv_z0 );
   #endif//PARTICLES_GPU
 }
 
 void Grid3D::Unload_Particles_from_Buffer_Z1( int *flags ){
   #ifdef PARTICLES_CPU
-  Particles.Unload_Particles_from_Buffer_CPU( 2, 1, recv_buffer_z1_particles, Particles.n_recv_z1, send_buffer_y0_particles, send_buffer_y1_particles, send_buffer_z0_particles, send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
+  Particles.Unload_Particles_from_Buffer_CPU( 2, 1, h_recv_buffer_z1_particles, Particles.n_recv_z1, 
+      h_send_buffer_y0_particles, h_send_buffer_y1_particles, h_send_buffer_z0_particles,
+      h_send_buffer_z1_particles, buffer_length_particles_y0_send , buffer_length_particles_y1_send, 
+      buffer_length_particles_z0_send, buffer_length_particles_z1_send, flags);
   #endif//PARTICLES_CPU
   #ifdef PARTICLES_GPU
-  Particles.Unload_Particles_from_Buffer_GPU( 2, 1, recv_buffer_z1_particles, Particles.n_recv_z1 );
+  #ifndef MPI_GPU
+  cudaMemcpy(d_recv_buffer_z1_particles, h_recv_buffer_z1_particles, 
+             buffer_length_particles_z1_recv*sizeof(Real), 
+             cudaMemcpyHostToDevice);
+  #endif
+  Particles.Unload_Particles_from_Buffer_GPU( 2, 1, d_recv_buffer_z1_particles, Particles.n_recv_z1 );
   #endif//PARTICLES_GPU
 }
 

--- a/src/simple_3D_cuda.cu
+++ b/src/simple_3D_cuda.cu
@@ -146,7 +146,7 @@ Real Simple_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1,
     get_offsets_3D(nx_s, ny_s, nz_s, n_ghost, x_off, y_off, z_off, block, block1_tot, block2_tot, block3_tot, remainder1, remainder2, remainder3, &x_off_s, &y_off_s, &z_off_s);
 
     // copy the conserved variables onto the GPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(dev_conserved, tmp1, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyHostToDevice) );
     #endif
     
@@ -236,7 +236,7 @@ Real Simple_Algorithm_3D_CUDA(Real *host_conserved0, Real *host_conserved1,
     CudaCheckError();
 
     // copy the updated conserved variable array back to the CPU
-    #ifndef MPI_GPU
+    #ifndef HYDRO_GPU
     CudaSafeCall( cudaMemcpy(tmp2, dev_conserved, n_fields*BLOCK_VOL*sizeof(Real), cudaMemcpyDeviceToHost) );
     #endif
 


### PR DESCRIPTION
This PR splits the previously called `GPU_MPI` flag to `HYDRO_GPU` and `MPI_GPU` flags.

`-DHYDRO_GPU` leaves the hydro grid on GPU after each timestep. This is enabled by default in `make.type.hydro`. 

`-DMPI_GPU` lets the code passes GPU buffers to MPI calls to be used with GPU-aware MPI implementation for more efficient transfer. Otherwise, GPU buffers are copied to host first before being passed to MPI calls. This flag is used in Hydro, Gravity (including Paris solver), and Particles. This can be enabled via makefile / environment variable in the appropriate `make.host.<machine>`.
