### PR TITLE
Add the option to perform inter-process halo exchange directly on the device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,12 @@ DFLAGS += -DVL
 # Use Grackle for cooling in cosmological simulations
 #DFLAGS += -DCOOLING_GRACKLE
 
+# Use NVTX
+#DFLAGS += -DUSE_NVTX
+
+# Use device comm
+#DFLAGS += -DDEVICE_COMM
+
 CC ?= cc
 CXX ?= CC
 CFLAGS += -g -Ofast
@@ -119,6 +125,16 @@ CXXFLAGS += -g -Ofast -std=c++14
 CFLAGS += $(DFLAGS) -Isrc
 CXXFLAGS += $(DFLAGS) -Isrc
 GPUFLAGS += $(DFLAGS) -Isrc
+
+ifeq ($(findstring -DUSE_NVTX,$(DFLAGS)),-DUSE_NVTX)
+ifneq ($(CUDA_DIR),)
+	CFLAGS += -I$(CUDA_DIR)/include
+	CXXFLAGS += -I$(CUDA_DIR)/include
+	GPUFLAGS += -I$(CUDA_DIR)/include
+	LIBS += -L$(CUDA_DIR)/lib64
+endif
+	LIBS += -lnvToolsExt
+endif
 
 ifeq ($(findstring -DPFFT,$(DFLAGS)),-DPFFT)
 	CXXFLAGS += -I$(FFTW_ROOT)/include -I$(PFFT_ROOT)/include

--- a/src/boundary_conditions_cuda.cu
+++ b/src/boundary_conditions_cuda.cu
@@ -1,0 +1,31 @@
+#include "grid3D.h"
+#include "boundary_conditions_cuda.cuh"
+#include "global_cuda.h"
+
+#ifdef DEVICE_COMM
+
+// This is a CUDA ported version of the `Set_Ghost_Cells` function
+
+void Grid3D::Set_Ghost_Cells_Cuda(int imin[3], int imax[3], Real a[3], int flags[6], int dir) {
+
+  int threads = (imax[0] - imin[0]) * (imax[1] - imin[1]) * (imax[2] - imin[2]);
+  int block = 256;
+  int grid = (threads + block - 1) / block;
+
+  Set_Ghost_Cells_Cuda_Arg arg;
+  for (int d = 0; d < 3; d++) {
+    arg.imin[d] = imin[d];
+    arg.imax[d] = imax[d];
+  }
+  for (int d = 0; d < 6; d++) {
+    arg.flags[d] = flags[d];
+  }
+  arg.dir = dir;
+
+  Set_Ghost_Cells_Cuda_Kernel<<<grid, block>>>(dev_conserved, H, arg);
+  CudaSafeCall(cudaStreamSynchronize(0));
+
+}
+
+#endif
+

