### PR TITLE
Refactor HLLC test to use a test fixture and add doxygen comments to tests

### DIFF
--- a/src/riemann_solvers/hllc_cuda_tests.cu
+++ b/src/riemann_solvers/hllc_cuda_tests.cu
@@ -31,12 +31,6 @@
     class tHYDROCalculateHLLCFluxesCUDA : public ::testing::Test
     {
     protected:
-        // OOP
-        // 1. Get the state
-        // 2. Perform the calculations
-        // 3. Perform the check, should take some kind of stream for optional extra
-        //    output
-
         // =====================================================================
         /*!
          * \brief Compute and return the HLLC fluxes

--- a/src/riemann_solvers/hllc_cuda_tests.cu
+++ b/src/riemann_solvers/hllc_cuda_tests.cu
@@ -1,5 +1,5 @@
 /*!
-* \file hllc_cuda-tests.cpp
+* \file hllc_cuda_tests.cpp
 * \author Robert 'Bob' Caddy (rvc@pitt.edu)
 * \brief Test the code units within hllc_cuda.cu
 *
@@ -19,95 +19,118 @@
 #include "../utils/testing_utilities.h"
 #include "../riemann_solvers/hllc_cuda.h"   // Include code to test
 
+#if defined(CUDA) && defined(HLLC)
 
-// =============================================================================
-#if defined(CUDA) \
-    && defined(HLLC)
-// Testing Calculate_HLLC_Fluxes_CUDA
-TEST(tHYDROCalculateHLLCFluxesCUDA,  // Test suite name
-     HighPressureSideExpectCorrectOutput)  // Test name
-{
-    // Physical Values
-    Real const density   = 1.0;
-    Real const pressure  = 1.0;
-    Real const velocityX = 0.0;
-    Real const velocityY = 0.0;
-    Real const velocityZ = 0.0;
-    Real const momentumX = density * velocityX;
-    Real const momentumY = density * velocityY;
-    Real const momentumZ = density * velocityZ;
-    Real const gamma     = 1.4;
-    Real const energy    = (pressure/(gamma - 1)) + 0.5 * density * (velocityX*velocityX + velocityY*velocityY + velocityZ*velocityZ);
-
-    // Simulation Paramters
-    int const nx        = 1;  // Number of cells in the x-direction?
-    int const ny        = 1;  // Number of cells in the y-direction?
-    int const nz        = 1;  // Number of cells in the z-direction?
-    int const n_ghost   = 0;  // Isn't actually used it appears
-    int const direction = 0;  // Which direction, 0=x, 1=y, 2=z
-    int const n_fields  = 5;  // Total number of conserved fields
-
-    // Launch Parameters
-    dim3 const dimGrid (1,1,1);  // How many blocks in the grid
-    dim3 const dimBlock(1,1,1);  // How many threads per block
-
-    // Create arrays like the kernel expects
-    Real *conserved = new Real[n_fields] {density, momentumX, momentumY, momentumZ, energy};
-    Real *testFlux  = new Real[n_fields];
-    Real *dev_conserved;
-    Real *dev_testFlux;
-
-    // Fiducial values and field names
-    std::vector<Real> const fiducialFlux{0, 1, 0, 0, 0};
-    std::vector<std::string> const fieldNames {"Densities",
-                                               "X Momentum",
-                                               "Y Momentum",
-                                               "Z Momentum",
-                                               "Energies"};
-
-    CudaSafeCall( cudaMalloc(&dev_conserved, n_fields*sizeof(Real)) );
-    CudaSafeCall( cudaMalloc(&dev_testFlux,  n_fields*sizeof(Real)) );
-    CudaSafeCall( cudaMemcpy(dev_conserved, conserved, n_fields*sizeof(Real), cudaMemcpyHostToDevice) );
-    // Run kernel
-    hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA,
-                       dimGrid,
-                       dimBlock,
-                       0,
-                       0,
-                       dev_conserved,  // the "left" interface
-                       dev_conserved,  // the "right" interface
-                       dev_testFlux,
-                       nx,
-                       ny,
-                       nz,
-                       n_ghost,
-                       gamma,
-                       direction,
-                       n_fields);
-
-    CudaCheckError();
-    CudaSafeCall( cudaMemcpy(testFlux, dev_testFlux, n_fields*sizeof(Real), cudaMemcpyDeviceToHost) );
-    cudaDeviceSynchronize();  // Make sure to sync with the device so we have the results
-    CudaCheckError();
-
-    // Check for equality
-    for (size_t i = 0; i < n_fields; i++)
+    // =========================================================================
+    // Testing Calculate_HLLC_Fluxes_CUDA
+    /*!
+    * \brief Test the HLLC solver with the input from the high pressure side of a
+    sod shock tube. Correct results are hard coded into this test. Similar tests
+    do not need to be this verbose, simply passing values to the kernel call
+    should be sufficient in most cases
+    *
+    */
+    TEST(tHYDROCalculateHLLCFluxesCUDA,  // Test suite name
+         HighPressureSideExpectCorrectOutput)  // Test name
     {
-        // Check for equality and iff not equal return difference
-        double absoluteDiff;
-        int64_t ulpsDiff;
-        bool areEqual = testingUtilities::nearlyEqualDbl(fiducialFlux[i],
-                                                         testFlux[i],
-                                                         absoluteDiff,
-                                                         ulpsDiff);
-        EXPECT_TRUE(areEqual)
-            << std::endl
-            << "Difference in "                << fieldNames[i]   << std::endl
-            << "The fiducial value is:       " << fiducialFlux[i] << std::endl
-            << "The test value is:           " << testFlux[i]     << std::endl
-            << "The absolute difference is:  " << absoluteDiff    << std::endl
-            << "The ULP difference is:       " << ulpsDiff        << std::endl;
+        // Physical Values
+        Real const density   = 1.0;
+        Real const pressure  = 1.0;
+        Real const velocityX = 0.0;
+        Real const velocityY = 0.0;
+        Real const velocityZ = 0.0;
+        Real const momentumX = density * velocityX;
+        Real const momentumY = density * velocityY;
+        Real const momentumZ = density * velocityZ;
+        Real const gamma     = 1.4;
+        Real const energy    = (pressure/(gamma - 1)) + 0.5 * density
+                               * (velocityX*velocityX
+                                  + velocityY*velocityY
+                                  + velocityZ*velocityZ);
+
+        // Simulation Paramters
+        int const nx        = 1;  // Number of cells in the x-direction?
+        int const ny        = 1;  // Number of cells in the y-direction?
+        int const nz        = 1;  // Number of cells in the z-direction?
+        int const n_ghost   = 0;  // Isn't actually used it appears
+        int const direction = 0;  // Which direction, 0=x, 1=y, 2=z
+        int const n_fields  = 5;  // Total number of conserved fields
+
+        // Launch Parameters
+        dim3 const dimGrid (1,1,1);  // How many blocks in the grid
+        dim3 const dimBlock(1,1,1);  // How many threads per block
+
+        // Create arrays like the kernel expects
+        Real *conserved = new Real[n_fields] {density,
+                                              momentumX,
+                                              momentumY,
+                                              momentumZ,
+                                              energy};
+        Real *testFlux  = new Real[n_fields];
+        Real *dev_conserved;
+        Real *dev_testFlux;
+
+        // Fiducial values and field names
+        std::vector<Real> const fiducialFlux{0, 1, 0, 0, 0};
+        std::vector<std::string> const fieldNames {"Densities",
+        "X Momentum",
+        "Y Momentum",
+        "Z Momentum",
+        "Energies"};
+
+        CudaSafeCall(cudaMalloc(&dev_conserved, n_fields*sizeof(Real)));
+        CudaSafeCall(cudaMalloc(&dev_testFlux,  n_fields*sizeof(Real)));
+        CudaSafeCall(cudaMemcpy(dev_conserved,
+                                conserved,
+                                n_fields*sizeof(Real),
+                                cudaMemcpyHostToDevice));
+
+        // Run kernel
+        hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA,
+                           dimGrid,
+                           dimBlock,
+                           0,
+                           0,
+                           dev_conserved,  // the "left" interface
+                           dev_conserved,  // the "right" interface
+                           dev_testFlux,
+                           nx,
+                           ny,
+                           nz,
+                           n_ghost,
+                           gamma,
+                           direction,
+                           n_fields);
+
+        CudaCheckError();
+        CudaSafeCall(cudaMemcpy(testFlux,
+                                dev_testFlux,
+                                n_fields*sizeof(Real),
+                                cudaMemcpyDeviceToHost));
+        // Make sure to sync with the device so we have the results
+        cudaDeviceSynchronize();
+        CudaCheckError();
+
+        // Check for equality
+        for (size_t i = 0; i < n_fields; i++)
+        {
+            // Check for equality and iff not equal return difference
+            double absoluteDiff;
+            int64_t ulpsDiff;
+
+            bool areEqual = testingUtilities::nearlyEqualDbl(fiducialFlux[i],
+                                                             testFlux[i],
+                                                             absoluteDiff,
+                                                             ulpsDiff);
+            EXPECT_TRUE(areEqual)
+                << std::endl
+                << "Difference in "                << fieldNames[i]   << std::endl
+                << "The fiducial value is:       " << fiducialFlux[i] << std::endl
+                << "The test value is:           " << testFlux[i]     << std::endl
+                << "The absolute difference is:  " << absoluteDiff    << std::endl
+                << "The ULP difference is:       " << ulpsDiff        << std::endl;
+        }
     }
