### PR TITLE
Makefilei

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CUOBJS := $(subst .cu,.o,$(GPUFILES))
 #To use GPUs, CUDA must be turned on here
 #Optional error checking can also be enabled
 DFLAGS += -DCUDA #-DCUDA_ERROR_CHECK
+# Architecture must be set correctly 
 CHOLLA_ARCH ?= sm_70
 
 #To use MPI, DFLAGS must also include -DMPI_CHOLLA

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ CUOBJS := $(subst .cu,.o,$(GPUFILES))
 #To use GPUs, CUDA must be turned on here
 #Optional error checking can also be enabled
 DFLAGS += -DCUDA #-DCUDA_ERROR_CHECK
+CHOLLA_ARCH ?= sm_70
 
 #To use MPI, DFLAGS must also include -DMPI_CHOLLA
-DFLAGS += -DMPI_CHOLLA -DBLOCK
+#DFLAGS += -DMPI_CHOLLA -DBLOCK
 
 #Set the MPI Processes grid [nproc_x, nproc_y, nproc_z]
 #DFLAGS += -DSET_MPI_GRID
@@ -28,7 +29,7 @@ DFLAGS += -DPRECISION=2
 #Set output preferences
 DFLAGS += -DOUTPUT
 #DFLAGS += -DBINARY
-DFLAGS += -DHDF5
+#DFLAGS += -DHDF5
 #DFLAGS += -DSLICES
 #DFLAGS += -DPROJECTION
 #DFLAGS += -DROTATED_PROJECTION
@@ -148,7 +149,7 @@ endif
 
 ifeq ($(findstring -DCUDA,$(DFLAGS)),-DCUDA)
 	GPUCXX := nvcc
-	GPUFLAGS += --expt-extended-lambda -g -O3 -arch sm_61 -fmad=false
+	GPUFLAGS += --expt-extended-lambda -g -O3 -arch $(CHOLLA_ARCH) -fmad=false
 	LD := $(CXX)
 	LDFLAGS := $(CXXFLAGS)
 ifneq ($(CUDA_DIR),)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CUOBJS := $(subst .cu,.o,$(GPUFILES))
 DFLAGS += -DCUDA #-DCUDA_ERROR_CHECK
 
 #To use MPI, DFLAGS must also include -DMPI_CHOLLA
-#DFLAGS += -DMPI_CHOLLA -DBLOCK
+DFLAGS += -DMPI_CHOLLA -DBLOCK
 
 #Set the MPI Processes grid [nproc_x, nproc_y, nproc_z]
 #DFLAGS += -DSET_MPI_GRID
@@ -28,7 +28,7 @@ DFLAGS += -DPRECISION=2
 #Set output preferences
 DFLAGS += -DOUTPUT
 #DFLAGS += -DBINARY
-#DFLAGS += -DHDF5
+DFLAGS += -DHDF5
 #DFLAGS += -DSLICES
 #DFLAGS += -DPROJECTION
 #DFLAGS += -DROTATED_PROJECTION
@@ -129,24 +129,32 @@ ifeq ($(findstring -DCUFFT,$(DFLAGS)),-DCUFFT)
 endif
 
 ifeq ($(findstring -DHDF5,$(DFLAGS)),-DHDF5)
-	CFLAGS += -I$(HDF5INCLUDE)
-	CXXFLAGS += -I$(HDF5INCLUDE)
-	GPUFLAGS += -I$(HDF5INCLUDE)
-	LIBS += -L$(HDF5DIR) -lhdf5
+ifneq ($(HDF5_ROOT),)
+	CFLAGS += -I$(HDF5_ROOT)/include
+	CXXFLAGS += -I$(HDF5_ROOT)/include
+	GPUFLAGS += -I$(HDF5_ROOT)/include
+	LIBS += -L$(HDF5_ROOT)/lib
+endif
+	LIBS += -lhdf5
 endif
 
 ifeq ($(findstring -DMPI_CHOLLA,$(DFLAGS)),-DMPI_CHOLLA)
 	CC = mpicc
 	CXX = mpicxx
+ifneq ($(MPI_HOME),)
 	GPUFLAGS += -I$(MPI_HOME)/include
+endif
 endif
 
 ifeq ($(findstring -DCUDA,$(DFLAGS)),-DCUDA)
 	GPUCXX := nvcc
-	GPUFLAGS += --expt-extended-lambda -g -O3 -arch sm_70 -fmad=false
+	GPUFLAGS += --expt-extended-lambda -g -O3 -arch sm_61 -fmad=false
 	LD := $(CXX)
 	LDFLAGS := $(CXXFLAGS)
-	LIBS += -L$(CUDA_DIR)/lib64 -lcudart
+ifneq ($(CUDA_DIR),)
+	LIBS += -L$(CUDA_DIR)/lib64
+endif
+	LIBS += -lcudart
 endif
 
 ifeq ($(findstring -DCOOLING_GRACKLE,$(DFLAGS)),-DCOOLING_GRACKLE)


### PR DESCRIPTION
The suggested changes do 3 things:

Add new variable $(CHOLLA_ARCH) to make it easier for new users to find (and set correctly) 

For -I$(DIR) include flags, check that $(DIR) is actually set to a value, to avoid adding spurious -I and -I/include to the flags. 

Change $(HDF5INCLUDE) to $(HDF5_ROOT) (as in CAAR branch) 