--- a/src/boundary_conditions_cuda.cuh
+++ b/src/boundary_conditions_cuda.cuh
@@ -1,0 +1,247 @@
+#ifndef __BOUNDARY_CONDITIONS_CUDA_H__
+#define __BOUNDARY_CONDITIONS_CUDA_H__
+
+#include "grid3D.h"
+
+// This is a CUDA ported version of the `Set_Ghost_Cells` function
+
+/*! \fn int Find_Index(int ig, int nx, int flag, int face, Real *a)
+ *  \brief Given a ghost cell index and boundary flag,
+    return the index of the corresponding real cell. */
+__device__ __host__ inline int Find_Index(Header &H, int ig, int nx, int flag, int face, Real a[3])
+{
+  int id;
+
+  // lower face
+  if (face==0) {
+    switch(flag)
+    {
+      // periodic
+      case 1: id = ig+nx-2*H.n_ghost;
+        break;
+      // reflective
+      case 2: id = 2*H.n_ghost-ig-1;
+        *(a) = -1.0;
+        break;
+      // transmissive
+      case 3: id = H.n_ghost;
+        break;
+      // custom
+      case 4: id = -1;
+        break;
+      // MPI
+      case 5: id = ig;
+        break;
+      // default is periodic
+      default: id = ig+nx-2*H.n_ghost;
+    }
+  }
+  // upper face
+  else {
+    switch(flag)
+    {
+      // periodic
+      case 1: id = ig-nx+2*H.n_ghost;
+        break;
+      // reflective
+      case 2: id = 2*(nx-H.n_ghost)-ig-1;
+        *(a) = -1.0;
+        break;
+      // transmissive
+      case 3: id = nx-H.n_ghost-1;
+        break;
+      // custom
+      case 4: id = -1;
+        break;
+      // MPI
+      case 5: id = ig;
+        break;
+      // default is periodic
+      default: id = ig-nx+2*H.n_ghost;
+    }
+  }
+
+  return id;
+}
+
+/*! \fn Set_Boundary_Mapping(int ig, int jg, int kg, int flags[], Real *a)
+ *  \brief Given the i,j,k index of a ghost cell, return the index of the
+    corresponding real cell, and reverse the momentum if necessary. */
+__device__ __host__ inline int Set_Boundary_Mapping(Header &H, int ig, int jg, int kg, int flags[6], Real a[3])
+{
+  // index of real cell we're mapping to
+  int ir, jr, kr, idx;
+  ir = jr = kr = idx = 0;
+
+  /* 1D */
+  if (H.nx>1) {
+
+    // set index on -x face
+    if (ig < H.n_ghost) {
+      ir = Find_Index(H, ig, H.nx, flags[0], 0, &a[0]);
+    }
+    // set index on +x face
+    else if (ig >= H.nx-H.n_ghost) {
+      ir = Find_Index(H, ig, H.nx, flags[1], 1, &a[0]);
+    }
+    // set i index for multi-D problems
+    else {
+      ir = ig;
+    }
+
+    // if custom x boundaries are needed, set index to -1 and return
+    if (ir < 0) {
+      return idx = -1;
+    }
+
+    // otherwise add i index to ghost cell mapping
+    idx += ir;
+
+  }
+
+  /* 2D */
+  if (H.ny > 1) {
+
+    // set index on -y face
+    if (jg < H.n_ghost) {
+      jr = Find_Index(H, jg, H.ny, flags[2], 0, &a[1]);
+    }
+    // set index on +y face
+    else if (jg >= H.ny-H.n_ghost) {
+      jr = Find_Index(H, jg, H.ny, flags[3], 1, &a[1]);
+    }
+    // set j index for multi-D problems
+    else {
+      jr = jg;
+    }
+
+    // if custom y boundaries are needed, set index to -1 and return
+    if (jr < 0) {
+      return idx = -1;
+    }
+
+    // otherwise add j index to ghost cell mapping
+    idx += H.nx*jr;
+
+  }
+
+  /* 3D */
+  if (H.nz > 1) {
+
+    // set index on -z face
+    if (kg < H.n_ghost) {
+      kr = Find_Index(H, kg, H.nz, flags[4], 0, &a[2]);
+    }
+    // set index on +z face
+    else if (kg >= H.nz-H.n_ghost) {
+      kr = Find_Index(H, kg, H.nz, flags[5], 1, &a[2]);
+    }
+    // set k index for multi-D problems
+    else {
+      kr = kg;
+    }
+
+    // if custom z boundaries are needed, set index to -1 and return
+    if (kr < 0) {
+      return idx = -1;
+    }
+
+    // otherwise add k index to ghost cell mapping
+    idx += H.nx*H.ny*kr;
+
+  }
+
+  return idx;
+}
+
+struct Set_Ghost_Cells_Cuda_Arg {
+
+  int imin[3];
+  int imax[3];
+
+  int flags[6];
+
+  int dir;
+
+};
+
+__global__ void Set_Ghost_Cells_Cuda_Kernel(Real *dev_conserved, Header H, Set_Ghost_Cells_Cuda_Arg arg) {
+
+  int thread_idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int i = thread_idx % (arg.imax[0] - arg.imin[0]) + arg.imin[0]; thread_idx /= (arg.imax[0] - arg.imin[0]);
+  int j = thread_idx % (arg.imax[1] - arg.imin[1]) + arg.imin[1];
+  int k = thread_idx / (arg.imax[1] - arg.imin[1]) + arg.imin[2];
+
+  Real a[3];
+
+  //reset sign of momenta
+  a[0] = 1.;
+  a[1] = 1.;
+  a[2] = 1.;
+
+  //find the ghost cell index
+  int gidx = i + j*H.nx + k*H.nx*H.ny;
+
+  //find the corresponding real cell index and momenta signs
+  int idx  = Set_Boundary_Mapping(H, i,j,k,arg.flags,&a[0]);
+
+  Real *density    = &dev_conserved[0*H.n_cells];
+  Real *momentum_x = &dev_conserved[1*H.n_cells];
+  Real *momentum_y = &dev_conserved[2*H.n_cells];
+  Real *momentum_z = &dev_conserved[3*H.n_cells];
+  Real *Energy     = &dev_conserved[4*H.n_cells];
+
+  //idx will be >= 0 if the boundary mapping function has
+  //not set this ghost cell by hand, for instance for analytical
+  //boundary conditions
+  //
+  //Otherwise, the boundary mapping function will set idx<0
+  //if this ghost cell has been set by hand
+  if(idx>=0)
+  {
+    //set the ghost cell value
+    density[gidx]    = density[idx];
+    momentum_x[gidx] = momentum_x[idx]*a[0];
+    momentum_y[gidx] = momentum_y[idx]*a[1];
+    momentum_z[gidx] = momentum_z[idx]*a[2];
+    Energy[gidx]     = Energy[idx];
+#ifdef DE
+    C.GasEnergy[gidx]  = C.GasEnergy[idx];
+#endif
+#ifdef SCALAR
+    for (int ii=0; ii<NSCALARS; ii++) {
+      C.scalar[gidx + ii*H.n_cells]  = C.scalar[idx + ii*H.n_cells];
+    }
+#endif
+
+    //for outflow boundaries, set momentum to restrict inflow
+    if (arg.flags[arg.dir] == 3) {
+      // first subtract kinetic energy from total
+      Energy[gidx] -= 0.5*(momentum_x[gidx]*momentum_x[gidx] + momentum_y[gidx]*momentum_y[gidx] + momentum_z[gidx]*momentum_z[gidx])/density[gidx];
+      if (arg.dir == 0) {
+        momentum_x[gidx] = fmin(momentum_x[gidx], 0.0);
+      }
+      if (arg.dir == 1) {
+        momentum_x[gidx] = fmax(momentum_x[gidx], 0.0);
+      }
+      if (arg.dir == 2) {
+        momentum_y[gidx] = fmin(momentum_y[gidx], 0.0);
+      }
+      if (arg.dir == 3) {
+        momentum_y[gidx] = fmax(momentum_y[gidx], 0.0);
+      }
+      if (arg.dir == 4) {
+        momentum_z[gidx] = fmin(momentum_z[gidx], 0.0);
+      }
+      if (arg.dir == 5) {
+        momentum_z[gidx] = fmax(momentum_z[gidx], 0.0);
+      }
+      // now re-add the new kinetic energy
+      Energy[gidx] += 0.5*(momentum_x[gidx]*momentum_x[gidx] + momentum_y[gidx]*momentum_y[gidx] + momentum_z[gidx]*momentum_z[gidx])/density[gidx];
+    }
+
+
+  }
+}
+
+#endif

