### PR TITLE
Hydro without MPI

### DIFF
--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -136,7 +136,9 @@ void WriteData(Grid3D &G, struct parameters P, int nfile)
   G.H.Output_Now = false;
   #endif
 
+  #ifdef MPI_CHOLLA
   MPI_Barrier(world);
+  #endif
 }
 
 

--- a/src/mpi/cuda_mpi_routines.cu
+++ b/src/mpi/cuda_mpi_routines.cu
@@ -1,3 +1,4 @@
+#ifdef MPI_CHOLLA
 #include <stdio.h>
 #include "../utils/gpu.hpp"
 #include "../io/io.h"
@@ -48,3 +49,4 @@ int initialize_cuda_mpi(int myid, int nprocs)
   return 0;
 
 }
+#endif //MPI_CHOLLA

--- a/src/old_cholla/subgrid_routines_3D.cu
+++ b/src/old_cholla/subgrid_routines_3D.cu
@@ -10,7 +10,7 @@
 #include "../global/global.h"
 #include "../mpi/mpi_routines.h"
 #include "../old_cholla/subgrid_routines_3D.h"
-
+#include "../utils/gpu.hpp"
 
 
 


### PR DESCRIPTION
This PR confirms that I was wrong in the CAAR meeting -- currently the CAAR branch will not compile without MPI. 

I added two protections (and a soon-to-be-deprecated include to subgrid routines), and now (CAAR branch + hydro only) will work without MPI (MPI_CHOLLA off, MPI_GPU off, and compiler set to g++ instead of mpicc(x)). 

One outstanding but scientifically unimportant issue is that the "domain" attribute of HDF5 output differs for irrelevant dimensions (Y,Z for 1D, Z for 2D, no difference for 3D) between MPI and non-MPI. This is based on how the variables H.ydglobal and H.zdglobal are set. 