### PR TITLE
Extend the particles arrays and buffers for transfers as needed

### DIFF
--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -287,10 +287,33 @@ part_int_t Particles_3D::Compute_Particles_GPU_Array_Size( part_int_t n ){
 
 
 #ifdef MPI_CHOLLA
+
+void Particles_3D::ReAllocate_Memory_GPU_MPI(){
+  
+  // Free the previous arrays
+  Free_GPU_Array_bool(G.transfer_particles_flags_d);
+  Free_GPU_Array_int(G.transfer_particles_indices_d);
+  Free_GPU_Array_int(G.replace_particles_indices_d);
+  Free_GPU_Array_int(G.transfer_particles_prefix_sum_d);
+  Free_GPU_Array_int(G.transfer_particles_prefix_sum_blocks_d);
+  
+  //Allocate new resized arrays for the particles MPI transfers
+  part_int_t buffer_size, half_blocks_size;
+  buffer_size = particles_array_size;
+  half_blocks_size = ( (buffer_size-1)/2   ) / TPB_PARTICLES + 1;
+  Allocate_Particles_GPU_Array_bool( &G.transfer_particles_flags_d,      buffer_size );
+  Allocate_Particles_GPU_Array_int(  &G.transfer_particles_indices_d,    buffer_size );
+  Allocate_Particles_GPU_Array_int(  &G.replace_particles_indices_d,     buffer_size );
+  Allocate_Particles_GPU_Array_int(  &G.transfer_particles_prefix_sum_d, buffer_size );
+  Allocate_Particles_GPU_Array_int(  &G.transfer_particles_prefix_sum_blocks_d, half_blocks_size );
+  printf(" New allocation of arrays for particles transfers   new_size: %d \n", (int)buffer_size   );
+  
+}
+
 void Particles_3D::Allocate_Memory_GPU_MPI(){
 
-  //Allocate memory for the the particles MPI transfers
 
+  //Allocate memory for the the particles MPI transfers
   part_int_t buffer_size, half_blocks_size;
 
   buffer_size = Compute_Particles_GPU_Array_Size( n_local );

--- a/src/particles/particles_3D.h
+++ b/src/particles/particles_3D.h
@@ -231,7 +231,6 @@ class Particles_3D
   void Allocate_Particles_GPU_Array_bool( bool **array_dev, part_int_t size );
   void Allocate_Particles_GPU_Array_int( int **array_dev, part_int_t size );
   void Allocate_Particles_Grid_Field_Real( Real **array_dev, int size );
-  void Reallocate_and_Copy_Partciles_Array_Real( Real **src_array_dev, part_int_t size_initial, part_int_t size_end );
   void Copy_Particles_Array_Real_Host_to_Device( Real *array_host, Real *array_dev, part_int_t size);
   void Copy_Particles_Array_Real_Device_to_Host( Real *array_dev, Real *array_host, part_int_t size);
   void Set_Particles_Array_Real( Real value, Real *array_dev, part_int_t size);
@@ -310,6 +309,7 @@ class Particles_3D
 
   #ifdef PARTICLES_GPU
   void Allocate_Memory_GPU_MPI();
+  void ReAllocate_Memory_GPU_MPI();
   void Load_Particles_to_Buffer_GPU( int direction, int side, Real *send_buffer, int buffer_length  );
   #endif //PARTICLES_GPU
   #endif

--- a/src/particles/particles_3D_gpu.cu
+++ b/src/particles/particles_3D_gpu.cu
@@ -31,40 +31,6 @@ void Copy_Device_to_Device( Real *src_array_dev, Real *dst_array_dev, part_int_t
 
 }
 
-void Particles_3D::Reallocate_and_Copy_Partciles_Array_Real( Real **src_array_dev, part_int_t size_initial, part_int_t size_end  ){
-  size_t global_free, global_total;
-  CudaSafeCall( cudaMemGetInfo( &global_free, &global_total ) );
-  cudaDeviceSynchronize();
-  #ifdef PRINT_GPU_MEMORY
-  printf( "ReAllocating GPU Memory:  %ld  MB free \n", global_free/1000000);
-  #endif
-  if ( global_free < size_end*sizeof(Real) ){
-    printf( "ERROR: Not enough global device memory \n" );
-    printf( " Available Memory: %ld  MB \n", global_free/1000000  );
-    printf( " Requested Memory: %ld  MB \n", size_end*sizeof(Real)/1000000  );
-    exit(-1);
-  }
-  Real *temp_array_dev;
-  CudaSafeCall( cudaMalloc((void**)&temp_array_dev,  size_end*sizeof(Real)) );
-  cudaDeviceSynchronize();
-  // printf( " Allocated GPU Memory:  %ld  MB \n", size_end*sizeof(Real)/1000000 );
-  if ( size_initial*sizeof(Real) > size_end*sizeof(Real) ){
-    printf("ERROR: Memory to copy larger than array size\n" );
-    exit(-1);
-  }
-  // printf( " Copying:  %ld  ->  %ld  \n", size_initial*sizeof(Real), size_end*sizeof(Real) );
-  // CudaSafeCall( cudaMemcpy(temp_array_dev, *src_array_dev, size_initial*sizeof(Real), cudaMemcpyDeviceToDevice) );
-  // NOTE: cudaMemcpy is not working! made kernel to do the device to device copy
-  Copy_Device_to_Device( *src_array_dev, temp_array_dev,  size_initial );
-  cudaDeviceSynchronize();
-  CudaSafeCall( cudaFree( *src_array_dev ));
-  cudaDeviceSynchronize();
-  *src_array_dev = temp_array_dev;
-
-}
-
-
-
 
 void Particles_3D::Allocate_Particles_GPU_Array_Real( Real **array_dev, part_int_t size ){
   size_t global_free, global_total;

--- a/src/particles/particles_boundaries.cpp
+++ b/src/particles/particles_boundaries.cpp
@@ -11,6 +11,7 @@
 #include "../mpi/mpi_routines.h"
 #ifdef PARTICLES_GPU
 #include "../particles/particles_boundaries_gpu.h"
+#include "../utils/gpu_arrays_functions.h"
 #endif//PARTICLES_GPU
 #endif//MPI_CHOLLA
 
@@ -177,37 +178,115 @@ void Grid3D::Load_NTtransfer_and_Request_Receive_Particles_Transfer(int index, i
 
   if ( index == 0){
     buffer_length = Particles.n_recv_x0 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU 
+    if ( buffer_length > Particles.G.recv_buffer_size_x0 ){
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_x0_particles, Particles.G.recv_buffer_size_x0, Particles.G.gpu_allocation_factor*buffer_length, true );
+      Particles.G.recv_buffer_size_x0 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_x0_particles , &buffer_length_particles_x0_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_x0_particles , &buffer_length_particles_x0_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_x0 > 0 ) std::cout << " Recv X0: " << Particles.n_recv_x0 << std::endl;
     MPI_Irecv(recv_buffer_x0_particles, buffer_length, MPI_CHREAL, source[0], 0, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
   if ( index == 1){
     buffer_length = Particles.n_recv_x1 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU 
+    if ( buffer_length > Particles.G.recv_buffer_size_x1 ){
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_x1_particles, Particles.G.recv_buffer_size_x1, Particles.G.gpu_allocation_factor*buffer_length, true  );
+      Particles.G.recv_buffer_size_x1 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_x1_particles , &buffer_length_particles_x1_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_x1_particles , &buffer_length_particles_x1_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_x1 > 0 ) if ( Particles.n_recv_x1 > 0 ) std::cout << " Recv X1:  " << Particles.n_recv_x1 <<  "  " << procID <<  "  from "  <<  source[1] <<  std::endl;
     MPI_Irecv(recv_buffer_x1_particles, buffer_length, MPI_CHREAL, source[1], 1, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
   if ( index == 2){
     buffer_length = Particles.n_recv_y0 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU 
+    if ( buffer_length > Particles.G.recv_buffer_size_y0 ){
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_y0_particles, Particles.G.recv_buffer_size_y0, Particles.G.gpu_allocation_factor*buffer_length, true  );
+      Particles.G.recv_buffer_size_y0 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_y0_particles , &buffer_length_particles_y0_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_y0_particles , &buffer_length_particles_y0_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_y0 > 0 ) std::cout << " Recv Y0: " << Particles.n_recv_y0 << std::endl;
     MPI_Irecv(recv_buffer_y0_particles, buffer_length, MPI_CHREAL, source[2], 2, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
   if ( index == 3){
     buffer_length = Particles.n_recv_y1 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU
+    if ( buffer_length > Particles.G.recv_buffer_size_y1 ){ 
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_y1_particles, Particles.G.recv_buffer_size_y1, Particles.G.gpu_allocation_factor*buffer_length, true  );
+      Particles.G.recv_buffer_size_y1 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_y1_particles , &buffer_length_particles_y1_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_y1_particles , &buffer_length_particles_y1_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_y1 > 0 ) std::cout << " Recv Y1: " << Particles.n_recv_y1 << std::endl;
     MPI_Irecv(recv_buffer_y1_particles, buffer_length, MPI_CHREAL, source[3], 3, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
   if ( index == 4){
     buffer_length = Particles.n_recv_z0 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU 
+    if ( buffer_length > Particles.G.recv_buffer_size_z0 ){
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_z0_particles, Particles.G.recv_buffer_size_z0, Particles.G.gpu_allocation_factor*buffer_length, true  );
+      Particles.G.recv_buffer_size_z0 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_z0_particles , &buffer_length_particles_z0_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_z0_particles , &buffer_length_particles_z0_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_z0 > 0 ) std::cout << " Recv Z0: " << Particles.n_recv_z0 << std::endl;
     MPI_Irecv(recv_buffer_z0_particles, buffer_length, MPI_CHREAL, source[4], 4, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
   if ( index == 5){
     buffer_length = Particles.n_recv_z1 * N_DATA_PER_PARTICLE_TRANSFER;
+    #ifdef PARTICLES_GPU
+    #ifdef MPI_GPU 
+    if ( buffer_length > Particles.G.recv_buffer_size_z1 ){
+      printf( "Extending Particles Transfer Buffer  ");
+      Extend_GPU_Array_Real( &recv_buffer_z1_particles, Particles.G.recv_buffer_size_z1, Particles.G.gpu_allocation_factor*buffer_length, true  );
+      Particles.G.recv_buffer_size_z1 = (part_int_t) Particles.G.gpu_allocation_factor*buffer_length;
+    }
+    #else
     Check_and_Grow_Particles_Buffer( &recv_buffer_z1_particles , &buffer_length_particles_z1_recv, buffer_length );
+    #endif
+    #endif
+    #ifdef PARTICLES_CPU
+    Check_and_Grow_Particles_Buffer( &recv_buffer_z1_particles , &buffer_length_particles_z1_recv, buffer_length );
+    #endif
     // if ( Particles.n_recv_z1 >0 ) std::cout << " Recv Z1: " << Particles.n_recv_z1 << std::endl;
     MPI_Irecv(recv_buffer_z1_particles, buffer_length, MPI_CHREAL, source[5], 5, world, &recv_request_particles_transfer[*ireq_particles_transfer]);
   }
@@ -231,9 +310,9 @@ void Grid3D::Load_and_Send_Particles_X0( int ireq_n_particles, int ireq_particle
   MPI_Request_free(send_request_n_particles);
   // if ( Particles.n_send_x0 > 0 )   if ( Particles.n_send_x0 > 0 ) std::cout << " Sent X0:  " << Particles.n_send_x0 <<  "  " << procID <<  "  to  "  <<  dest[0] <<  std::endl;
   buffer_length = Particles.n_send_x0 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_x0_particles , &buffer_length_particles_x0_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_x0_particles = h_send_buffer_x0_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_x0_particles , &buffer_length_particles_x0_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 0, 0, send_buffer_x0_particles,  buffer_length_particles_x0_send );
   #endif //PARTICLES_CPU
 
@@ -261,9 +340,9 @@ void Grid3D::Load_and_Send_Particles_X1( int ireq_n_particles, int ireq_particle
   MPI_Request_free(send_request_n_particles+1);
   // if ( Particles.n_send_x1 > 0 )  std::cout << " Sent X1: " << Particles.n_send_x1 << std::endl;
   buffer_length = Particles.n_send_x1 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_x1_particles , &buffer_length_particles_x1_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_x1_particles = h_send_buffer_x1_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_x1_particles , &buffer_length_particles_x1_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 0, 1, send_buffer_x1_particles,  buffer_length_particles_x1_send  );
   #endif //PARTICLES_CPU
 
@@ -291,9 +370,9 @@ void Grid3D::Load_and_Send_Particles_Y0( int ireq_n_particles, int ireq_particle
   MPI_Irecv(&Particles.n_recv_y0, 1, MPI_PART_INT, source[2], 2, world, &recv_request_n_particles[ireq_n_particles]);
   // if ( Particles.n_send_y0 > 0 )   std::cout << " Sent Y0: " << Particles.n_send_y0 << std::endl;
   buffer_length = Particles.n_send_y0 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_y0_particles , &buffer_length_particles_y0_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_y0_particles = h_send_buffer_y0_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_y0_particles , &buffer_length_particles_y0_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 1, 0, send_buffer_y0_particles,  buffer_length_particles_y0_send  );
   #endif //PARTICLES_CPU
 
@@ -321,9 +400,9 @@ void Grid3D::Load_and_Send_Particles_Y1( int ireq_n_particles, int ireq_particle
   MPI_Irecv(&Particles.n_recv_y1, 1, MPI_PART_INT, source[3], 3, world, &recv_request_n_particles[ireq_n_particles]);
   // if ( Particles.n_send_y1 > 0 )  std::cout << " Sent Y1: " << Particles.n_send_y1 << std::endl;
   buffer_length = Particles.n_send_y1 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_y1_particles , &buffer_length_particles_y1_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_y1_particles = h_send_buffer_y1_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_y1_particles , &buffer_length_particles_y1_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 1, 1, send_buffer_y1_particles,  buffer_length_particles_y1_send  );
   #endif //PARTICLES_CPU
 
@@ -351,9 +430,9 @@ void Grid3D::Load_and_Send_Particles_Z0( int ireq_n_particles, int ireq_particle
   MPI_Irecv(&Particles.n_recv_z0, 1, MPI_PART_INT, source[4], 4, world, &recv_request_n_particles[ireq_n_particles]);
   // if ( Particles.n_send_z0 > 0 )   std::cout << " Sent Z0: " << Particles.n_send_z0 << std::endl;
   buffer_length = Particles.n_send_z0 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_z0_particles , &buffer_length_particles_z0_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_z0_particles = h_send_buffer_z0_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_z0_particles , &buffer_length_particles_z0_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 2, 0, send_buffer_z0_particles,  buffer_length_particles_z0_send  );
   #endif //PARTICLES_CPU
 
@@ -381,9 +460,9 @@ void Grid3D::Load_and_Send_Particles_Z1( int ireq_n_particles, int ireq_particle
   MPI_Irecv(&Particles.n_recv_z1, 1, MPI_CHREAL, source[5], 5, world, &recv_request_n_particles[ireq_n_particles]);
   // if ( Particles.n_send_z1 > 0 )   std::cout << " Sent Z1: " << Particles.n_send_z1 << std::endl;
   buffer_length = Particles.n_send_z1 * N_DATA_PER_PARTICLE_TRANSFER;
-  Check_and_Grow_Particles_Buffer( &send_buffer_z1_particles , &buffer_length_particles_z1_send, buffer_length );
   #ifdef PARTICLES_CPU
   send_buffer_z1_particles = h_send_buffer_z1_particles;
+  Check_and_Grow_Particles_Buffer( &send_buffer_z1_particles , &buffer_length_particles_z1_send, buffer_length );
   Particles.Load_Particles_to_Buffer_CPU( 2, 1, send_buffer_z1_particles,  buffer_length_particles_z1_send  );
   #endif //PARTICLES_CPU
 
@@ -590,7 +669,8 @@ int Particles_3D::Select_Particles_to_Transfer_GPU( int direction, int side ){
 void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int direction, int side, Real *send_buffer_h, int buffer_length  ){
 
   part_int_t *n_send;
-  int n_fields_to_transfer, buffer_size;
+  int *buffer_size;
+  int n_fields_to_transfer;
   Real *pos, *send_buffer_d;
   Real domainMin, domainMax;
   int bt_pos_x, bt_pos_y, bt_pos_z, bt_non_pos;
@@ -606,13 +686,13 @@ void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int dir
     domainMax = G.domainMax_x;
     if ( side == 0 ){
       n_send = &n_send_x0;
-      buffer_size = G.send_buffer_size_x0;
+      buffer_size = &G.send_buffer_size_x0;
       send_buffer_d = G.send_buffer_x0_d;
       bt_pos_x = G.boundary_type_x0;
     }
     if ( side == 1 ){
       n_send = &n_send_x1;
-      buffer_size = G.send_buffer_size_x1;
+      buffer_size = &G.send_buffer_size_x1;
       send_buffer_d = G.send_buffer_x1_d;
       bt_pos_x = G.boundary_type_x1;
     }
@@ -623,13 +703,13 @@ void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int dir
     domainMax = G.domainMax_y;
     if ( side == 0 ){
       n_send = &n_send_y0;
-      buffer_size = G.send_buffer_size_y0;
+      buffer_size = &G.send_buffer_size_y0;
       send_buffer_d = G.send_buffer_y0_d;
       bt_pos_y = G.boundary_type_y0;
     }
     if ( side == 1 ){
       n_send = &n_send_y1;
-      buffer_size = G.send_buffer_size_y1;
+      buffer_size = &G.send_buffer_size_y1;
       send_buffer_d = G.send_buffer_y1_d;
       bt_pos_y = G.boundary_type_y1;
     }
@@ -640,13 +720,13 @@ void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int dir
     domainMax = G.domainMax_z;
     if ( side == 0 ){
       n_send = &n_send_z0;
-      buffer_size = G.send_buffer_size_z0;
+      buffer_size = &G.send_buffer_size_z0;
       send_buffer_d = G.send_buffer_z0_d;
       bt_pos_z = G.boundary_type_z0;
     }
     if ( side == 1 ){
       n_send = &n_send_z1;
-      buffer_size = G.send_buffer_size_z1;
+      buffer_size = &G.send_buffer_size_z1;
       send_buffer_d = G.send_buffer_z1_d;
       bt_pos_z = G.boundary_type_z1;
     }
@@ -654,10 +734,11 @@ void Particles_3D::Copy_Transfer_Particles_to_Buffer_GPU(int n_transfer, int dir
 
 
 
-
-  if ( (*n_send + n_transfer)*N_DATA_PER_PARTICLE_TRANSFER > buffer_size  ){
-      printf("ERROR:Transfer Buffer is not large enough\n" );
-      exit(-1);
+  // If the number of particles in the array exceeds the size of the array, extend the array
+  if ( (*n_send + n_transfer)*N_DATA_PER_PARTICLE_TRANSFER > *buffer_size  ){
+    printf( "Extending Particles Transfer Buffer  ");
+    Extend_GPU_Array_Real( &send_buffer_d, *buffer_size,  G.gpu_allocation_factor*(*n_send + n_transfer)*N_DATA_PER_PARTICLE_TRANSFER, true  );
+    *buffer_size = (part_int_t) G.gpu_allocation_factor*(*n_send + n_transfer)*N_DATA_PER_PARTICLE_TRANSFER;
   }
 
   // Load the particles that will be transferred into the buffers
@@ -714,14 +795,19 @@ void Particles_3D::Copy_Transfer_Particles_from_Buffer_GPU(int n_recv, Real *rec
 
   part_int_t n_local_after = n_local + n_recv;
   if ( n_local_after > particles_array_size ){
-    particles_array_size = Compute_Particles_GPU_Array_Size( n_local_after );
-    printf("Reallocating GPU particles arrays \n" );
-    Reallocate_and_Copy_Partciles_Array_Real( &pos_x_dev, n_local, particles_array_size  );
-    Reallocate_and_Copy_Partciles_Array_Real( &pos_y_dev, n_local, particles_array_size  );
-    Reallocate_and_Copy_Partciles_Array_Real( &pos_z_dev, n_local, particles_array_size  );
-    Reallocate_and_Copy_Partciles_Array_Real( &vel_x_dev, n_local, particles_array_size  );
-    Reallocate_and_Copy_Partciles_Array_Real( &vel_y_dev, n_local, particles_array_size  );
-    Reallocate_and_Copy_Partciles_Array_Real( &vel_z_dev, n_local, particles_array_size  );
+    printf(" Reallocating GPU particles arrays \n" );
+    int new_size = G.gpu_allocation_factor * n_local_after;
+    Extend_GPU_Array_Real( &pos_x_dev,  (int) particles_array_size, new_size, true  );
+    Extend_GPU_Array_Real( &pos_y_dev,  (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &pos_z_dev,  (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &vel_x_dev,  (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &vel_y_dev,  (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &vel_z_dev,  (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &grav_x_dev, (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &grav_y_dev, (int) particles_array_size, new_size, false );
+    Extend_GPU_Array_Real( &grav_z_dev, (int) particles_array_size, new_size, false );
+    particles_array_size = (part_int_t) new_size;
+    ReAllocate_Memory_GPU_MPI();
   }
 
   // Unload the particles that were transferred from the buffers

--- a/src/utils/gpu_arrays_functions.cu
+++ b/src/utils/gpu_arrays_functions.cu
@@ -1,0 +1,66 @@
+#include "../utils/error_handling.h"
+#include "../utils/gpu.hpp"
+#include "../global/global_cuda.h"
+#include "../utils/gpu_arrays_functions.h"
+#include <iostream>
+
+
+void Extend_GPU_Array_Real( Real **current_array_d, int current_size, int new_size, bool print_out ){
+  
+  if ( new_size <= current_size ) return;
+  if ( print_out ) std::cout << " Extending GPU Array, size: " << current_size << "  new_size: " << new_size << std::endl;
+  
+  size_t global_free, global_total;
+  CudaSafeCall( cudaMemGetInfo( &global_free, &global_total ) );
+  cudaDeviceSynchronize();
+  #ifdef PRINT_GPU_MEMORY
+  printf( "ReAllocating GPU Memory:  %ld  MB free \n", global_free/1000000);
+  #endif
+  
+  if ( global_free < new_size*sizeof(Real) ){
+    printf( "ERROR: Not enough global device memory \n" );
+    printf( " Available Memory: %ld  MB \n", global_free/1000000  );
+    printf( " Requested Memory: %ld  MB \n", new_size*sizeof(Real)/1000000  );
+    exit(-1);
+  }
+  
+  Real *new_array_d;
+  CudaSafeCall( cudaMalloc((void**)&new_array_d,  new_size*sizeof(Real)) );
+  cudaDeviceSynchronize();
+  CudaCheckError();
+  if ( new_array_d == NULL ){
+    std::cout << " Error When Allocating New GPU Array" << std::endl;
+    chexit(-1);
+  }
+  
+  // Copy the content of the original array to the new array
+  CudaSafeCall( cudaMemcpy( new_array_d, *current_array_d, current_size*sizeof(Real), cudaMemcpyDeviceToDevice ) );	
+  cudaDeviceSynchronize();
+  CudaCheckError();
+  
+  // Free the original array
+  cudaFree(*current_array_d);
+  cudaDeviceSynchronize();
+  CudaCheckError();
+  
+  // Replace the pointer of the original array with the new one
+  *current_array_d = new_array_d;
+  
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/utils/gpu_arrays_functions.h
+++ b/src/utils/gpu_arrays_functions.h
@@ -1,0 +1,10 @@
+#ifndef GPU_ARRAY_FUNCTIONS_H
+#define GPU_ARRAY_FUNCTIONS_H
+
+#include "../global/global.h"
+
+void Extend_GPU_Array_Real( Real **current_array_d, int current_size, int new_size, bool print_out );
+
+
+
+#endif


### PR DESCRIPTION
This pull request addresses issues encountered when the number of particles in a given GPU exceeds the size of the arrays and transfer buffers initially allocated.
 
When transferring the particles via MPI, before loading the particles into the send buffers the size of the buffer is compared to the number of particles to load, if the buffer is not large enough then the buffer is reallocated having a larger size. The same check is made for the recv buffers before the MPI transfer is performed.

Before unloading the particles from the recv buffers into the arrays that contain the particle data, the new number of local particles (including the one received from the MPI transfer) is compared to the size of the particle data arrays, if the arrays are not large enough then new larger arrays for the positions, velocities and accelerations are allocated, the content of the previous arrays is copied to the new ones and then the previous arrays are freed.   

After fixing this issue, large cosmological simulations (1024^3 cells and particles using 128 GPUs) evolved with the new GPU-Only version of the code reproduce the results from the original code and I measure ~10x better performance.  

   