--- a/src/global_cuda.h
+++ b/src/global_cuda.h
@@ -6,6 +6,7 @@
 #include<stdlib.h>
 #include<stdio.h>
 #include<cuda.h>
+#include<cuda_runtime.h>
 #include<math.h>
 #include"global.h"
 

--- a/src/grid3D.h
+++ b/src/grid3D.h
@@ -35,6 +35,8 @@
 #include "timing_functions.h"
 #endif
 
+#include "global_cuda.h"
+
 struct Rotation
 {
   /*! \var nx
@@ -557,6 +559,12 @@ class Grid3D
      *  \brief Set the extents of the ghost region we are initializing. */
     void Set_Boundary_Extents(int dir, int *imin, int *imax);
 
+    void Set_Ghost_Cells(int imin[3], int imax[3], Real a[3], int flags[6], int dir);
+
+    #ifdef DEVICE_COMM
+    void Set_Ghost_Cells_Cuda(int imin[3], int imax[3], Real a[3], int flags[6], int dir);
+    #endif
+
     /*! \fn Set_Boundary_Mapping(int ig, int jg, int kg, int flags[], Real *a)
      *  \brief Given the i,j,k index of a ghost cell, return the index of the
         corresponding real cell, and reverse the momentum if necessary. */
@@ -603,12 +611,23 @@ class Grid3D
     void Unload_MPI_Comm_Buffers(int index);
     void Unload_MPI_Comm_Buffers_SLAB(int index);
     void Unload_MPI_Comm_Buffers_BLOCK(int index);
+    #ifdef DEVICE_COMM
+    void Unload_MPI_Comm_Buffers_BLOCK_Cuda(int index);
+    #endif
     int Load_Hydro_Buffer_X0();
     int Load_Hydro_Buffer_X1();
     int Load_Hydro_Buffer_Y0();
     int Load_Hydro_Buffer_Y1();
     int Load_Hydro_Buffer_Z0();
     int Load_Hydro_Buffer_Z1();
+    #ifdef DEVICE_COMM
+    int Load_Hydro_Buffer_X0_Cuda();
+    int Load_Hydro_Buffer_X1_Cuda();
+    int Load_Hydro_Buffer_Y0_Cuda();
+    int Load_Hydro_Buffer_Y1_Cuda();
+    int Load_Hydro_Buffer_Z0_Cuda();
+    int Load_Hydro_Buffer_Z1_Cuda();
+    #endif
 #endif /*MPI_CHOLLA*/
 
   #ifdef GRAVITY
@@ -642,6 +661,14 @@ class Grid3D
   void Load_and_Send_Particles_Y1( int ireq_n_particles, int ireq_particles_transfer );
   void Load_and_Send_Particles_Z0( int ireq_n_particles, int ireq_particles_transfer );
   void Load_and_Send_Particles_Z1( int ireq_n_particles, int ireq_particles_transfer );
+  #ifdef DEVICE_COMM
+  void Load_and_Send_Particles_X0_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  void Load_and_Send_Particles_X1_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  void Load_and_Send_Particles_Y0_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  void Load_and_Send_Particles_Y1_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  void Load_and_Send_Particles_Z0_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  void Load_and_Send_Particles_Z1_Cuda( int ireq_n_particles, int ireq_particles_transfer );
+  #endif
   void Unload_Particles_from_Buffer_X0( int *flags );
   void Unload_Particles_from_Buffer_X1( int *flags );
   void Unload_Particles_from_Buffer_Y0( int *flags );

--- a/src/initial_conditions.cpp
+++ b/src/initial_conditions.cpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <fstream>
 
+#include "global_cuda.h"
+
 using namespace std;
 
 /*! \fn void Set_Initial_Conditions(parameters P)
@@ -76,6 +78,9 @@ void Grid3D::Set_Initial_Conditions(parameters P) {
     chprintf ("ABORT: %s: Unknown initial conditions!\n", P.init);
     chexit(-1);
   }
+  #ifdef DEVICE_COMM
+  CudaSafeCall( cudaMemcpy(dev_conserved, &C.density[0], H.n_fields*H.n_cells*sizeof(Real), cudaMemcpyHostToDevice) );
+  #endif
 
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -21,6 +21,10 @@
 #include "cosmology/cosmology.h"
 #endif
 
+#ifdef DEVICE_COMM
+#include "global_cuda.h"
+#endif
+
 using namespace std;
 
 // #define OUTPUT_ENERGY
@@ -74,6 +78,10 @@ void Write_Message_To_Log_File( const char* message ){
 /* Write the initial conditions */
 void WriteData(Grid3D &G, struct parameters P, int nfile)
 {
+  #ifdef DEVICE_COMM
+  // copy the updated conserved variable array back to the CPU
+  CudaSafeCall( cudaMemcpy(&G.C.density[0], dev_conserved, G.H.n_fields*G.H.n_cells*sizeof(Real), cudaMemcpyDeviceToHost) );
+  #endif
   
   chprintf( "\nSaving Snapshot: %d \n", nfile );
   

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,16 @@ int main(int argc, char *argv[])
   G.Initialize(&P);
   chprintf("Local number of grid cells: %d %d %d %d\n", G.H.nx_real, G.H.ny_real, G.H.nz_real, G.H.n_cells);
 
+  #if defined(DEVICE_COMM)
+  #if defined(GRAVITY) || defined(PARTICLES) || defined(CTU)
+    printf("Device communicaiton does not support GRAVITY, PARTICLES, or CTU\n");
+    exit(90);
+  #endif
+  if (G.H.nx == 1 || G.H.ny == 1 || G.H.nz == 1) {
+    printf("Device communicaiton only support 3D\n");
+    exit(91);
+  }
+  #endif
 
   // Set initial conditions and calculate first dt
   chprintf("Setting initial conditions...\n");
@@ -174,7 +184,7 @@ int main(int argc, char *argv[])
     //Transfer the particles that moved outside the local domain  
     G.Transfer_Particles_Boundaries(P); 
     #endif
-    
+
     // Advance the grid by one timestep
     dti = G.Update_Hydro_Grid();
     
@@ -262,7 +272,7 @@ int main(int argc, char *argv[])
   G.Reset();
 
   #ifdef MPI_CHOLLA
-  MPI_Finalize();
+  FinalizeChollaMPI();
   #endif /*MPI_CHOLLA*/
 
   return 0;

--- a/src/mpi_boundaries_cuda.cu
+++ b/src/mpi_boundaries_cuda.cu
@@ -1,0 +1,331 @@
+#ifdef MPI_CHOLLA
+#include"grid3D.h"
+#include"mpi_routines.h"
+#include"io.h"
+#include"error_handling.h"
+#include <iostream>
+
+#include "nvtx.h"
+#include "global_cuda.h"
+
+#include <cassert>
+
+#ifdef DEVICE_COMM
+
+template <bool load, bool forward>
+__global__ void Load_Hydro_Buffer_X_Cuda_kernel(Header H, Real *dev_send_recv_buffer, Real *dev_conserved) {
+
+  int offset = H.n_ghost*(H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost);
+
+  int thread_idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (thread_idx >= (H.ny-2*H.n_ghost) * (H.nz-2*H.n_ghost)) { return; }
+  int j = thread_idx % (H.ny-2*H.n_ghost);
+  int k = thread_idx / (H.ny-2*H.n_ghost);
+
+  int i_offset = load ? (forward ? H.nx-2*H.n_ghost : H.n_ghost) : (forward ? H.nx-H.n_ghost : 0);
+
+  for(int i=0;i<H.n_ghost;i++)
+  {
+    int idx  = (i+i_offset) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+    int gidx = i + j*H.n_ghost + k*H.n_ghost*(H.ny-2*H.n_ghost);
+    for (int ii=0; ii<H.n_fields; ii++) {
+      if (load) {
+        *(dev_send_recv_buffer + gidx + ii*offset) = dev_conserved[idx + ii*H.n_cells];
+      } else { // unload
+        dev_conserved[idx + ii*H.n_cells] = *(dev_send_recv_buffer + gidx + ii*offset);
+      }
+    }
+  }
+}
+
+template <bool load, bool forward>
+__global__ void Load_Hydro_Buffer_Y_Cuda_kernel(Header H, Real *dev_send_recv_buffer, Real *dev_conserved) {
+
+  int offset = H.n_ghost*H.nx*(H.nz-2*H.n_ghost);
+
+  int thread_idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (thread_idx >= H.nx*(H.nz-2*H.n_ghost)) { return; }
+  int i = thread_idx % (H.nx);
+  int k = thread_idx / (H.nx);
+
+  int j_offset = load ? (forward ? H.ny-2*H.n_ghost : H.n_ghost) : (forward ? H.ny-H.n_ghost : 0);
+
+  for(int j=0;j<H.n_ghost;j++)
+  {
+    int idx  = i + (j+j_offset)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+    int gidx = i + j*H.nx + k*H.nx*H.n_ghost;
+    for (int ii=0; ii<H.n_fields; ii++) {
+      if (load) {
+        *(dev_send_recv_buffer + gidx + ii*offset) = dev_conserved[idx + ii*H.n_cells];
+      } else { // unload
+        dev_conserved[idx + ii*H.n_cells] = *(dev_send_recv_buffer + gidx + ii*offset);
+      }
+    }
+  }
+}
+
+template <bool load, bool forward>
+__global__ void Load_Hydro_Buffer_Z_Cuda_kernel(Header H, Real *dev_send_recv_buffer, Real *dev_conserved) {
+
+  int offset = H.n_ghost*H.nx*H.ny;
+
+  int thread_idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (thread_idx >= H.nx*H.ny) { return; }
+  int i = thread_idx % (H.nx);
+  int j = thread_idx / (H.nx);
+
+  int k_offset = load ? (forward ? H.nz-2*H.n_ghost : H.n_ghost) : (forward ? H.nz-H.n_ghost : 0);
+
+  for(int k=0;k<H.n_ghost;k++)
+  {
+    int idx  = i + j*H.nx + (k+k_offset)*H.nx*H.ny;
+    int gidx = i + j*H.nx + k*H.nx*H.ny;
+    for (int ii=0; ii<H.n_fields; ii++) {
+      if (load) {
+        *(dev_send_recv_buffer + gidx + ii*offset) = dev_conserved[idx + ii*H.n_cells];
+      } else { // unload
+        dev_conserved[idx + ii*H.n_cells] = *(dev_send_recv_buffer + gidx + ii*offset);
+      }
+    }
+  }
+}
+
+// load left x communication buffer
+int Grid3D::Load_Hydro_Buffer_X0_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  // 1D
+  if (H.ny == 1 && H.nz == 1) {
+    assert(false);
+  }
+  // 2D
+  if (H.ny > 1 && H.nz == 1) {
+    assert(false);
+  }
+  // 3D
+  if (H.ny > 1 && H.nz > 1) {
+    int block = 256;
+    int grid = ((H.ny-2*H.n_ghost) * (H.nz-2*H.n_ghost) + block - 1) / block;
+    // forward = false
+    Load_Hydro_Buffer_X_Cuda_kernel<true, false><<<grid, block>>>(H, dev_send_buffer_x0, dev_conserved);
+    CudaSafeCall(cudaStreamSynchronize(0));
+  }
+  return x_buffer_length;
+}
+
+// load right x communication buffer
+int Grid3D::Load_Hydro_Buffer_X1_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  // 1D
+  if (H.ny == 1 && H.nz == 1) {
+    assert(false);
+  }
+  // 2D
+  if (H.ny > 1 && H.nz == 1) {
+    assert(false);
+  }
+  // 3D
+  if (H.ny > 1 && H.nz > 1) {
+    int block = 256;
+    int grid = ((H.ny-2*H.n_ghost) * (H.nz-2*H.n_ghost) + block - 1) / block;
+    // forward = true
+    Load_Hydro_Buffer_X_Cuda_kernel<true, true><<<grid, block>>>(H, dev_send_buffer_x1, dev_conserved);
+    CudaSafeCall(cudaStreamSynchronize(0));
+  }
+  return x_buffer_length;
+}
+
+// load left y communication buffer
+int Grid3D::Load_Hydro_Buffer_Y0_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+  // 2D
+  if (H.nz == 1) {
+    assert(false);
+  }
+  // 3D
+  if (H.nz > 1) {
+    int block = 256;
+    int grid = (H.nx*(H.nz-2*H.n_ghost) + block - 1) / block;
+    // forward = false
+    Load_Hydro_Buffer_Y_Cuda_kernel<true, false><<<grid, block>>>(H, dev_send_buffer_y0, dev_conserved);
+    CudaSafeCall(cudaStreamSynchronize(0));
+  }
+  return y_buffer_length;
+}
+
+// load right y communication buffer
+int Grid3D::Load_Hydro_Buffer_Y1_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  // 2D
+  if (H.nz == 1) {
+    assert(false);
+  }
+  // 3D
+  if (H.nz > 1) {
+    int block = 256;
+    int grid = (H.nx*(H.nz-2*H.n_ghost) + block - 1) / block;
+    // forward = true
+    Load_Hydro_Buffer_Y_Cuda_kernel<true, true><<<grid, block>>>(H, dev_send_buffer_y1, dev_conserved);
+    CudaSafeCall(cudaStreamSynchronize(0));
+  }
+  return y_buffer_length;
+}
+
+// load left z communication buffer
+int Grid3D::Load_Hydro_Buffer_Z0_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  int block = 256;
+  int grid = (H.nx*H.ny + block - 1) / block;
+  // forward = false
+  Load_Hydro_Buffer_Z_Cuda_kernel<true, false><<<grid, block>>>(H, dev_send_buffer_z0, dev_conserved);
+  CudaSafeCall(cudaStreamSynchronize(0));
+
+  return z_buffer_length;
+}
+
+// load right z communication buffer
+int Grid3D::Load_Hydro_Buffer_Z1_Cuda(){
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  int block = 256;
+  int grid = (H.nx*H.ny + block - 1) / block;
+  // forward = true
+  Load_Hydro_Buffer_Z_Cuda_kernel<true, true><<<grid, block>>>(H, dev_send_buffer_z1, dev_conserved);
+  CudaSafeCall(cudaStreamSynchronize(0));
+
+  return z_buffer_length;
+}
+
+void Grid3D::Unload_MPI_Comm_Buffers_BLOCK_Cuda(int index)
+{
+  nvtx_raii _nvtx(__FUNCTION__, __LINE__);
+
+  if ( H.TRANSFER_HYDRO_BOUNDARIES ){
+    //unload left x communication buffer
+    if(index==0)
+    {
+      // 1D
+      if (H.ny == 1 && H.nz == 1) {
+        assert(false);
+      }
+      // 2D
+      if (H.ny > 1 && H.nz == 1) {
+        assert(false);
+      }
+      // 3D
+      if (H.nz > 1) {
+        int block = 256;
+        int grid = ((H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost) + block - 1) / block;
+        // forward = false
+        Load_Hydro_Buffer_X_Cuda_kernel<false, false><<<grid, block>>>(H, dev_recv_buffer_x0, dev_conserved);
+        CudaSafeCall(cudaStreamSynchronize(0));
+      }
+    }
+
+    //unload right x communication buffer
+    if(index==1)
+    {
+      // 1D
+      if (H.ny == 1 && H.nz == 1) {
+        assert(false);
+      }
+      // 2D
+      if (H.ny > 1 && H.nz == 1) {
+        assert(false);
+      }
+      // 3D
+      if (H.nz > 1) {
+        int block = 256;
+        int grid = ((H.ny-2*H.n_ghost)*(H.nz-2*H.n_ghost) + block - 1) / block;
+        // forward = true
+        Load_Hydro_Buffer_X_Cuda_kernel<false, true><<<grid, block>>>(H, dev_recv_buffer_x1, dev_conserved);
+        CudaSafeCall(cudaStreamSynchronize(0));
+      }
+    }
+
+
+    //unload left y communication buffer
+    if(index==2)
+    {
+      // 2D
+      if (H.nz == 1) {
+        assert(false);
+      }
+      // 3D
+      if (H.nz > 1) {
+        int block = 256;
+        int grid = (H.nx*(H.nz-2*H.n_ghost) + block - 1) / block;
+        // forward = false
+        Load_Hydro_Buffer_Y_Cuda_kernel<false, false><<<grid, block>>>(H, dev_recv_buffer_y0, dev_conserved);
+        CudaSafeCall(cudaStreamSynchronize(0));
+      }
+    }
+
+    //unload right y communication buffer
+    if(index==3)
+    {
+      // 2D
+      if (H.nz == 1) {
+        assert(false);
+      }
+      // 3D
+      if (H.nz > 1) {
+        int block = 256;
+        int grid = (H.nx*(H.nz-2*H.n_ghost) + block - 1) / block;
+        // forward = true
+        Load_Hydro_Buffer_Y_Cuda_kernel<false, true><<<grid, block>>>(H, dev_recv_buffer_y1, dev_conserved);
+        CudaSafeCall(cudaStreamSynchronize(0));
+      }
+    }
+
+    //unload left z communication buffer
+    if(index==4)
+    {
+      int block = 256;
+      int grid = (H.nx*H.ny + block - 1) / block;
+      // forward = false
+      Load_Hydro_Buffer_Z_Cuda_kernel<false, false><<<grid, block>>>(H, dev_recv_buffer_z0, dev_conserved);
+      CudaSafeCall(cudaStreamSynchronize(0));
+    }
+
+    //unload right z communication buffer
+    if(index==5)
+    {
+      int block = 256;
+      int grid = (H.nx*H.ny + block - 1) / block;
+      // forward = false
+      Load_Hydro_Buffer_Z_Cuda_kernel<false, true><<<grid, block>>>(H, dev_recv_buffer_z1, dev_conserved);
+      CudaSafeCall(cudaStreamSynchronize(0));
+    }
+  }
+
+  #if( defined(GRAVITY)  )
+  if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
+    if ( index == 0 ) Unload_Gravity_Potential_from_Buffer( 0, 0, recv_buffer_x0, 0  );
+    if ( index == 1 ) Unload_Gravity_Potential_from_Buffer( 0, 1, recv_buffer_x1, 0  );
+    if ( index == 2 ) Unload_Gravity_Potential_from_Buffer( 1, 0, recv_buffer_y0, 0  );
+    if ( index == 3 ) Unload_Gravity_Potential_from_Buffer( 1, 1, recv_buffer_y1, 0  );
+    if ( index == 4 ) Unload_Gravity_Potential_from_Buffer( 2, 0, recv_buffer_z0, 0  );
+    if ( index == 5 ) Unload_Gravity_Potential_from_Buffer( 2, 1, recv_buffer_z1, 0  );
+  }
+  #endif
+
+  #ifdef PARTICLES
+  if (  Particles.TRANSFER_DENSITY_BOUNDARIES ){
+    if ( index == 0 ) Unload_Particles_Density_Boundary_From_Buffer( 0, 0, recv_buffer_x0 );
+    if ( index == 1 ) Unload_Particles_Density_Boundary_From_Buffer( 0, 1, recv_buffer_x1 );
+    if ( index == 2 ) Unload_Particles_Density_Boundary_From_Buffer( 1, 0, recv_buffer_y0 );
+    if ( index == 3 ) Unload_Particles_Density_Boundary_From_Buffer( 1, 1, recv_buffer_y1 );
+    if ( index == 4 ) Unload_Particles_Density_Boundary_From_Buffer( 2, 0, recv_buffer_z0 );
+    if ( index == 5 ) Unload_Particles_Density_Boundary_From_Buffer( 2, 1, recv_buffer_z1 );
+  }
+  #endif
+
+}
+
+#endif
+
+#endif /*MPI_CHOLLA*/

