### PR TITLE
Clean boundaries

### DIFF
--- a/src/boundary_conditions.cpp
+++ b/src/boundary_conditions.cpp
@@ -389,6 +389,26 @@ void Grid3D::Set_Hydro_Boundaries_CPU
     //for outflow boundaries, set momentum to restrict inflow
     
     if (flags[dir] == 3) {
+      int momdex = iaBoundary[iB] + (dir/2+1)*H.n_cells;
+      // (X) Dir 0,1 -> Mom 1 -> c_density[gidx+1*n_cells]
+      // (Y) Dir 2,3 -> Mom 2 -> c_density[gidx+2*n_cells]
+      // (Z) Dir 4,5 -> Mom 3 -> c_density[gidx+3*n_cells]
+      // If a momentum is set to 0, subtract its kinetic energy [gidx+4*n_cells]
+      if (dir%2 == 0){
+	// Direction 0,2,4 are left-side, don't allow inflow with positive momentum
+	if (c_density[momdex] > 0.0) {
+	  c_energy[iaBoundary[iB]] -= 0.5*(c_density[momdex]*c_density[momdex])/c_density[iaBoundary[iB]];
+	  c_density[momdex] = 0.0;
+	}
+      } else {
+	// Direction 1,3,5 are right-side, don't allow inflow with negative momentum
+	if (c_density[momdex] < 0.0) {
+	  c_energy[iaBoundary[iB]] -= 0.5*(c_density[momdex]*c_density[momdex])/c_density[iaBoundary[iB]];
+	  c_density[momdex] = 0.0;
+	}
+      } 
+
+      /*
       // first subtract kinetic energy from total
       c_energy[iaBoundary[iB]] -= 
         0.5*(c_momentum_x[iaBoundary[iB]] * c_momentum_x[iaBoundary[iB]] 
@@ -420,7 +440,9 @@ void Grid3D::Set_Hydro_Boundaries_CPU
              + c_momentum_y[iaBoundary[iB]]*c_momentum_y[iaBoundary[iB]] 
              + c_momentum_z[iaBoundary[iB]]*c_momentum_z[iaBoundary[iB]])
             /c_density[iaBoundary[iB]]; 
-    }
+      */
+    }//end restrict outflow
+
           
   }      
 }

--- a/src/cuda_pack_buffers.cu
+++ b/src/cuda_pack_buffers.cu
@@ -28,7 +28,9 @@ void PackBuffers3D(Real * buffer, Real * c_head, int isize, int jsize, int ksize
   dim3 dim1dGrid((isize*jsize*ksize+TPB-1)/TPB, 1, 1);
   dim3 dim1dBlock(TPB, 1, 1); 
   hipLaunchKernelGGL(PackBuffers3DKernel,dim1dGrid,dim1dBlock,0,0,buffer,c_head,isize,jsize,ksize,nx,ny,idxoffset,offset,n_fields,n_cells);
+  #ifdef O_HIP
   CHECK(cudaDeviceSynchronize());
+  #endif
 }
 
 

--- a/src/cuda_pack_buffers.cu
+++ b/src/cuda_pack_buffers.cu
@@ -28,7 +28,7 @@ void PackBuffers3D(Real * buffer, Real * c_head, int isize, int jsize, int ksize
   dim3 dim1dGrid((isize*jsize*ksize+TPB-1)/TPB, 1, 1);
   dim3 dim1dBlock(TPB, 1, 1); 
   hipLaunchKernelGGL(PackBuffers3DKernel,dim1dGrid,dim1dBlock,0,0,buffer,c_head,isize,jsize,ksize,nx,ny,idxoffset,offset,n_fields,n_cells);
-  hipDeviceSynchronize();
+  CHECK(cudaDeviceSynchronize());
 }
 
 

--- a/src/cuda_pack_buffers.cu
+++ b/src/cuda_pack_buffers.cu
@@ -28,9 +28,7 @@ void PackBuffers3D(Real * buffer, Real * c_head, int isize, int jsize, int ksize
   dim3 dim1dGrid((isize*jsize*ksize+TPB-1)/TPB, 1, 1);
   dim3 dim1dBlock(TPB, 1, 1); 
   hipLaunchKernelGGL(PackBuffers3DKernel,dim1dGrid,dim1dBlock,0,0,buffer,c_head,isize,jsize,ksize,nx,ny,idxoffset,offset,n_fields,n_cells);
-  #ifdef O_HIP
   CHECK(cudaDeviceSynchronize());
-  #endif
 }
 
 

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -638,19 +638,23 @@ class Grid3D
     void Unload_MPI_Comm_Buffers_SLAB(int index);
     void Unload_MPI_Comm_Buffers_BLOCK(int index);
     
