### PR TITLE
Add support for Crusher in testing

### DIFF
--- a/builds/make.host.frontier
+++ b/builds/make.host.frontier
@@ -1,4 +1,4 @@
-#-- make.host for Frontier at the OLCF with 
+#-- make.host for Frontier at the OLCF with
 #-- Compiler and flags for different build type
 CC                = cc
 CXX               = CC
@@ -16,11 +16,12 @@ HIPCONFIG	  = $(shell hipconfig -C)
 
 OMP_NUM_THREADS   = 8
 #-- How to launch job
-JOB_LAUNCH        = srun -u -A STF016 -n 1 -c 8 
+JOB_LAUNCH        = srun -u -A STF016 -n 1 -c 8
 
 #-- Library
 MPI_ROOT          = ${CRAY_MPICH_DIR}
 FFTW_ROOT         = $(shell dirname $(FFTW_DIR))
+GOOGLETEST_ROOT := $(if $(GOOGLETEST_ROOT),$(GOOGLETEST_ROOT),$(OLCF_GOOGLETEST_ROOT))
 
 #-- Use GPU-aware MPI
 MPI_GPU           = -DMPI_GPU

--- a/builds/scripts/run_tests.sh
+++ b/builds/scripts/run_tests.sh
@@ -23,7 +23,6 @@ setupTests ()
   echo -e "\nRunning Setup..."
   unset CHOLLA_MAKE_TYPE
   unset CHOLLA_COMPILER
-  unset BUILD_GTEST
   unset MAKE_TYPE_ARG
   # Check arguments & default CHOLLA_MAKE_TYPE
   export CHOLLA_MAKE_TYPE='hydro'
@@ -80,6 +79,10 @@ setupTests ()
     *c3po*)
       export CHOLLA_MACHINE='c3po'
       export CHOLLA_LAUNCH_COMMAND='mpirun -np'
+      ;;
+    *frontier* | *crusher*)
+      export CHOLLA_MACHINE='frontier'
+      export CHOLLA_LAUNCH_COMMAND='srun -n'
       ;;
     *github*)
       export CHOLLA_MACHINE='github'
@@ -206,6 +209,10 @@ runTests ()
 # GoogleTest to use instead of the machine default
 buildAndRunTests ()
 {
+  # Unset BUILD_GTEST so that subsequent runs aren't tied to what previous runs
+  # did
+  unset BUILD_GTEST
+
   # Check arguments
   local OPTIND
   while getopts "t:c:g" opt; do

--- a/src/system_tests/system_tester.cpp
+++ b/src/system_tests/system_tester.cpp
@@ -190,10 +190,14 @@ void systemTest::SystemTestRunner::runTest()
                     // Check for equality and iff not equal return difference
                     double absoluteDiff;
                     int64_t ulpsDiff;
+                    // Fixed epsilon is changed from the default since AMD/Clang
+                    // appear to differ from NVIDIA/GCC/XL by roughly 1E-12
+                    double fixedEpsilon = 5.0E-12;
                     bool areEqual = testingUtilities::nearlyEqualDbl(fiducialData.at(index),
                                                                      testData.at(index),
                                                                      absoluteDiff,
-                                                                     ulpsDiff);
+                                                                     ulpsDiff,
+                                                                     fixedEpsilon);
                     ASSERT_TRUE(areEqual)
                         << std::endl
                         << "Difference in "


### PR DESCRIPTION
- Added the GoogleTest path variable in `make.host.frontier`
- Added Crusher/Frontier to the list of hosts in `run_tests.sh`
- Fixed a bug the prevented GoogleTest from being built by
  `buildAndRunTests` when the `-g` flag was passed to it
- Increased the absolute error allowed in systems tests. Previously it
  was 1E-14 since that was an order of magnitude larger than the
  differences between GCC and XL on NVIDIA hardware. AMD/Clang appear
  to differ from NVIDIA/GCC/XL by roughly 1E-12 or approximately one
  ten billionth of a percent