--- a/src/mpi_routines.h
+++ b/src/mpi_routines.h
@@ -62,6 +62,21 @@ extern Real *recv_buffer_y1;
 extern Real *recv_buffer_z0;
 extern Real *recv_buffer_z1;
 
+#ifdef DEVICE_COMM
+extern Real *dev_send_buffer_x0;
+extern Real *dev_send_buffer_x1;
+extern Real *dev_send_buffer_y0;
+extern Real *dev_send_buffer_y1;
+extern Real *dev_send_buffer_z0;
+extern Real *dev_send_buffer_z1;
+extern Real *dev_recv_buffer_x0;
+extern Real *dev_recv_buffer_x1;
+extern Real *dev_recv_buffer_y0;
+extern Real *dev_recv_buffer_y1;
+extern Real *dev_recv_buffer_z0;
+extern Real *dev_recv_buffer_z1;
+#endif
+
 #ifdef PARTICLES
 //Buffers for particles transfers
 extern Real *send_buffer_x0_particles;
@@ -130,6 +145,8 @@ extern int nproc_z;
 /*\fn void InitializeChollaMPI(void) */
 /* Routine to initialize MPI */
 void InitializeChollaMPI(int *pargc, char **pargv[]);
+
+void FinalizeChollaMPI();
 
 /* Perform domain decomposition */
 void DomainDecomposition(struct parameters *P, struct Header *H, int nx_global, int ny_global, int nz_global);

