### PR TITLE
Move all timestep calculations to GPU

### DIFF
--- a/builds/make.type.cooling
+++ b/builds/make.type.cooling
@@ -1,14 +1,13 @@
 #-- Default hydro + cooling_gpu
 
-#-- separated output flag so that it can be overriden in target-specific 
+#-- separated output flag so that it can be overriden in target-specific
 #   for make check
 OUTPUT    ?=  -DOUTPUT -DHDF5
 
 MPI_GPU   ?=
 
-DFLAGS	  += -DHYDRO_GPU
 DFLAGS    += -DCUDA
-DFLAGS    += -DMPI_CHOLLA 
+DFLAGS    += -DMPI_CHOLLA
 DFLAGS    += -DBLOCK
 DFLAGS    += -DPRECISION=2
 DFLAGS    += -DPPMP
@@ -40,9 +39,9 @@ DFLAGS    += $(OUTPUT)
 
 #Select if the Hydro Conserved data will reside in the GPU
 #and the MPI transfers are done from the GPU
-#If not specified, MPI_GPU is off by default 
+#If not specified, MPI_GPU is off by default
 #This is set in the system make.host file
-DFLAGS    += $(MPI_GPU)  
+DFLAGS    += $(MPI_GPU)
 
 DFLAGS    += -DPARALLEL_OMP
 DFLAGS    += -DN_OMP_THREADS=$(OMP_NUM_THREADS)

--- a/src/global/global_cuda.cu
+++ b/src/global/global_cuda.cu
@@ -10,11 +10,9 @@ bool dt_memory_allocated, memory_allocated;
 Real *dev_conserved, *dev_conserved_half;
 Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
 Real *eta_x, *eta_y, *eta_z, *etah_x, *etah_y, *etah_z;
-Real *dev_dti_array;
 #ifdef COOLING_GPU
 Real *dev_dt_array;
 #endif
-Real *host_dti_array;
 #ifdef COOLING_GPU
 Real *host_dt_array;
 #endif

--- a/src/global/global_cuda.h
+++ b/src/global/global_cuda.h
@@ -27,14 +27,10 @@ extern bool dt_memory_allocated; // Flag becomes true after allocating the memor
 extern Real *dev_conserved, *dev_conserved_half;
 // input states and associated interface fluxes (Q* and F* from Stone, 2008)
 extern Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
-// array of inverse timesteps for dt calculation
-extern Real *dev_dti_array;
 #ifdef COOLING_GPU
 // array of timesteps for dt calculation (cooling restriction)
 extern Real *dev_dt_array;
 #endif
-// Array on the CPU to hold max_dti returned from each thread block
-extern Real *host_dti_array;
 #ifdef COOLING_GPU
 extern Real *host_dt_array;
 #endif

