### PR TITLE
Caar

### DIFF
--- a/src/cooling/cooling_cuda.cu
+++ b/src/cooling/cooling_cuda.cu
@@ -14,8 +14,6 @@ extern texture<float, 2, cudaReadModeElementType> coolTexObj;
 extern texture<float, 2, cudaReadModeElementType> heatTexObj;
 
 void Cooling_Update(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dt, Real gamma, Real *dt_array){
-  // from global/global_cuda.h: TPB
-  int ngrid = (nx*ny*nz + TPB - 1) / TPB;
   dim3 dim1dGrid(ngrid, 1, 1);
   dim3 dim1dBlock(TPB, 1, 1);
   hipLaunchKernelGGL(cooling_kernel, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, dt, gama, dt_array);

--- a/src/global/global_cuda.cu
+++ b/src/global/global_cuda.cu
@@ -6,6 +6,7 @@
 #include "../global/global.h"
 
 // Declare global variables
+bool memory_allocated;
 Real *dev_conserved, *dev_conserved_half;
 Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
 Real *eta_x, *eta_y, *eta_z, *etah_x, *etah_y, *etah_z;

--- a/src/global/global_cuda.cu
+++ b/src/global/global_cuda.cu
@@ -6,22 +6,11 @@
 #include "../global/global.h"
 
 // Declare global variables
-bool dt_memory_allocated, memory_allocated;
 Real *dev_conserved, *dev_conserved_half;
 Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
 Real *eta_x, *eta_y, *eta_z, *etah_x, *etah_y, *etah_z;
-#ifdef COOLING_GPU
-Real *dev_dt_array;
-#endif
-#ifdef COOLING_GPU
-Real *host_dt_array;
-#endif
-Real *buffer, *tmp1, *tmp2;
-int nx_s, ny_s, nz_s;
-int x_off_s, y_off_s, z_off_s;
-int block1_tot, block2_tot, block3_tot, block_tot;
-int remainder1, remainder2, remainder3;
-int BLOCK_VOL;
+Real *host_dti_array;
+Real *dev_dti_array;
 int ngrid;
 
 //Arrays for potential in GPU: Will be set to NULL if not using GRAVITY

--- a/src/global/global_cuda.h
+++ b/src/global/global_cuda.h
@@ -18,7 +18,6 @@
 
 
 extern bool memory_allocated; // Flag becomes true after allocating the memory on the first timestep
-extern bool dt_memory_allocated; // Flag becomes true after allocating the memory on the first calc_dt_GPU call
 
 // Arrays are global so that they can be allocated only once.
 // Not all arrays will be allocated for every integrator
@@ -27,38 +26,15 @@ extern bool dt_memory_allocated; // Flag becomes true after allocating the memor
 extern Real *dev_conserved, *dev_conserved_half;
 // input states and associated interface fluxes (Q* and F* from Stone, 2008)
 extern Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
-#ifdef COOLING_GPU
-// array of timesteps for dt calculation (cooling restriction)
-extern Real *dev_dt_array;
-#endif
-#ifdef COOLING_GPU
-extern Real *host_dt_array;
-#endif
-// Buffer to copy conserved variable blocks to/from
-extern Real *buffer;
-// Pointers for the location to copy from and to
-extern Real *tmp1;
-extern Real *tmp2;
+// array of inverse timesteps for dt calculation
+extern Real *host_dti_array;
+extern Real *dev_dti_array;
 
 //Arrays for potential in GPU: Will be set to NULL if not using GRAVITY
 extern Real *dev_grav_potential;
 extern Real *temp_potential;
 extern Real *buffer_potential;
 
-// Similarly, sizes of subgrid blocks and kernel dimensions are global variables
-// so subgrid splitting function is only called once
-// dimensions of subgrid blocks
-extern int nx_s, ny_s, nz_s;
-// x, y, and z offsets for subgrid blocks
-extern int x_off_s, y_off_s, z_off_s;
-// total number of subgrid blocks needed
-extern int block_tot;
-// number of subgrid blocks needed in each direction
-extern int block1_tot, block2_tot, block3_tot;
-// modulus of number of cells after block subdivision in each direction
-extern int remainder1, remainder2, remainder3;
-// number of cells in one subgrid block
-extern int BLOCK_VOL;
 // dimensions for the GPU grid
 extern int ngrid;
 

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -333,6 +333,9 @@ class Grid3D
 
     struct Conserved
     {
+      /*! pointer to conserved variable array on the host */
+      Real *host;
+
       /*! \var density
        *  \brief Array containing the density of each cell in the grid */
       Real *density;

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -290,14 +290,6 @@ class Grid3D
      *  \brief Rotation struct for data projections */
     struct Rotation R;
 
-    /*! \var buffer0
-     *  \brief Buffer to hold conserved variable arrays */
-    Real *buffer0;
-
-    /*! \var buffer1
-     *  \brief Buffer to hold conserved variable arrays */
-    Real *buffer1;
-
     #ifdef GRAVITY
     // Object that contains data for gravity
     Grav3D Grav;

--- a/src/integrators/CTU_1D_cuda.cu
+++ b/src/integrators/CTU_1D_cuda.cu
@@ -34,7 +34,6 @@ void CTU_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Re
   int nz = 1;
 
   // set the dimensions of the cuda grid
-  ngrid = (n_cells + TPB - 1) / TPB;
   dim3 dimGrid(ngrid, 1, 1);
   dim3 dimBlock(TPB, 1, 1);
 
@@ -112,19 +111,11 @@ void CTU_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Re
 
 void Free_Memory_CTU_1D() {
 
-  // free the CPU memory
-  #if defined COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(Q_Lx);
   cudaFree(Q_Rx);
   cudaFree(F_x);
-  #if defined COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
 
 }
 

--- a/src/integrators/CTU_2D_cuda.cu
+++ b/src/integrators/CTU_2D_cuda.cu
@@ -37,8 +37,6 @@ void CTU_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_o
   int nz = 1;
 
   // set values for GPU kernels
-  // dimensions for the 1D GPU grid
-  ngrid = (n_cells + TPB - 1) / (TPB);
   // number of blocks per 1D grid
   dim3 dim2dGrid(ngrid, 1, 1);
   //number of threads per 1D block
@@ -146,12 +144,6 @@ void CTU_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_o
 
 void Free_Memory_CTU_2D() {
 
-  // free the CPU memory
-  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(Q_Lx);
@@ -160,9 +152,6 @@ void Free_Memory_CTU_2D() {
   cudaFree(Q_Ry);
   cudaFree(F_x);
   cudaFree(F_y);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
 
 }
 

--- a/src/integrators/CTU_3D_cuda.cu
+++ b/src/integrators/CTU_3D_cuda.cu
@@ -39,8 +39,6 @@ void CTU_Algorithm_3D_CUDA(Real *d_conserved, int nx, int ny, int nz, int x_off,
   int n_cells = nx*ny*nz;
 
   // set values for GPU kernels
-  // dimensions for the 1D GPU grid
-  ngrid = (n_cells + TPB - 1) / TPB;
   // number of blocks per 1D grid
   dim3 dim1dGrid(ngrid, 1, 1);
   //  number of threads per 1D block
@@ -192,11 +190,6 @@ void CTU_Algorithm_3D_CUDA(Real *d_conserved, int nx, int ny, int nz, int x_off,
 
 void Free_Memory_CTU_3D() {
 
-  // free CPU memory
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(Q_Lx);
@@ -208,9 +201,6 @@ void Free_Memory_CTU_3D() {
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
   #if defined( GRAVITY )
   cudaFree(dev_grav_potential);
   #endif

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -39,7 +39,6 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
   int nz = 1;
 
   // set the dimensions of the cuda grid
-  ngrid = (n_cells + TPB - 1) / TPB;
   dim3 dimGrid(ngrid, 1, 1);
   dim3 dimBlock(TPB, 1, 1);
 
@@ -135,20 +134,12 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
 
 void Free_Memory_VL_1D() {
 
-  // free the CPU memory
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(dev_conserved_half);
   cudaFree(Q_Lx);
   cudaFree(Q_Rx);
   cudaFree(F_x);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
 
 }
 

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -38,9 +38,6 @@ void VL_Algorithm_2D_CUDA ( Real *d_conserved, int nx, int ny, int x_off, int y_
   int n_cells = nx*ny;
   int nz = 1;
 
-  // dimensions for the 1D GPU grid
-  ngrid = (n_cells + TPB - 1) / (TPB);
-
   // set values for GPU kernels
   // number of blocks per 1D grid
   dim3 dim2dGrid(ngrid, 1, 1);
@@ -150,12 +147,6 @@ void VL_Algorithm_2D_CUDA ( Real *d_conserved, int nx, int ny, int x_off, int y_
 
 void Free_Memory_VL_2D() {
 
-  // free the CPU memory
-  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(dev_conserved_half);
@@ -165,9 +156,6 @@ void Free_Memory_VL_2D() {
   cudaFree(Q_Ry);
   cudaFree(F_x);
   cudaFree(F_y);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
 
 }
 

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -20,7 +20,6 @@
 #include "../riemann_solvers/exact_cuda.h"
 #include "../riemann_solvers/roe_cuda.h"
 #include "../riemann_solvers/hllc_cuda.h"
-#include "../old_cholla/h_correction_3D_cuda.h"
 #include "../io/io.h"
 #include "../riemann_solvers/hll_cuda.h"
 
@@ -39,9 +38,6 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   //concatenated into a 1-d array
 
   int n_cells = nx*ny*nz;
-
-  // dimensions for the 1D GPU grid
-  ngrid = (n_cells + TPB - 1) / TPB;
 
   // set values for GPU kernels
   // number of blocks per 1D grid
@@ -198,11 +194,6 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
 void Free_Memory_VL_3D(){
 
-  // free CPU memory
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(dev_conserved_half);
@@ -215,10 +206,6 @@ void Free_Memory_VL_3D(){
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
-
 
 }
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -38,8 +38,6 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved,  Real *d_grav_potential,
   int n_cells = nx*ny*nz;
 
   // set values for GPU kernels
-  // dimensions for the 1D GPU grid
-  ngrid = (n_cells + TPB - 1) / TPB;
   // number of blocks per 1D grid
   dim3 dim1dGrid(ngrid, 1, 1);
   //  number of threads per 1D block
@@ -160,12 +158,6 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved,  Real *d_grav_potential,
 
 void Free_Memory_Simple_3D(){
 
-  // free CPU memory
-  if (block_tot > 1) CudaSafeCall( cudaFreeHost(buffer) );
-  #ifdef COOLING_GPU
-  CudaSafeCall( cudaFreeHost(host_dt_array) );
-  #endif
-
   // free the GPU memory
   cudaFree(dev_conserved);
   cudaFree(Q_Lx);
@@ -177,9 +169,6 @@ void Free_Memory_Simple_3D(){
   cudaFree(F_x);
   cudaFree(F_y);
   cudaFree(F_z);
-  #ifdef COOLING_GPU
-  cudaFree(dev_dt_array);
-  #endif
 
 }
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -136,7 +136,7 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved,  Real *d_grav_potential,
   #endif
 
   // Step 3: Update the conserved variable array
-  hipLaunchKernelGGL(Update_Conserved_Variables_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved,  Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, F_x, F_y, F_z, nx, ny, nz, x_off_s, y_off_s, z_off_s, n_ghost, dx, dy, dz, xbound, ybound, zbound, dt, gama, n_fields, density_floor, dev_grav_potential);
+  hipLaunchKernelGGL(Update_Conserved_Variables_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved,  Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz, Q_Rz, F_x, F_y, F_z, nx, ny, nz, x_off, y_off, z_off, n_ghost, dx, dy, dz, xbound, ybound, zbound, dt, gama, n_fields, density_floor, dev_grav_potential);
   CudaCheckError();
 
   #ifdef DE

--- a/src/utils/error_check_cuda.cu
+++ b/src/utils/error_check_cuda.cu
@@ -61,7 +61,7 @@ int Check_Field_Along_Axis( Real *dev_array, int n_field, int nx, int ny, int nz
 
   int *error_value_dev;
   CudaSafeCall( cudaMalloc((void**)&error_value_dev,   sizeof(int)) );
-  hipLaunchKernelGGL(Check_Value_Along_Axis, Grid_Error, Block_Error, 0, 0,  dev_conserved, 0, nx_s, ny_s, nz_s, n_ghost, error_value_dev );
+  hipLaunchKernelGGL(Check_Value_Along_Axis, Grid_Error, Block_Error, 0, 0,  dev_conserved, 0, nx, ny, nz, n_ghost, error_value_dev );
 
   int error_value_host;
   CudaSafeCall( cudaMemcpy( &error_value_host, error_value_dev, sizeof(int), cudaMemcpyDeviceToHost) );


### PR DESCRIPTION
Moved the memory allocations for host and device dti arrays to grid3D.cpp, so they are single allocated. These are used for the GPU time step reduction in Calc_dt_GPU. Also, the cooling dti calculation now re-uses the same arrays (since both are only used in the kernel).
Added definition of global variable 'ngrid' - the number of GPU thread blocks - to grid3D.cpp. Removed duplicate definitions in hydro integrators.
Removed duplicate hydro conserved variable array on the host (in grid3D.cpp).