### PR TITLE
Fixed GRAVITY_GPU periodic boundaries when n_mpi=1, 2, 4

### DIFF
--- a/src/gravity/gravity_boundaries.cpp
+++ b/src/gravity/gravity_boundaries.cpp
@@ -205,10 +205,9 @@ void Grid3D::Compute_Potential_Isolated_Boundary( int direction, int side,  int 
 
 #endif //GRAV_ISOLATED_BOUNDARY_X
 
-void Grid3D::Copy_Potential_Boundaries( int direction, int side, int *flags ){
+void Grid3D::Set_Potential_Boundaries_Periodic( int direction, int side, int *flags ){
   // Flags: 1 (periodic), 2 (reflective), 3 (transmissive), 4 (custom), 5 (mpi)
 
-  int boundary_flag;
   int i, j, k, indx_src, indx_dst;
   int nGHST, nx_g, ny_g, nz_g;
   nGHST = N_GHOST_POTENTIAL;
@@ -222,15 +221,11 @@ void Grid3D::Copy_Potential_Boundaries( int direction, int side, int *flags ){
       for ( j=0; j<ny_g; j++ ){
         for ( i=0; i<nGHST; i++ ){
           if ( side == 0 ){
-            boundary_flag = flags[0];
-            if ( boundary_flag == 1 ) indx_src = (nx_g - 2*nGHST + i) + (j)*nx_g + (k)*nx_g*ny_g; //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (2*nGHST-i) + (j)*nx_g + (k)*nx_g*ny_g; // Zero Gradient
+            indx_src = (nx_g - 2*nGHST + i) + (j)*nx_g + (k)*nx_g*ny_g; //Periodic
             indx_dst = (i) + (j)*nx_g + (k)*nx_g*ny_g;
           }
           if ( side == 1 ){
-            boundary_flag = flags[1];
-            if ( boundary_flag == 1 ) indx_src = (i+nGHST) + (j)*nx_g + (k)*nx_g*ny_g;   //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (nx_g - nGHST - 2 -i ) + (j)*nx_g + (k)*nx_g*ny_g; //Zero Gradient
+            indx_src = (i+nGHST) + (j)*nx_g + (k)*nx_g*ny_g;   //Periodic
             indx_dst = (nx_g - nGHST + i) + (j)*nx_g + (k)*nx_g*ny_g;
           }
           Grav.F.potential_h[indx_dst] = Grav.F.potential_h[indx_src] ;
@@ -245,15 +240,11 @@ void Grid3D::Copy_Potential_Boundaries( int direction, int side, int *flags ){
       for ( j=0; j<nGHST; j++ ){
         for ( i=0; i<nx_g; i++ ){
           if ( side == 0 ){
-            boundary_flag = flags[2];
-            if ( boundary_flag == 1 ) indx_src = (i) + (ny_g - 2*nGHST + j)*nx_g + (k)*nx_g*ny_g; //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (i) + (2*nGHST - j)*nx_g + (k)*nx_g*ny_g;  //Zero Gradient
+            indx_src = (i) + (ny_g - 2*nGHST + j)*nx_g + (k)*nx_g*ny_g; //Periodic
             indx_dst = (i) + (j)*nx_g + (k)*nx_g*ny_g;
           }
           if ( side == 1 ){
-            boundary_flag = flags[3];
-            if ( boundary_flag == 1 ) indx_src = (i) + (j+nGHST)*nx_g + (k)*nx_g*ny_g; //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (i) + (ny_g - nGHST - 2 - j)*nx_g + (k)*nx_g*ny_g; //Zero Gradient
+            indx_src = (i) + (j+nGHST)*nx_g + (k)*nx_g*ny_g; //Periodic
             indx_dst = (i) + (ny_g - nGHST + j)*nx_g + (k)*nx_g*ny_g;
           }
           Grav.F.potential_h[indx_dst] = Grav.F.potential_h[indx_src] ;
@@ -268,15 +259,11 @@ void Grid3D::Copy_Potential_Boundaries( int direction, int side, int *flags ){
       for ( j=0; j<ny_g; j++ ){
         for ( i=0; i<nx_g; i++ ){
           if ( side == 0 ){
-            boundary_flag = flags[4];
-            if ( boundary_flag == 1 ) indx_src = (i) + (j)*nx_g + (nz_g - 2*nGHST + k)*nx_g*ny_g;  //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (i) + (j)*nx_g + (2*nGHST - k)*nx_g*ny_g; //Zero Gradient
+            indx_src = (i) + (j)*nx_g + (nz_g - 2*nGHST + k)*nx_g*ny_g;  //Periodic
             indx_dst = (i) + (j)*nx_g + (k)*nx_g*ny_g;
           }
           if ( side == 1 ){
-            boundary_flag = flags[5];
-            if ( boundary_flag == 1 ) indx_src = (i) + (j)*nx_g + (k+nGHST)*nx_g*ny_g; //Periodic
-            // if ( boundary_flag == 3 ) indx_src = (i) + (j)*nx_g + (nz_g - nGHST - 2 - k)*nx_g*ny_g; //Zero Gradient
+            indx_src = (i) + (j)*nx_g + (k+nGHST)*nx_g*ny_g; //Periodic
             indx_dst = (i) + (j)*nx_g + (nz_g - nGHST + k)*nx_g*ny_g;
           }
         Grav.F.potential_h[indx_dst] = Grav.F.potential_h[indx_src] ;

--- a/src/gravity/gravity_boundaries_gpu.cu
+++ b/src/gravity/gravity_boundaries_gpu.cu
@@ -103,6 +103,80 @@ void Grid3D::Set_Potential_Boundaries_Isolated_GPU( int direction, int side, int
 
 #endif //GRAV_ISOLATED_BOUNDARY
 
+
+void __global__ Set_Potential_Boundaries_Periodic_kernel(int direction, int side, int n_i, int n_j, int nx, int ny, int nz, int n_ghost, Real *potential_d ){
+  
+  // get a global thread ID
+  int tid, tid_i, tid_j, tid_k, tid_src, tid_dst;
+  tid = threadIdx.x + blockIdx.x * blockDim.x;
+  tid_k = tid / (n_i*n_j);
+  tid_j = (tid - tid_k*n_i*n_j) / n_i;
+  tid_i = tid - tid_k*n_i*n_j - tid_j*n_i;
+  
+  if ( tid_i < 0 || tid_i >= n_i || tid_j < 0 || tid_j >= n_j || tid_k < 0 || tid_k >= n_ghost ) return;
+  
+  if ( direction == 0 ){
+    if ( side == 0 ) tid_src = ( nx - 2*n_ghost + tid_k )  + (tid_i)*nx  + (tid_j)*nx*ny;
+    if ( side == 0 ) tid_dst = ( tid_k )                   + (tid_i)*nx  + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_src = ( n_ghost + tid_k  )        + (tid_i)*nx  + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_dst = ( nx - n_ghost + tid_k )    + (tid_i)*nx  + (tid_j)*nx*ny;
+
+  }
+  if ( direction == 1 ){
+    if ( side == 0 ) tid_src = (tid_i) + ( ny - 2*n_ghost + tid_k  )*nx  + (tid_j)*nx*ny;
+    if ( side == 0 ) tid_dst = (tid_i) + ( tid_k )*nx                    + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_src = (tid_i) + ( n_ghost + tid_k  )*nx         + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_dst = (tid_i) + ( ny - n_ghost + tid_k )*nx     + (tid_j)*nx*ny;
+  }
+  if ( direction == 2 ){
+    if ( side == 0 ) tid_src = (tid_i) + (tid_j)*nx + ( nz - 2*n_ghost + tid_k  )*nx*ny;
+    if ( side == 0 ) tid_dst = (tid_i) + (tid_j)*nx + ( tid_k  )*nx*ny;
+    if ( side == 1 ) tid_src = (tid_i) + (tid_j)*nx + ( n_ghost + tid_k  )*nx*ny;
+    if ( side == 1 ) tid_dst = (tid_i) + (tid_j)*nx + ( nz - n_ghost + tid_k  )*nx*ny;
+  }
+  
+  potential_d[tid_dst] = potential_d[tid_src];
+  
+}
+
+
+void Grid3D::Set_Potential_Boundaries_Periodic_GPU( int direction, int side, int *flags ){
+  
+  int n_i, n_j, n_ghost, size;
+  int nx_g, ny_g, nz_g;
+  n_ghost = N_GHOST_POTENTIAL;
+  nx_g = Grav.nx_local + 2*n_ghost;
+  ny_g = Grav.ny_local + 2*n_ghost;
+  nz_g = Grav.nz_local + 2*n_ghost;
+
+  if ( direction == 0 ){
+    n_i = ny_g;
+    n_j = nz_g;
+  }
+  if ( direction == 1 ){
+    n_i = nx_g;
+    n_j = nz_g;
+  }
+  if ( direction == 2 ){
+    n_i = nx_g;
+    n_j = ny_g;
+  }
+
+  size = N_GHOST_POTENTIAL * n_i * n_j;
+
+  // set values for GPU kernels
+  int ngrid = ( size - 1 ) / TPB_GRAV + 1;
+  // number of blocks per 1D grid
+  dim3 dim1dGrid(ngrid, 1, 1);
+  //  number of threads per 1D block
+  dim3 dim1dBlock(TPB_GRAV, 1, 1);
+
+  // Copy the potential boundary from buffer to potential array
+  hipLaunchKernelGGL( Set_Potential_Boundaries_Periodic_kernel, dim1dGrid, dim1dBlock, 0, 0, direction, side, n_i, n_j, nx_g, ny_g, nz_g, n_ghost, Grav.F.potential_d );
+
+
+}
+
 __global__ void Load_Transfer_Buffer_GPU_kernel( int direction, int side, int size_buffer, int n_i, int n_j, int nx, int ny, int nz, int n_ghost_transfer, int n_ghost_potential, Real *potential_d, Real *transfer_buffer_d   ){
 
   // get a global thread ID
@@ -173,58 +247,6 @@ int Grid3D::Load_Gravity_Potential_To_Buffer_GPU( int direction, int side, Real 
   hipLaunchKernelGGL( Load_Transfer_Buffer_GPU_kernel, dim1dGrid, dim1dBlock, 0, 0, direction, side, size_buffer, n_i, n_j,  nx_pot, ny_pot, nz_pot, n_ghost_transfer, n_ghost_potential, potential_d, send_buffer_d  );
   CHECK(cudaDeviceSynchronize());
 
-  // NOTE: I couldn't figure out how top do it using OpenMP
-  // int i, j, k, indx, indx_buff;
-  // if ( direction == 0 ){
-  //   #pragma omp target teams distribute parallel for collapse ( 2 ) \
-  //           private ( indx, indx_buff ) \
-  //           firstprivate ( side ) \
-  //           is_device_ptr ( send_buffer_d, potential_d )
-  //   for ( k=0; k<nz_g; k++ ){
-  //     for ( j=0; j<ny_g; j++ ){
-  //       for ( i=0; i<nGHST; i++ ){
-  //         if ( side == 0 ) indx = (i+nGHST) + (j)*nx_g + (k)*nx_g*ny_g;
-  //         if ( side == 1 ) indx = (nx_g - 2*nGHST + i) + (j)*nx_g + (k)*nx_g*ny_g;
-  //         indx_buff = (j) + (k)*ny_g + i*ny_g*nz_g ;
-  //         send_buffer_d[indx_buff] = potential_d[indx];
-  //       }
-  //     }
-  //   }
-  // }
-  //
-  //
-  // if ( direction == 1 ){
-  //   #pragma omp target teams distribute parallel for collapse ( 3 ) \
-  //           private ( indx, indx_buff ) \
-  //           firstprivate ( side ) \
-  //           is_device_ptr ( send_buffer_d, potential_d )
-  //   for ( k=0; k<nz_g; k++ ){
-  //     for ( j=0; j<nGHST; j++ ){
-  //       for ( i=0; i<nx_g; i++ ){
-  //         if ( side == 0 ) indx = (i) + (j+nGHST)*nx_g + (k)*nx_g*ny_g;
-  //         if ( side == 1 ) indx = (i) + (ny_g - 2*nGHST + j)*nx_g + (k)*nx_g*ny_g;
-  //         indx_buff = (i) + (k)*nx_g + j*nx_g*nz_g ;
-  //         send_buffer_d[indx_buff] = potential_d[indx];
-  //       }
-  //     }
-  //   }
-  // }
-  //
-  // if ( direction == 1 ){
-  //   for ( k=0; k<nGHST; k++ ){
-  //     for ( j=0; j<ny_g; j++ ){
-  //       for ( i=0; i<nx_g; i++ ){
-  //         if ( side == 0 ) indx = (i) + (j)*nx_g + (k+nGHST)*nx_g*ny_g;
-  //         if ( side == 1 ) indx = (i) + (j)*nx_g + (nz_g - 2*nGHST + k)*nx_g*ny_g;
-  //         indx_buff = (i) + (j)*nx_g + k*nx_g*ny_g ;
-  //         send_buffer_d[indx_buff] = potential_d[indx];
-  //       }
-  //     }
-  //   }
-  // }
-  //
-
-  // printf( "Loaded Gravity Buffer \n" );
   return size_buffer;
 }
 

--- a/src/grid/boundary_conditions.cpp
+++ b/src/grid/boundary_conditions.cpp
@@ -198,12 +198,21 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
   if ( Grav.TRANSFER_POTENTIAL_BOUNDARIES ){
     if ( flags[dir] == 1 ){
       // Set Periodic Boundaries for the ghost cells.
-      if ( dir == 0 ) Copy_Potential_Boundaries( 0, 0, flags );
-      if ( dir == 1 ) Copy_Potential_Boundaries( 0, 1, flags );
-      if ( dir == 2 ) Copy_Potential_Boundaries( 1, 0, flags );
-      if ( dir == 3 ) Copy_Potential_Boundaries( 1, 1, flags );
-      if ( dir == 4 ) Copy_Potential_Boundaries( 2, 0, flags );
-      if ( dir == 5 ) Copy_Potential_Boundaries( 2, 1, flags );
+      #ifdef GRAVITY_GPU
+      if ( dir == 0 ) Set_Potential_Boundaries_Periodic_GPU( 0, 0, flags );
+      if ( dir == 1 ) Set_Potential_Boundaries_Periodic_GPU( 0, 1, flags );
+      if ( dir == 2 ) Set_Potential_Boundaries_Periodic_GPU( 1, 0, flags );
+      if ( dir == 3 ) Set_Potential_Boundaries_Periodic_GPU( 1, 1, flags );
+      if ( dir == 4 ) Set_Potential_Boundaries_Periodic_GPU( 2, 0, flags );
+      if ( dir == 5 ) Set_Potential_Boundaries_Periodic_GPU( 2, 1, flags );
+      #else
+      if ( dir == 0 ) Set_Potential_Boundaries_Periodic( 0, 0, flags );
+      if ( dir == 1 ) Set_Potential_Boundaries_Periodic( 0, 1, flags );
+      if ( dir == 2 ) Set_Potential_Boundaries_Periodic( 1, 0, flags );
+      if ( dir == 3 ) Set_Potential_Boundaries_Periodic( 1, 1, flags );
+      if ( dir == 4 ) Set_Potential_Boundaries_Periodic( 2, 0, flags );
+      if ( dir == 5 ) Set_Potential_Boundaries_Periodic( 2, 1, flags );
+      #endif
     }
     if ( flags[dir] == 3 ){
 
@@ -243,12 +252,23 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
   #ifdef PARTICLES
   if ( Particles.TRANSFER_DENSITY_BOUNDARIES ){
     if ( flags[dir] ==1 ){
-      if ( dir == 0 ) Copy_Particles_Density_Boundaries( 0, 0 );
-      if ( dir == 1 ) Copy_Particles_Density_Boundaries( 0, 1 );
-      if ( dir == 2 ) Copy_Particles_Density_Boundaries( 1, 0 );
-      if ( dir == 3 ) Copy_Particles_Density_Boundaries( 1, 1 );
-      if ( dir == 4 ) Copy_Particles_Density_Boundaries( 2, 0 );
-      if ( dir == 5 ) Copy_Particles_Density_Boundaries( 2, 1 );
+      // Set Periodic Boundaries for the particles density.
+      #ifdef PARTICLES_GPU
+      if ( dir == 0 ) Set_Particles_Density_Boundaries_Periodic_GPU( 0, 0 );
+      if ( dir == 1 ) Set_Particles_Density_Boundaries_Periodic_GPU( 0, 1 );
+      if ( dir == 2 ) Set_Particles_Density_Boundaries_Periodic_GPU( 1, 0 );
+      if ( dir == 3 ) Set_Particles_Density_Boundaries_Periodic_GPU( 1, 1 );
+      if ( dir == 4 ) Set_Particles_Density_Boundaries_Periodic_GPU( 2, 0 );
+      if ( dir == 5 ) Set_Particles_Density_Boundaries_Periodic_GPU( 2, 1 );
+      #endif
+      #ifdef PARTICLES_CPU       
+      if ( dir == 0 ) Set_Particles_Density_Boundaries_Periodic( 0, 0 );
+      if ( dir == 1 ) Set_Particles_Density_Boundaries_Periodic( 0, 1 );
+      if ( dir == 2 ) Set_Particles_Density_Boundaries_Periodic( 1, 0 );
+      if ( dir == 3 ) Set_Particles_Density_Boundaries_Periodic( 1, 1 );
+      if ( dir == 4 ) Set_Particles_Density_Boundaries_Periodic( 2, 0 );
+      if ( dir == 5 ) Set_Particles_Density_Boundaries_Periodic( 2, 1 );
+      #endif
     }
     return;
   }

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -656,7 +656,7 @@ class Grid3D
   void Copy_Hydro_Density_to_Gravity();
   void Extrapolate_Grav_Potential_Function( int g_start, int g_end );
   void Extrapolate_Grav_Potential();
-  void Copy_Potential_Boundaries( int direction, int side, int *flags );
+  void Set_Potential_Boundaries_Periodic( int direction, int side, int *flags );
   int Load_Gravity_Potential_To_Buffer( int direction, int side, Real *buffer, int buffer_start  );
   void Unload_Gravity_Potential_from_Buffer( int direction, int side, Real *buffer, int buffer_start  );
   void Set_Potential_Boundaries_Isolated( int direction, int side, int *flags );
@@ -673,6 +673,7 @@ class Grid3D
   int Load_Gravity_Potential_To_Buffer_GPU( int direction, int side, Real *buffer, int buffer_start  );
   void Unload_Gravity_Potential_from_Buffer_GPU( int direction, int side, Real *buffer, int buffer_start  );
   void Set_Potential_Boundaries_Isolated_GPU( int direction, int side, int *flags );
+  void Set_Potential_Boundaries_Periodic_GPU( int direction, int side, int *flags );
   #endif
 
   #endif//GRAVITY
@@ -688,7 +689,7 @@ class Grid3D
   void Copy_Particles_Density_function( int g_start, int g_end );
   void Copy_Particles_Density();
   void Copy_Particles_Density_to_Gravity(struct parameters P);
-  void Copy_Particles_Density_Boundaries( int direction, int side );
+  void Set_Particles_Density_Boundaries_Periodic( int direction, int side );
   void Transfer_Particles_Boundaries( struct parameters P );
   Real Update_Grid_and_Particles_KDK( struct parameters P );
   void Set_Particles_Boundary( int dir, int side);
@@ -741,6 +742,7 @@ class Grid3D
   void Advance_Particles_KDK_Step1_GPU();
   void Advance_Particles_KDK_Step2_GPU();
   void Set_Particles_Boundary_GPU( int dir, int side);
+  void Set_Particles_Density_Boundaries_Periodic_GPU( int direction, int side );
   #endif//PARTICLES_GPU
   #ifdef GRAVITY_GPU
   void Copy_Particles_Density_GPU();

--- a/src/particles/density_boundaries.cpp
+++ b/src/particles/density_boundaries.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 //Copy the particles density boundaries for non-MPI PERIODIC transfers
-void Grid3D::Copy_Particles_Density_Boundaries( int direction, int side ){
+void Grid3D::Set_Particles_Density_Boundaries_Periodic( int direction, int side ){
 
   int i, j, k, indx_src, indx_dst;
   int nGHST, nx_g, ny_g, nz_g;

--- a/src/particles/density_boundaries_gpu.cu
+++ b/src/particles/density_boundaries_gpu.cu
@@ -7,6 +7,77 @@
 
 
 
+__global__ void Set_Particles_Density_Boundaries_Periodic_kernel( int direction, int side, int n_i, int n_j, int nx, int ny, int nz, int n_ghost, Real *density_d   ){
+
+  // get a global thread ID
+  int tid, tid_i, tid_j, tid_k, tid_src, tid_dst;
+  tid = threadIdx.x + blockIdx.x * blockDim.x;
+  tid_k = tid / (n_i*n_j);
+  tid_j = (tid - tid_k*n_i*n_j) / n_i;
+  tid_i = tid - tid_k*n_i*n_j - tid_j*n_i;
+  
+  if ( tid_i < 0 || tid_i >= n_i || tid_j < 0 || tid_j >= n_j || tid_k < 0 || tid_k >= n_ghost ) return;
+
+  if ( direction == 0 ){
+    if ( side == 0 ) tid_src = ( nx - n_ghost + tid_k )   + (tid_i)*nx + (tid_j)*nx*ny;
+    if ( side == 0 ) tid_dst = ( n_ghost + tid_k )        + (tid_i)*nx + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_src = ( tid_k )                  + (tid_i)*nx + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_dst = ( nx - 2*n_ghost + tid_k ) + (tid_i)*nx + (tid_j)*nx*ny;
+  }
+  if ( direction == 1 ){
+    if ( side == 0 ) tid_src = (tid_i) + ( ny - n_ghost + tid_k )*nx    + (tid_j)*nx*ny;
+    if ( side == 0 ) tid_dst = (tid_i) + ( n_ghost + tid_k )*nx         + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_src = (tid_i) + ( tid_k )*nx                   + (tid_j)*nx*ny;
+    if ( side == 1 ) tid_dst = (tid_i) + ( ny - 2*n_ghost + tid_k )*nx  + (tid_j)*nx*ny;
+  }
+  if ( direction == 2 ){
+    if ( side == 0 ) tid_src = (tid_i) + (tid_j)*nx + ( nz - n_ghost + tid_k  )*nx*ny;
+    if ( side == 0 ) tid_dst = (tid_i) + (tid_j)*nx + ( n_ghost + tid_k )*nx*ny;
+    if ( side == 1 ) tid_src = (tid_i) + (tid_j)*nx + ( tid_k )*nx*ny;
+    if ( side == 1 ) tid_dst = (tid_i) + (tid_j)*nx + ( nz - 2* n_ghost + tid_k  )*nx*ny;
+  }
+  
+  density_d[tid_dst] += density_d[tid_src];
+  
+}
+
+
+void Grid3D::Set_Particles_Density_Boundaries_Periodic_GPU( int direction, int side ){
+  
+  int n_ghost, nx_g, ny_g, nz_g, size, ngrid, n_i, n_j;
+  n_ghost = Particles.G.n_ghost_particles_grid;
+  nx_g = Particles.G.nx_local + 2*n_ghost;
+  ny_g = Particles.G.ny_local + 2*n_ghost;
+  nz_g = Particles.G.nz_local + 2*n_ghost;
+
+  if ( direction == 0 ){
+    n_i = ny_g;
+    n_j = nz_g;
+  }
+  if ( direction == 1 ){
+    n_i = nx_g;
+    n_j = nz_g;
+  }
+  if ( direction == 2 ){
+    n_i = nx_g;
+    n_j = ny_g;
+  }
+
+  size = n_ghost * n_i * n_j;
+
+  // set values for GPU kernels
+  ngrid = ( size - 1 ) / TPB_PARTICLES + 1;
+  // number of blocks per 1D grid
+  dim3 dim1dGrid(ngrid, 1, 1);
+  //  number of threads per 1D block
+  dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
+
+  hipLaunchKernelGGL( Set_Particles_Density_Boundaries_Periodic_kernel, dim1dGrid, dim1dBlock, 0, 0, direction, side, n_i, n_j, nx_g, ny_g, nz_g, n_ghost, Particles.G.density_dev );
+  
+}
+
+
+
 
 
 #ifdef MPI_CHOLLA


### PR DESCRIPTION
Implemented a periodic copy of the gravitational potential and particles density when using GRAVITY_GPU and one of the axes is handled by a single mpi task i.e. n_mpi=1 or n_mpi=2 or n_mpi=4.