+    void Load_Hydro_Buffer_CPU(Real *buffer, int idxoffset, int isize, int jsize, int ksize);
+    
     int Load_Hydro_Buffer_X0(Real *buffer);
     int Load_Hydro_Buffer_X1(Real *buffer);
     int Load_Hydro_Buffer_Y0(Real *buffer);
     int Load_Hydro_Buffer_Y1(Real *buffer);
     int Load_Hydro_Buffer_Z0(Real *buffer);
     int Load_Hydro_Buffer_Z1(Real *buffer);
-    void Load_Hydro_DeviceBuffer3D(Real *buffer, int axis, int side);
+
     int Load_Hydro_DeviceBuffer_X0(Real *buffer);
     int Load_Hydro_DeviceBuffer_X1(Real *buffer);
     int Load_Hydro_DeviceBuffer_Y0(Real *buffer);
     int Load_Hydro_DeviceBuffer_Y1(Real *buffer);
     int Load_Hydro_DeviceBuffer_Z0(Real *buffer);
     int Load_Hydro_DeviceBuffer_Z1(Real *buffer);
+
+    void Unload_Hydro_Buffer_CPU(Real *buffer, int idxoffset, int isize, int jsize, int ksize);
     
     void Unload_Hydro_Buffer_X0(Real *buffer);
     void Unload_Hydro_Buffer_X1(Real *buffer);