--- a/src/integrators/CTU_1D_cuda.cu
+++ b/src/integrators/CTU_1D_cuda.cu
@@ -113,7 +113,6 @@ void CTU_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Re
 void Free_Memory_CTU_1D() {
 
   // free the CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
   #if defined COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -123,7 +122,6 @@ void Free_Memory_CTU_1D() {
   cudaFree(Q_Lx);
   cudaFree(Q_Rx);
   cudaFree(F_x);
-  cudaFree(dev_dti_array);
   #if defined COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/CTU_2D_cuda.cu
+++ b/src/integrators/CTU_2D_cuda.cu
@@ -147,7 +147,7 @@ void CTU_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_o
 void Free_Memory_CTU_2D() {
 
   // free the CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
+  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -160,7 +160,6 @@ void Free_Memory_CTU_2D() {
   cudaFree(Q_Ry);
   cudaFree(F_x);
   cudaFree(F_y);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/CTU_3D_cuda.cu
+++ b/src/integrators/CTU_3D_cuda.cu
@@ -193,7 +193,6 @@ void CTU_Algorithm_3D_CUDA(Real *d_conserved, int nx, int ny, int nz, int x_off,
 void Free_Memory_CTU_3D() {
 
   // free CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -209,7 +208,6 @@ void Free_Memory_CTU_3D() {
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -136,7 +136,6 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
 void Free_Memory_VL_1D() {
 
   // free the CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -147,7 +146,6 @@ void Free_Memory_VL_1D() {
   cudaFree(Q_Lx);
   cudaFree(Q_Rx);
   cudaFree(F_x);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -152,7 +152,6 @@ void Free_Memory_VL_2D() {
 
   // free the CPU memory
   if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -166,7 +165,6 @@ void Free_Memory_VL_2D() {
   cudaFree(Q_Ry);
   cudaFree(F_x);
   cudaFree(F_y);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -199,7 +199,6 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 void Free_Memory_VL_3D(){
 
   // free CPU memory
-  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -191,7 +191,6 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
     hipLaunchKernelGGL(Apply_Temperature_Floor, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, U_floor );
     CudaCheckError();
     #endif //TEMPERATURE_FLOOR
-    
   return;
 
 }
@@ -200,7 +199,7 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 void Free_Memory_VL_3D(){
 
   // free CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
+  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -217,7 +216,6 @@ void Free_Memory_VL_3D(){
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -151,7 +151,7 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved,  Real *d_grav_potential,
   hipLaunchKernelGGL(Apply_Temperature_Floor, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, U_floor );
   CudaCheckError();
   #endif //TEMPERATURE_FLOOR
-  
+
 
   return;
 
@@ -161,7 +161,7 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved,  Real *d_grav_potential,
 void Free_Memory_Simple_3D(){
 
   // free CPU memory
-  CudaSafeCall( cudaFreeHost(host_dti_array) );
+  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
   #ifdef COOLING_GPU
   CudaSafeCall( cudaFreeHost(host_dt_array) );
   #endif
@@ -177,7 +177,6 @@ void Free_Memory_Simple_3D(){
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  cudaFree(dev_dti_array);
   #ifdef COOLING_GPU
   cudaFree(dev_dt_array);
   #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,16 +111,16 @@ int main(int argc, char *argv[])
   #ifdef COOLING_GRACKLE
   G.Initialize_Grackle(&P);
   #endif
-  
+
   #ifdef CHEMISTRY_GPU
   G.Initialize_Chemistry(&P);
   #endif
-  
+
   #ifdef ANALYSIS
   G.Initialize_Analysis_Module(&P);
   if ( G.Analysis.Output_Now ) G.Compute_and_Output_Analysis(&P);
   #endif
-  
+
   #ifdef GRAVITY
   // Get the gravitational potential for the first timestep
   G.Compute_Gravitational_Potential( &P);
@@ -178,13 +178,14 @@ int main(int argc, char *argv[])
   while (G.H.t < P.tout)
   {
     // get the start time
-    
     #ifdef CPU_TIME
     G.Timer.Total.Start();
     #endif //CPU_TIME
     start_step = get_time();
 
-    // calculate the timestep
+    // calculate the timestep. Note: this computes the timestep ONLY on the
+    // first loop, on subsequent time steps it just calls the MPI_Allreduce to
+    // determine the global timestep
     G.set_dt(dti);
 
     if (G.H.t + G.H.dt > outtime) G.H.dt = outtime - G.H.t;


### PR DESCRIPTION
Passes All Tests

- Switched the first time step calculation to be done on GPU rather
  than CPU
- Make the `host` and `device` `dti_array`'s local to `Calc_dt_GPU`
- Removed last reference to `HYDRO_GPU` flag in cooling make file
- Added comments to main to clarify what `Grid3D::set_dt` does
- Deleted CPU time step functions
  - `calc_dti_cpu`
  - `calc_dti_cpu_1D`
  - `calc_dti_cpu_2D`
  - `calc_dti_cpu_3D`
  - `calc_dti_CPU_3D_function`