### PR TITLE
Fixed duplicate CudaFree of grav_potential device array

### DIFF
--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -299,10 +299,7 @@ void Free_Memory_VL_3D(){
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif
-  #if defined( GRAVITY )
-  cudaFree(dev_grav_potential);
-  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer_potential) );
-  #endif
+
 
 }
 


### PR DESCRIPTION
The VL integrator FreeMemory call was freeing the grav_ppotenttial device array which is also freed by the Reset function causing a CUDA error at the end of the simulation.

Deleted redundant CudaFree from the VL integrator