--- a/src/initial_conditions.cpp
+++ b/src/initial_conditions.cpp
@@ -59,7 +59,7 @@ void Grid3D::Set_Initial_Conditions(parameters P) {
     Disk_3D(P); 
   } else if (strcmp(P.init, "Disk_3D_particles")==0) {
     #ifndef ONLY_PARTICLES
-    Disk_3D(P)
+    Disk_3D(P);
     #else 
     // Initialize a uniforn hydro grid when only integrating particles
     Uniform_Grid();

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -851,13 +851,11 @@ void Grid3D::Unload_Hydro_DeviceBuffer_X1 ( Real *recv_buffer_x1 ) {
 void Grid3D::Unload_Hydro_Buffer_Y0 ( Real *recv_buffer_y0 ) {
   // 2D
   if (nz == 1) {
-    offset = H.n_ghost*H.nx;
     int idxoffset = 0;
     Unload_Hydro_Buffer_CPU(recv_buffer_y0, idxoffset, H.nx, H.n_ghost, 1);
   }
   // 3D
   if (nz > 1) {
-    offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
     int idxoffset = H.n_ghost*H.nx*H.ny;
     Unload_Hydro_Buffer_CPU(recv_buffer_y0, idxoffset, H.nx, H.n_ghost, H.nz-2*H.n_ghost);
   }

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -893,7 +893,7 @@ void Grid3D::Unload_Hydro_Buffer_Y1 ( Real *recv_buffer_y1 ) {
   // 3D
   if (H.nz > 1) {
     int idxoffset = (H.ny-H.n_ghost)*H.nx + H.n_ghost*H.nx*H.ny;
-    Unload_Hydro_Buffer_CPU(recv_buffer_y1, idxoffset, H.nx, H.n_ghost, H.nz-H.n_ghost);
+    Unload_Hydro_Buffer_CPU(recv_buffer_y1, idxoffset, H.nx, H.n_ghost, H.nz-2*H.n_ghost);
   }
 }
 

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -943,7 +943,7 @@ void Grid3D::Unload_Hydro_DeviceBuffer_Z0 ( Real *recv_buffer_z0 ) {
 
 void Grid3D::Unload_Hydro_Buffer_Z1 ( Real *recv_buffer_z1 ) {
   int idxoffset = (H.nz-H.n_ghost)*H.nx*H.ny;
-  Unload_Hydro_Buffer_CPU(recv_buffer_z0, idxoffset, H.nx, H.ny, H.n_ghost);
+  Unload_Hydro_Buffer_CPU(recv_buffer_z1, idxoffset, H.nx, H.ny, H.n_ghost);
 }
 
 void Grid3D::Unload_Hydro_DeviceBuffer_Z1 ( Real *recv_buffer_z1 ) {

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -802,19 +802,19 @@ void Grid3D::Unload_Hydro_DeviceBuffer_X0 ( Real *recv_buffer_x0 ) {
 
 void Grid3D::Unload_Hydro_Buffer_X1 ( Real *recv_buffer_x1 ) {
   // 1D
-  if (ny == 1 && nz == 1) {
+  if (H.ny == 1 && H.nz == 1) {
     int idxoffset = H.nx - H.n_ghost;
     Unload_Hydro_Buffer_CPU(recv_buffer_x1, idxoffset, H.n_ghost, 1, 1);
   }
   // 2D
-  if (ny > 1 && nz == 1) {
+  if (H.ny > 1 && H.nz == 1) {
     int idxoffset = H.nx - H.n_ghost + H.n_ghost*H.nx;
-    Unload_Hydro_Buffer_CPU(recv_buffer_x1, idxoffset, H.n_ghost, ,H.ny-2*H.n_ghost, 1);
+    Unload_Hydro_Buffer_CPU(recv_buffer_x1, idxoffset, H.n_ghost, H.ny-2*H.n_ghost, 1);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     int idxoffset = H.nx - H.n_ghost + H.n_ghost*(H.nx+H.nx*H.ny);
-    Unload_Hydro_Buffer_CPU(recv_buffer_x1, idxoffset, H.n_ghost, ,H.ny-2*H.n_ghost, H.nz-2*H.n_ghost);
+    Unload_Hydro_Buffer_CPU(recv_buffer_x1, idxoffset, H.n_ghost, H.ny-2*H.n_ghost, H.nz-2*H.n_ghost);
   }
 }
 
@@ -827,19 +827,19 @@ void Grid3D::Unload_Hydro_DeviceBuffer_X1 ( Real *recv_buffer_x1 ) {
   c_head = (Real *) C.device;
 
   // 1D
-  if (ny == 1 && nz == 1) {
+  if (H.ny == 1 && H.nz == 1) {
     offset = H.n_ghost;
     int idxoffset = H.nx - H.n_ghost;
     UnpackBuffers3D(recv_buffer_x1,c_head,H.n_ghost ,1 ,1 ,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
   }
   // 2D
-  if (ny > 1 && nz == 1) {
+  if (H.ny > 1 && H.nz == 1) {
     offset = H.n_ghost*(H.ny-2*H.n_ghost);
     int idxoffset = H.nx - H.n_ghost + H.n_ghost*H.nx;
     UnpackBuffers3D(recv_buffer_x1,c_head,H.n_ghost ,H.ny-2*H.n_ghost ,1 ,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     offset = H.n_ghost*(H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost);
     int idxoffset = H.nx - H.n_ghost + H.n_ghost*(H.nx+H.nx*H.ny);
     UnpackBuffers3D(recv_buffer_x1,c_head,H.n_ghost,H.ny-2*H.n_ghost,H.nz-2*H.n_ghost,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
@@ -850,12 +850,12 @@ void Grid3D::Unload_Hydro_DeviceBuffer_X1 ( Real *recv_buffer_x1 ) {
 
 void Grid3D::Unload_Hydro_Buffer_Y0 ( Real *recv_buffer_y0 ) {
   // 2D
-  if (nz == 1) {
+  if (H.nz == 1) {
     int idxoffset = 0;
     Unload_Hydro_Buffer_CPU(recv_buffer_y0, idxoffset, H.nx, H.n_ghost, 1);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     int idxoffset = H.n_ghost*H.nx*H.ny;
     Unload_Hydro_Buffer_CPU(recv_buffer_y0, idxoffset, H.nx, H.n_ghost, H.nz-2*H.n_ghost);
   }
@@ -870,13 +870,13 @@ void Grid3D::Unload_Hydro_DeviceBuffer_Y0 ( Real *recv_buffer_y0 ) {
   c_head = (Real *) C.device;
 
   // 2D
-  if (nz == 1) {
+  if (H.nz == 1) {
     offset = H.n_ghost*H.nx;
     int idxoffset = 0;
     UnpackBuffers3D(recv_buffer_y0,c_head,H.nx,H.n_ghost,1,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
     int idxoffset = H.n_ghost*H.nx*H.ny;
     UnpackBuffers3D(recv_buffer_y0,c_head,H.nx,H.n_ghost,H.nz-2*H.n_ghost,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
@@ -886,12 +886,12 @@ void Grid3D::Unload_Hydro_DeviceBuffer_Y0 ( Real *recv_buffer_y0 ) {
 
 void Grid3D::Unload_Hydro_Buffer_Y1 ( Real *recv_buffer_y1 ) {
   // 2D
-  if (nz == 1) {
+  if (H.nz == 1) {
     int idxoffset = (H.ny-H.n_ghost)*H.nx;
     Unload_Hydro_Buffer_CPU(recv_buffer_y1, idxoffset, H.nx, H.n_ghost, 1);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     int idxoffset = (H.ny-H.n_ghost)*H.nx + H.n_ghost*H.nx*H.ny;
     Unload_Hydro_Buffer_CPU(recv_buffer_y1, idxoffset, H.nx, H.n_ghost, H.nz-H.n_ghost);
   }
@@ -906,13 +906,13 @@ void Grid3D::Unload_Hydro_DeviceBuffer_Y1 ( Real *recv_buffer_y1 ) {
   c_head = (Real *) C.device;
 
   // 2D
-  if (nz == 1) {
+  if (H.nz == 1) {
     offset = H.n_ghost*H.nx;
     int idxoffset = (H.ny-H.n_ghost)*H.nx;
     UnpackBuffers3D(recv_buffer_y1,c_head,H.nx,H.n_ghost,1,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);
   }
   // 3D
-  if (nz > 1) {
+  if (H.nz > 1) {
     offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
     int idxoffset = (H.ny-H.n_ghost)*H.nx + H.n_ghost*H.nx*H.ny;
     UnpackBuffers3D(recv_buffer_y1,c_head,H.nx,H.n_ghost,H.nz-2*H.n_ghost,H.nx,H.ny,idxoffset,offset,H.n_fields,H.n_cells);

--- a/src/mpi_boundaries.cpp
+++ b/src/mpi_boundaries.cpp
@@ -1042,7 +1042,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
    
       if ( transfer_main_buffer ){
-        #ifdef MPI_GPU
+        #if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive left x communication buffer
         MPI_Irecv(d_recv_buffer_x0, buffer_length, MPI_CHREAL, source[0], 0, 
                   world, &recv_request[ireq]);
@@ -1121,7 +1121,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
-        #ifdef MPI_GPU
+	#if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive right x communication buffer
         MPI_Irecv(d_recv_buffer_x1, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request[ireq]);
 
@@ -1205,7 +1205,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
-        #ifdef MPI_GPU
+	#if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive left y communication buffer
         MPI_Irecv(d_recv_buffer_y0, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request[ireq]);
 
@@ -1281,8 +1281,8 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       }
       #endif
       
-      if ( transfer_main_buffer ){      
-        #ifdef MPI_GPU
+      if ( transfer_main_buffer ){
+        #if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive right y communication buffer
         MPI_Irecv(d_recv_buffer_y1, buffer_length, MPI_CHREAL, source[3], 3, world, &recv_request[ireq]);
 
@@ -1366,8 +1366,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
-      
-        #ifdef MPI_GPU
+        #if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive left z communication buffer
         MPI_Irecv(d_recv_buffer_z0, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request[ireq]);
         //non-blocking send left z communication buffer
@@ -1442,7 +1441,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers_BLOCK(int dir, int *flags)
       #endif
       
       if ( transfer_main_buffer ){
-        #ifdef MPI_GPU
+        #if defined(MPI_GPU) && defined(HYDRO_GPU)
         //post non-blocking receive right x communication buffer
         MPI_Irecv(d_recv_buffer_z1, buffer_length, MPI_CHREAL, source[5], 5, world, &recv_request[ireq]);
 


### PR DESCRIPTION
- Fixed transmissive boundaries in boundary_conditions.cpp and cuda_pack_buffers.cu to avoid floating point errors by performing fewer FLOPs (output matches much better between HYDRO_GPU on/off). This is the most significant change in terms of output differences from previous versions of the code, but should be more accurate. (boundary_conditions.cpp and cuda_pack_buffers.cu)
- After more testing, I realized the CUDA version of the code requires thread synchronization as well, and previous tests somehow got lucky. (cuda_pack_buffers.cu)
- Cleanup of a lot of trash code I generated when making no_offload changes (mpi_boundaries.cpp)
- Enable HYDRO_GPU to be turned off while MPI_GPU is turned on (for hydro buffers, it will not use cuda-aware MPI) (mpi_boundaries.cpp)
- Refactor of mpi_boundary CPU buffer packing/unpacking to look more similar to the GPU buffer packing/unpacking to make reading code / changing code / debugging code easier (if someone wants to, maybe they can insert an openmp pragma to make CPU buffer packing/unpacking faster. Since the loops are abstracted, the pragma only needs to be placed in a few locations). (mpi_boundaries.cpp)
- All changes tested with 2D and 3D multi-GPU on summit/spock