### PR TITLE
Increase `MAXLEN` in global.h

### DIFF
--- a/src/global/global.h
+++ b/src/global/global.h
@@ -25,7 +25,7 @@ typedef double Real;
 #endif
 #endif
 
-#define MAXLEN 140
+#define MAXLEN 2048
 #define TINY_NUMBER 1.0e-20
 #define PI 3.141592653589793
 #define MP 1.672622e-24 // mass of proton, grams


### PR DESCRIPTION
`MAXLEN`'s previous value of 140 was leading to variables that were too small to hold path names. Increasing it to 2048 should  avoid this in most cases