--- a/src/nvtx.h
+++ b/src/nvtx.h
@@ -1,0 +1,34 @@
+#ifndef __NVTX_H__
+#define __NVTX_H__
+
+#ifdef USE_NVTX
+#include "nvToolsExt.h"
+#endif
+
+const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
+const int num_colors = sizeof(colors)/sizeof(uint32_t);
+
+
+struct nvtx_raii {
+  nvtx_raii(const char name[], int color_id) {
+#ifdef USE_NVTX
+    color_id = color_id%num_colors;
+    nvtxEventAttributes_t eventAttrib = {0};
+    eventAttrib.version = NVTX_VERSION;
+    eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+    eventAttrib.colorType = NVTX_COLOR_ARGB;
+    eventAttrib.color = colors[color_id];
+    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+    eventAttrib.message.ascii = name;
+    nvtxRangePushEx(&eventAttrib);
+#endif
+  }
+
+  ~nvtx_raii() {
+#ifdef USE_NVTX
+    nvtxRangePop();
+#endif
+  }
+};
+
+#endif


### PR DESCRIPTION
This pull request adds the option (`DEVICE_COMM`) to perform inter-process halo exchange directly on the device. This option removes the need to: 
1. Copy data from device to host
2. Perform packing on the host
3. Run MPI send/receive routines to exchange data on the host
4. Perform unpacking on the host
5. Copy data from host to device

Instead, with this option, the routines are changed to:
1. Perform packing on the device
2. Run MPI send/receive routines to exchange data on the device, utilizing CUDA-aware-MPI
3. Perform unpacking on the device

For a workflow with the input shown [here](https://github.com/hummingtree/cholla/wiki):
- On a DGX-1V (with 8x NVIDIA V100 GPUs) the `DEVICE_COMM` version is **6x** faster, and
- On a DGX-A100-80GB (with 8x NVIDIA A100 GPUs) the `DEVICE_COMM` version is more than **5x** faster.

The speed up comes from the removal of the needs to copy data between the host and the device, as well as the fact that the packing and unpacking is much faster on the device.

Currently the option only works with the VL integrator (so CTU integrator does not work yet), and without the `PARTICLE` and `GRAVITY` option. However it would be straight forward to extend the changes to cover these cases. This option also requires that the device memory is large enough to hold all the data.