-}
+    // =========================================================================
+
 #endif
-// =============================================================================

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -15,6 +15,13 @@
 // =============================================================================
 // Test Suite: tHYDROSYSTEMSodShockTube
 // =============================================================================
+/*!
+ * \defgroup tHYDROSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput
+ * \brief Test the Sod Shock tube initial conditions as a parameterized test
+ * with varying numbers of MPI ranks
+ *
+ */
+/// @{
 class tHYDROSYSTEMSodShockTubeParameterizedMpi
       :public
       ::testing::TestWithParam<size_t>
@@ -33,4 +40,5 @@ TEST_P(tHYDROSYSTEMSodShockTubeParameterizedMpi,
 INSTANTIATE_TEST_SUITE_P(CorrectInputExpectCorrectOutput,
                          tHYDROSYSTEMSodShockTubeParameterizedMpi,
                          ::testing::Values(1, 2, 4));
+/// @}
 // =============================================================================

--- a/src/system_tests/particles_system_tests.cpp
+++ b/src/system_tests/particles_system_tests.cpp
@@ -5,7 +5,6 @@
  *
  */
 
-
 // External Libraries and Headers
 #include <gtest/gtest.h>
 
@@ -15,6 +14,13 @@
 // =============================================================================
 // Test Suite: tPARTICLESSYSTEMSphericalCollapse
 // =============================================================================
+/*!
+ * \defgroup tPARTICLESSYSTEMSphericalCollapseParameterizedMpi_CorrectInputExpectCorrectOutput
+ * \brief Test the spherical collapse with particles initial conditions as a
+ * parameterized test with varying numbers of MPI ranks
+ *
+ */
+/// @{
 class tPARTICLESSYSTEMSphericalCollapseParameterizedMpi
       :public
       ::testing::TestWithParam<size_t>
@@ -39,4 +45,5 @@ TEST_P(tPARTICLESSYSTEMSphericalCollapseParameterizedMpi,
 INSTANTIATE_TEST_SUITE_P(CorrectInputExpectCorrectOutput,
                          tPARTICLESSYSTEMSphericalCollapseParameterizedMpi,
                          ::testing::Values(1, 2, 4));
+/// @}
 // =============================================================================


### PR DESCRIPTION
The new test fixture enables the user to quickly write new tests for the
HLLC solver by moving almost all the boilerplate to the test fixture.
Now the user just needs to pass the `computeFluxes` method the left and
right states along with the adiabatic index. `computeFluxes` returns a
vector of the fluxes and then that vector can be passed to the
`checkResults` method, along with the fiducial values and (optionally)
a string for custom output, and that method will perform all the
assertions and I/O.

Added Doxygen comments to system tests and to the HLLC tests