### PR TITLE
Preliminary MHD Support

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        make-type: [hydro, gravity, disk, particles, cosmology]
+        make-type: [hydro, gravity, disk, particles, cosmology, mhd]
         gpu-api: [HIP, CUDA]
         # NOTE: if more than one parameter is in any of these three variables
         # you need to manually exclude it for the GPU API that doesn't use it.

--- a/builds/make.host.c3po
+++ b/builds/make.host.c3po
@@ -13,6 +13,7 @@ OMP_NUM_THREADS   = 7
 #-- Library
 CUDA_ROOT       := /usr/local/cuda-11.4
 HDF5_ROOT       := /usr/lib/x86_64-linux-gnu/hdf5/serial
+MPI_ROOT        := /usr/lib/x86_64-linux-gnu/openmpi
 # FFTW_ROOT       = ${OLCF_FFTW_ROOT}
 # PFFT_ROOT       = /ccs/proj/csc380/cholla/fom/code/pfft
 # GRACKLE_ROOT    = /ccs/home/bvilasen/code/grackle

--- a/builds/make.type.mhd
+++ b/builds/make.type.mhd
@@ -1,0 +1,52 @@
+#-- Default MHD hydro build
+
+#-- separated output flag so that it can be overriden in target-specific
+#   for make check
+OUTPUT    ?=  -DOUTPUT -DHDF5
+
+MPI_GPU   ?=
+
+DFLAGS	  += -DHYDRO_GPU
+DFLAGS    += -DCUDA
+DFLAGS    += -DMPI_CHOLLA
+DFLAGS    += -DBLOCK
+DFLAGS    += -DPRECISION=2
+DFLAGS    += -DPPMP
+DFLAGS    += -DHLLD
+DFLAGS    += -DMHD
+
+ifeq ($(findstring cosmology,$(TYPE)),cosmology)
+DFLAGS    += -DSIMPLE
+else
+DFLAGS    += -DVL
+endif
+
+# need this if using Disk_3D
+# DFLAGS += -DDISK_ICS
+
+# Apply a density and temperature floor
+DFLAGS    += -DDENSITY_FLOOR
+DFLAGS    += -DTEMPERATURE_FLOOR
+
+# Solve the Gas Internal Energy usisng a Dual Energy Formalism
+# DFLAGS    += -DDE
+
+# Evolve additional scalars
+# DFLAGS += -DSCALAR
+
+# Apply the cooling in the GPU from precomputed tables
+# DFLAGS    += -DCOOLING_GPU
+
+#Measure the Timing of the different stages
+DFLAGS += -DCPU_TIME
+
+DFLAGS    += $(OUTPUT)
+
+#Select if the Hydro Conserved data will reside in the GPU
+#and the MPI transfers are done from the GPU
+#If not specified, MPI_GPU is off by default
+#This is set in the system make.host file
+DFLAGS    += $(MPI_GPU)
+
+DFLAGS    += -DPARALLEL_OMP
+DFLAGS    += -DN_OMP_THREADS=$(OMP_NUM_THREADS)

--- a/builds/make.type.mhd
+++ b/builds/make.type.mhd
@@ -6,10 +6,8 @@ OUTPUT    ?=  -DOUTPUT -DHDF5
 
 MPI_GPU   ?=
 
-DFLAGS	  += -DHYDRO_GPU
 DFLAGS    += -DCUDA
 DFLAGS    += -DMPI_CHOLLA
-DFLAGS    += -DBLOCK
 DFLAGS    += -DPRECISION=2
 DFLAGS    += -DPPMP
 DFLAGS    += -DHLLD
@@ -47,6 +45,3 @@ DFLAGS    += $(OUTPUT)
 #If not specified, MPI_GPU is off by default
 #This is set in the system make.host file
 DFLAGS    += $(MPI_GPU)
-
-DFLAGS    += -DPARALLEL_OMP
-DFLAGS    += -DN_OMP_THREADS=$(OMP_NUM_THREADS)

--- a/builds/scripts/run_tests.sh
+++ b/builds/scripts/run_tests.sh
@@ -190,11 +190,13 @@ runTests ()
   GTEST_REPORT="--gtest_output=xml:${CHOLLA_ROOT}/bin/"
 
   builtin cd $CHOLLA_ROOT
+  set -x
   "${CHOLLA_ROOT}/bin/cholla.${CHOLLA_MAKE_TYPE}.${CHOLLA_MACHINE}.tests" \
   "${CHOLLA_OPTIONS[@]}" \
   "${GTEST_FILTER}" \
   "${GTEST_REPORT}" \
   "${@}"
+  set +x
 }
 # ==============================================================================
 

--- a/examples/1D/123.txt
+++ b/examples/1D/123.txt
@@ -42,9 +42,9 @@ P_l=0.4
 # density of right state
 rho_r=1.0
 # velocity of right state
-vx_l=2.0
-vy_l=0.0
-vz_l=0.0
+vx_r=2.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.4
 # location of initial discontinuity

--- a/examples/1D/123.txt
+++ b/examples/1D/123.txt
@@ -34,13 +34,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=-2.0
+vx_l=-2.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=0.4
 # density of right state
 rho_r=1.0
 # velocity of right state
-v_r=2.0
+vx_l=2.0
+vy_l=0.0
+vz_l=0.0
 # pressure of right state
 P_r=0.4
 # location of initial discontinuity

--- a/examples/1D/Creasey_shock.txt
+++ b/examples/1D/Creasey_shock.txt
@@ -34,13 +34,17 @@ outdir=./
 # density of left state
 rho_l=1.672622e-24
 # velocity of left state
-v_l=0.0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.380658e-10
 # density of right state
 rho_r=1.672622e-24
 # velocity of right state
-v_r=0.0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=1.380658e-10
 # location of initial discontinuity

--- a/examples/1D/constant.txt
+++ b/examples/1D/constant.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for box filled with gas 
+# Parameter File for box filled with gas
 #
 
 ################################################
@@ -41,6 +41,10 @@ vy=0
 vz=0
 # pressure
 P=1.380658e-5
+# Magnetic Field
+Bx=0.0
+By=0.0
+Bz=0.0
 # value of gamma
 gamma=1.666666667
 

--- a/examples/1D/noh_1D.txt
+++ b/examples/1D/noh_1D.txt
@@ -33,13 +33,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=1.0
+vx_l=1.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=0.000001
 # density of right state
 rho_r=1.0
 # velocity of right state
-v_r=-1.0
+vx_r=-1.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.000001
 # location of initial discontinuity

--- a/examples/1D/sod.txt
+++ b/examples/1D/sod.txt
@@ -37,13 +37,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0.0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0.0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/examples/1D/stationary.txt
+++ b/examples/1D/stationary.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for Toro test 5, a stationary contact. 
+# Parameter File for Toro test 5, a stationary contact.
 # Parameters derived from Toro, Sec. 6.4.4, test 5
 # Same as test 3a from Liska, 2003.
 #
@@ -35,13 +35,18 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=-19.59745
+vx_l=-19.59745
+vy_l=0.0
+vz_l=0.0
+
 # pressure of left state
 P_l=1000
 # density of right state
 rho_r=1.0
 # velocity of right state
-v_r=-19.59745
+vx_r=-19.59745
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.01
 # location of initial discontinuity

--- a/examples/1D/test_3.txt
+++ b/examples/1D/test_3.txt
@@ -34,13 +34,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0.0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1000
 # density of right state
 rho_r=1.0
 # velocity of right state
-v_r=0.0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.01
 # location of initial discontinuity

--- a/examples/1D/trac_pen.txt
+++ b/examples/1D/trac_pen.txt
@@ -34,13 +34,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=120.0
+vx_l=120.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.2
 # velocity of right state
-v_r=120.0
+vx_r=120.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.01
 # location of initial discontinuity

--- a/examples/1D/two_shocks.txt
+++ b/examples/1D/two_shocks.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for Toro test 4, a collision of two shocks. 
+# Parameter File for Toro test 4, a collision of two shocks.
 # Parameters derived from Toro, Sec. 6.4.4, test 4
 #
 
@@ -34,13 +34,18 @@ outdir=./
 # density of left state
 rho_l=5.99924
 # velocity of left state
-v_l=19.5975
+vx_l=19.5975
+vy_l=0.0
+vz_l=0.0
+
 # pressure of left state
 P_l=460.894
 # density of right state
 rho_r=5.99242
 # velocity of right state
-v_r=-6.19633
+vx_r=-6.19633
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=46.095
 # location of initial discontinuity

--- a/examples/2D/constant.txt
+++ b/examples/2D/constant.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for 3D box filled with gas 
+# Parameter File for 3D box filled with gas
 #
 
 ################################################
@@ -41,6 +41,10 @@ vy=0
 vz=0
 # pressure
 P=1.380658e-5
+# Magnetic Field
+Bx=0.0
+By=0.0
+Bz=0.0
 # value of gamma
 gamma=1.666666667
 

--- a/examples/2D/sod.txt
+++ b/examples/2D/sod.txt
@@ -35,13 +35,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0.0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0.0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/examples/3D/Brio_and_Wu.txt
+++ b/examples/3D/Brio_and_Wu.txt
@@ -1,20 +1,23 @@
 #
-# Parameter File for 1D strong shock test
+# Parameter File for 3D Brio & Wu MHD shock tube
+# Citation: Brio & Wu 1988 "An Upwind Differencing Scheme for the Equations of
+# Ideal Magnetohydrodynamics"
 #
 
 ################################################
 # number of grid cells in the x dimension
-nx=100
+nx=32
 # number of grid cells in the y dimension
-ny=1
+ny=32
 # number of grid cells in the z dimension
-nz=1
+nz=32
 # final output time
-tout=0.07
+tout=0.1
 # time interval for output
-outstep=0.07
+outstep=0.1
 # name of initial conditions
 init=Riemann
+
 # domain properties
 xmin=0.0
 ymin=0.0
@@ -22,32 +25,48 @@ zmin=0.0
 xlen=1.0
 ylen=1.0
 zlen=1.0
+
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
+
 # path to output directory
 outdir=./
 
 #################################################
 # Parameters for 1D Riemann problems
 # density of left state
-rho_l=10.0
+rho_l=1.0
 # velocity of left state
-vx_l=0.0
-vy_l=0.0
-vz_l=0.0
+vx_l=0
+vy_l=0
+vz_l=0
 # pressure of left state
-P_l=100.0
+P_l=1.0
+# Magnetic field of the left state
+Bx_l=0.75
+By_l=1.0
+Bz_l=0.0
+
 # density of right state
-rho_r=1.0
+rho_r=0.128
 # velocity of right state
-vx_r=0.0
-vy_r=0.0
-vz_r=0.0
+vx_r=0
+vy_r=0
+vz_r=0
 # pressure of right state
-P_r=1.0
+P_r=0.1
+# Magnetic field of the right state
+Bx_r=0.75
+By_r=-1.0
+Bz_r=0.0
+
 # location of initial discontinuity
 diaph=0.5
 # value of gamma
-gamma=1.4
+gamma=2
 

--- a/examples/3D/Dai_and_Woodward.txt
+++ b/examples/3D/Dai_and_Woodward.txt
@@ -1,20 +1,24 @@
 #
-# Parameter File for 1D strong shock test
+# Parameter File for 3D Dai & Woodward MHD shock tube
+# Citation: Dai & Woodward 1998 "On The Diverrgence-Free Condition and
+# Conservation Laws in Numerical Simulations for Supersonic Magnetohydrodynamic
+# Flows"
 #
 
 ################################################
 # number of grid cells in the x dimension
-nx=100
+nx=32
 # number of grid cells in the y dimension
-ny=1
+ny=32
 # number of grid cells in the z dimension
-nz=1
+nz=32
 # final output time
-tout=0.07
+tout=0.2
 # time interval for output
-outstep=0.07
+outstep=0.2
 # name of initial conditions
 init=Riemann
+
 # domain properties
 xmin=0.0
 ymin=0.0
@@ -22,32 +26,48 @@ zmin=0.0
 xlen=1.0
 ylen=1.0
 zlen=1.0
+
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
+
 # path to output directory
 outdir=./
 
 #################################################
 # Parameters for 1D Riemann problems
 # density of left state
-rho_l=10.0
+rho_l=1.08
 # velocity of left state
 vx_l=0.0
 vy_l=0.0
 vz_l=0.0
 # pressure of left state
-P_l=100.0
+P_l=1.0
+# Magnetic field of the left state
+Bx_l=14.17963081
+By_l=12.76166773
+Bz_l=7.0898154
+
 # density of right state
 rho_r=1.0
 # velocity of right state
 vx_r=0.0
 vy_r=0.0
-vz_r=0.0
+vz_r=1.0
 # pressure of right state
-P_r=1.0
+P_r=0.2
+# Magnetic field of the right state
+Bx_r=14.17963081
+By_r=14.17963081
+Bz_r=7.0898154
+
 # location of initial discontinuity
 diaph=0.5
 # value of gamma
-gamma=1.4
+gamma=1.6666666666666667
 

--- a/examples/3D/Einfeldt_Strong_Rarefaction.txt
+++ b/examples/3D/Einfeldt_Strong_Rarefaction.txt
@@ -1,20 +1,22 @@
 #
-# Parameter File for 1D strong shock test
+# Parameter File for 3D Einfeldt Strong Rarefaction MHD test
+# Citation: Einfeldt et al. 1991 "On Godunov-Type Methods near Low Densities"
 #
 
 ################################################
 # number of grid cells in the x dimension
-nx=100
+nx=32
 # number of grid cells in the y dimension
-ny=1
+ny=32
 # number of grid cells in the z dimension
-nz=1
+nz=32
 # final output time
-tout=0.07
+tout=0.16
 # time interval for output
-outstep=0.07
+outstep=0.16
 # name of initial conditions
 init=Riemann
+
 # domain properties
 xmin=0.0
 ymin=0.0
@@ -22,30 +24,46 @@ zmin=0.0
 xlen=1.0
 ylen=1.0
 zlen=1.0
+
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
+
 # path to output directory
 outdir=./
 
 #################################################
 # Parameters for 1D Riemann problems
 # density of left state
-rho_l=10.0
+rho_l=1.0
 # velocity of left state
-vx_l=0.0
+vx_l=-2.0
 vy_l=0.0
 vz_l=0.0
 # pressure of left state
-P_l=100.0
+P_l=0.45
+# Magnetic field of the left state
+Bx_l=0.0
+By_l=0.5
+Bz_l=0.0
+
 # density of right state
 rho_r=1.0
 # velocity of right state
-vx_r=0.0
+vx_r=2.0
 vy_r=0.0
 vz_r=0.0
 # pressure of right state
-P_r=1.0
+P_r=0.45
+# Magnetic field of the right state
+Bx_r=0.0
+By_r=0.5
+Bz_r=0.0
+
 # location of initial discontinuity
 diaph=0.5
 # value of gamma

--- a/examples/3D/Ryu_and_Jones_4d.txt
+++ b/examples/3D/Ryu_and_Jones_4d.txt
@@ -1,20 +1,26 @@
 #
-# Parameter File for 1D strong shock test
+# Parameter File for 3D Ryu & Jones MHD shock tube 4d.
+# Citation: Ryu & Jones 1995 "Numerical Magnetohydrodynamics in Astrophysics:
+# Algorithms and Tests for One-Dimensional Flow"
+#
+# Note: There are many shock tubes in this paper. This settings file is
+# specifically for shock tube 4d
 #
 
 ################################################
 # number of grid cells in the x dimension
-nx=100
+nx=32
 # number of grid cells in the y dimension
-ny=1
+ny=32
 # number of grid cells in the z dimension
-nz=1
+nz=32
 # final output time
-tout=0.07
+tout=0.16
 # time interval for output
-outstep=0.07
+outstep=0.16
 # name of initial conditions
 init=Riemann
+
 # domain properties
 xmin=0.0
 ymin=0.0
@@ -22,32 +28,47 @@ zmin=0.0
 xlen=1.0
 ylen=1.0
 zlen=1.0
+
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
+
 # path to output directory
 outdir=./
 
 #################################################
 # Parameters for 1D Riemann problems
 # density of left state
-rho_l=10.0
+rho_l=1.0
 # velocity of left state
 vx_l=0.0
 vy_l=0.0
 vz_l=0.0
 # pressure of left state
-P_l=100.0
+P_l=1.0
+# Magnetic field of the left state
+Bx_l=0.7
+By_l=0.0
+Bz_l=0.0
+
 # density of right state
-rho_r=1.0
+rho_r=0.3
 # velocity of right state
 vx_r=0.0
 vy_r=0.0
-vz_r=0.0
+vz_r=1.0
 # pressure of right state
-P_r=1.0
+P_r=0.2
+# Magnetic field of the right state
+Bx_r=0.7
+By_r=1.0
+Bz_r=0.0
+
 # location of initial discontinuity
 diaph=0.5
 # value of gamma
-gamma=1.4
-
+gamma=1.6666666666666667

--- a/examples/3D/constant.txt
+++ b/examples/3D/constant.txt
@@ -1,5 +1,5 @@
 #
-# Parameter File for 3D box filled with gas 
+# Parameter File for 3D box filled with gas
 #
 
 ################################################
@@ -41,6 +41,10 @@ vy=0
 vz=0
 # pressure
 P=1.380658e-5
+# Magnetic Field
+Bx=0.0
+By=0.0
+Bz=0.0
 # value of gamma
 gamma=1.666666667
 

--- a/examples/3D/sod.txt
+++ b/examples/3D/sod.txt
@@ -38,13 +38,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/examples/3D/sod256.txt
+++ b/examples/3D/sod256.txt
@@ -38,13 +38,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/examples/sample.txt
+++ b/examples/sample.txt
@@ -27,7 +27,7 @@ ylen=1.0
 tout=0.2
 # time interval for output
 outstep=0.01
-# ratio of specific heats 
+# ratio of specific heats
 gamma=1.4
 # name of initial conditions
 init=Riemann
@@ -47,13 +47,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -253,20 +253,46 @@ void parse_param(char *name,char *value, struct parameters *parms){
     parms->vz = atof(value);
   else if (strcmp(name, "P")==0)
     parms->P = atof(value);
+  else if (strcmp(name, "Bx")==0)
+    parms->Bx = atof(value);
+  else if (strcmp(name, "By")==0)
+    parms->By = atof(value);
+  else if (strcmp(name, "Bz")==0)
+    parms->Bz = atof(value);
   else if (strcmp(name, "A")==0)
     parms->A = atof(value);
   else if (strcmp(name, "rho_l")==0)
     parms->rho_l = atof(value);
-  else if (strcmp(name, "v_l")==0)
-    parms->v_l = atof(value);
+  else if (strcmp(name, "vx_l")==0)
+    parms->vx_l = atof(value);
+  else if (strcmp(name, "vy_l")==0)
+    parms->vy_l = atof(value);
+  else if (strcmp(name, "vz_l")==0)
+    parms->vz_l = atof(value);
   else if (strcmp(name, "P_l")==0)
     parms->P_l = atof(value);
+  else if (strcmp(name, "Bx_l")==0)
+    parms->Bx_l = atof(value);
+  else if (strcmp(name, "By_l")==0)
+    parms->By_l = atof(value);
+  else if (strcmp(name, "Bz_l")==0)
+    parms->Bz_l = atof(value);
   else if (strcmp(name, "rho_r")==0)
     parms->rho_r = atof(value);
-  else if (strcmp(name, "v_r")==0)
-    parms->v_r = atof(value);
+  else if (strcmp(name, "vx_r")==0)
+    parms->vx_r = atof(value);
+  else if (strcmp(name, "vy_r")==0)
+    parms->vy_r = atof(value);
+  else if (strcmp(name, "vz_r")==0)
+    parms->vz_r = atof(value);
   else if (strcmp(name, "P_r")==0)
     parms->P_r = atof(value);
+  else if (strcmp(name, "Bx_r")==0)
+    parms->Bx_r = atof(value);
+  else if (strcmp(name, "By_r")==0)
+    parms->By_r = atof(value);
+  else if (strcmp(name, "Bz_r")==0)
+    parms->Bz_r = atof(value);
   else if (strcmp(name, "diaph")==0)
     parms->diaph = atof(value);
 #ifdef PARTICLES

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -43,12 +43,13 @@ typedef double Real;
 
 #define TIME_UNIT 3.15569e10 // 1 kyr in s
 #define LENGTH_UNIT 3.08567758e21 // 1 kpc in cm
-#define MASS_UNIT 1.98855e33 // 1 solar mass in grams
+#define MASS_UNIT 1.98855e33 // 1 solar mass in gramsgit st
 #define DENSITY_UNIT (MASS_UNIT/(LENGTH_UNIT*LENGTH_UNIT*LENGTH_UNIT))
 #define VELOCITY_UNIT (LENGTH_UNIT/TIME_UNIT)
 #define ENERGY_UNIT (DENSITY_UNIT*VELOCITY_UNIT*VELOCITY_UNIT)
 #define PRESSURE_UNIT (DENSITY_UNIT*VELOCITY_UNIT*VELOCITY_UNIT)
 #define SP_ENERGY_UNIT (VELOCITY_UNIT*VELOCITY_UNIT)
+#define MAGNETIC_FIELD_UNIT (sqrt(MASS_UNIT/LENGTH_UNIT) / TIME_UNIT)
 
 #define LOG_FILE_NAME "run_output.log"
 
@@ -80,6 +81,12 @@ typedef double Real;
 #define NSCALARS 0
 #endif//SCALAR
 #endif//COOLING_GRACKLE
+
+#ifdef  MHD
+  #define N_MHD_FIELDS 3
+#else
+  #define N_MHD_FIELDS 0
+#endif  //MHD
 
 // Inital Chemistry fractions
 #define INITIAL_FRACTION_HI        0.75984603480
@@ -233,12 +240,25 @@ struct parameters
   Real vz;
   Real P;
   Real A;
+  Real Bx;
+  Real By;
+  Real Bz;
   Real rho_l;
-  Real v_l;
+  Real vx_l;
+  Real vy_l=0;
+  Real vz_l=0;
   Real P_l;
+  Real Bx_l;
+  Real By_l;
+  Real Bz_l;
   Real rho_r;
-  Real v_r;
+  Real vx_r;
+  Real vy_r=0;
+  Real vz_r=0;
   Real P_r;
+  Real Bx_r;
+  Real By_r;
+  Real Bz_r;
   Real diaph;
 #ifdef PARTICLES
   // The random seed for particle simulations. With the default of 0 then a

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -76,6 +76,8 @@ typedef double Real;
 #ifdef SCALAR
 // Set Number of scalar fields when not using grackle
 #define NSCALARS 1
+#else
+#define NSCALARS 0
 #endif//SCALAR
 #endif//COOLING_GRACKLE
 

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -43,7 +43,7 @@ typedef double Real;
 
 #define TIME_UNIT 3.15569e10 // 1 kyr in s
 #define LENGTH_UNIT 3.08567758e21 // 1 kpc in cm
-#define MASS_UNIT 1.98855e33 // 1 solar mass in gramsgit st
+#define MASS_UNIT 1.98847e33 // 1 solar mass in grams
 #define DENSITY_UNIT (MASS_UNIT/(LENGTH_UNIT*LENGTH_UNIT*LENGTH_UNIT))
 #define VELOCITY_UNIT (LENGTH_UNIT/TIME_UNIT)
 #define ENERGY_UNIT (DENSITY_UNIT*VELOCITY_UNIT*VELOCITY_UNIT)

--- a/src/grid/boundary_conditions.cpp
+++ b/src/grid/boundary_conditions.cpp
@@ -64,7 +64,7 @@ void Grid3D::Set_Boundary_Conditions(parameters P) {
   #ifdef PARTICLES
   n_bounds += (int) Particles.TRANSFER_PARTICLES_BOUNDARIES;
   n_bounds += (int) Particles.TRANSFER_DENSITY_BOUNDARIES;
-  #endif
+  #endif  //PARTICLES
 
   if ( n_bounds > 1 ){
     printf("ERROR: More than one boundary type for transfer. N boundary types: %d\n", n_bounds );
@@ -115,7 +115,7 @@ void Grid3D::Set_Boundary_Conditions(parameters P) {
 
   #ifdef GRAVITY
   Grav.Set_Boundary_Flags( flags );
-  #endif
+  #endif  //Gravity
 
 #else  /*MPI_CHOLLA*/
 
@@ -261,7 +261,7 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
       if ( dir == 4 ) Set_Particles_Density_Boundaries_Periodic_GPU( 2, 0 );
       if ( dir == 5 ) Set_Particles_Density_Boundaries_Periodic_GPU( 2, 1 );
       #endif
-      #ifdef PARTICLES_CPU       
+      #ifdef PARTICLES_CPU
       if ( dir == 0 ) Set_Particles_Density_Boundaries_Periodic( 0, 0 );
       if ( dir == 1 ) Set_Particles_Density_Boundaries_Periodic( 0, 1 );
       if ( dir == 2 ) Set_Particles_Density_Boundaries_Periodic( 1, 0 );
@@ -272,7 +272,7 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
     }
     return;
   }
-  #endif
+  #endif  //PARTICLES
 
   #ifdef PARTICLES
   if ( Particles.TRANSFER_PARTICLES_BOUNDARIES ){
@@ -299,7 +299,7 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
       } else if (flags[dir] == 3) {
         #ifdef PARTICLES_CPU
         Set_Particles_Open_Boundary(dir/2, dir%2);
-        #endif
+        #endif  //PARTICLES_CPU
     }
     return;
   }
@@ -308,7 +308,7 @@ void Grid3D::Set_Boundaries(int dir, int flags[])
   //get the extents of the ghost region we are initializing
   Set_Boundary_Extents(dir, &imin[0], &imax[0]);
 
-  // from grid/cuda_boundaries.cu 
+  // from grid/cuda_boundaries.cu
   SetGhostCells(C.device,
 		 H.nx, H.ny, H.nz, H.n_fields, H.n_cells, H.n_ghost, flags,
 		 imax[0]-imin[0], imax[1]-imin[1], imax[2]-imin[2],

--- a/src/grid/cuda_boundaries.cu
+++ b/src/grid/cuda_boundaries.cu
@@ -3,9 +3,9 @@
 #include "../global/global_cuda.h"
 #include "cuda_boundaries.h"
 
-__device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *a);
+__device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *a, int &idMag);
 
-__device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[],int nx, int ny, int nz, int n_ghost); 
+__device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[],int nx, int ny, int nz, int n_ghost,  int &magneticIdx);
 
 __global__ void PackBuffers3DKernel(Real * buffer, Real * c_head, int isize, int jsize, int ksize, int nx, int ny, int idxoffset, int buffer_ncells, int n_fields, int n_cells)
 {
@@ -66,7 +66,7 @@ __global__ void SetGhostCellsKernel(Real * c_head,
 				     int f0, int f1, int f2, int f3, int f4, int f5,
 				     int isize, int jsize, int ksize,
 				     int imin, int jmin, int kmin, int dir){
-  int id,i,j,k,gidx,idx,ii;
+  int id,i,j,k,gidx,idx,ii, magneticIdx;
   Real a[3] = {1.,1.,1.};
   int flags[6] = {f0,f1,f2,f3,f4,f5};
 
@@ -93,11 +93,17 @@ __global__ void SetGhostCellsKernel(Real * c_head,
   gidx = i + j*nx + k*nx*ny;
 
   // calculate idx (index of real cell) and a[:] for reflection
-  idx = SetBoundaryMapping(i,j,k,&a[0],flags,nx,ny,nz,n_ghost);
+  idx = SetBoundaryMapping(i,j,k,&a[0],flags,nx,ny,nz,n_ghost,magneticIdx);
 
   if (idx>=0){
     for (ii=0; ii<n_fields; ii++) {
-      c_head[gidx + ii*n_cells] = c_head[idx + ii*n_cells];
+      #ifdef  MHD
+        // Choose which index to use, the one for magnetic fields or not
+        int index = ((5+NSCALARS <= ii) and ( ii <= 7+NSCALARS))? magneticIdx: idx;
+        c_head[gidx + ii*n_cells] = c_head[index + ii*n_cells];
+      #else // MHD not defined
+        c_head[gidx + ii*n_cells] = c_head[idx + ii*n_cells];
+      #endif  //MHD
     }
     // momentum correction for reflection
     // these are set to -1 whenever ghost cells in a direction are in a reflective boundary condition
@@ -120,13 +126,13 @@ __global__ void SetGhostCellsKernel(Real * c_head,
       // (Z) Dir 4,5 -> Mom 3 -> c_head[gidx+3*n_cells]
       // If a momentum is set to 0, subtract its kinetic energy [gidx+4*n_cells]
       if (dir%2 == 0){
-	// Direction 0,2,4 are left-side, don't allow inflow with positive momentum	
+	// Direction 0,2,4 are left-side, don't allow inflow with positive momentum
 	if (c_head[momdex] > 0.0) {
 	  c_head[gidx+4*n_cells] -= 0.5*(c_head[momdex]*c_head[momdex])/c_head[gidx];
 	  c_head[momdex] = 0.0;
 	}
       } else {
-	// Direction 1,3,5 are right-side, don't allow inflow with negative momentum	
+	// Direction 1,3,5 are right-side, don't allow inflow with negative momentum
 	if (c_head[momdex] < 0.0) {
 	  c_head[gidx+4*n_cells] -= 0.5*(c_head[momdex]*c_head[momdex])/c_head[gidx];
 	  c_head[momdex] = 0.0;
@@ -150,33 +156,43 @@ void SetGhostCells(Real * c_head,
 
 }
 
-__device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[], int nx, int ny, int nz, int n_ghost){
+__device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[], int nx, int ny, int nz, int n_ghost, int &magneticIdx){
   // nx, ny, nz, n_ghost
   /* 1D */
-  int ir, jr, kr, idx;
-  ir=jr=kr=idx=0;
+  // irMag, jrMag, krMag are the magnetic indices
+  int ir, jr, kr, irMag, jrMag, krMag, idx;
+  ir=jr=kr=irMag=jrMag=krMag=idx=magneticIdx=0;
   if (nx>1) {
 
     // set index on -x face
     if (ig < n_ghost) {
-      ir = FindIndex(ig, nx, flags[0], 0, n_ghost, &a[0]);
+      ir = FindIndex(ig, nx, flags[0], 0, n_ghost, &a[0], irMag);
     }
     // set index on +x face
     else if (ig >= nx-n_ghost) {
-      ir = FindIndex(ig, nx, flags[1], 1, n_ghost, &a[0]);
+      ir = FindIndex(ig, nx, flags[1], 1, n_ghost, &a[0], irMag);
     }
     // set i index for multi-D problems
     else {
       ir = ig;
+      #ifdef  MHD
+        irMag = ig;
+      #endif  //MHD
     }
 
     // if custom x boundaries are needed, set index to -1 and return
     if (ir < 0) {
+      #ifdef  MHD
+        magneticIdx = -1;
+      #endif  //MHD
       return idx = -1;
     }
 
     // otherwise add i index to ghost cell mapping
     idx += ir;
+    #ifdef  MHD
+      magneticIdx += irMag;
+    #endif  //MHD
 
   }
 
@@ -185,24 +201,33 @@ __device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[], 
 
     // set index on -y face
     if (jg < n_ghost) {
-      jr = FindIndex(jg, ny, flags[2], 0, n_ghost, &a[1]);
+      jr = FindIndex(jg, ny, flags[2], 0, n_ghost, &a[1], jrMag);
     }
     // set index on +y face
     else if (jg >= ny-n_ghost) {
-      jr = FindIndex(jg, ny, flags[3], 1, n_ghost, &a[1]);
+      jr = FindIndex(jg, ny, flags[3], 1, n_ghost, &a[1], jrMag);
     }
     // set j index for multi-D problems
     else {
       jr = jg;
+      #ifdef  MHD
+        jrMag = jg;
+      #endif  //MHD
     }
 
     // if custom y boundaries are needed, set index to -1 and return
     if (jr < 0) {
+      #ifdef  MHD
+        magneticIdx = -1;
+      #endif  //MHD
       return idx = -1;
     }
 
     // otherwise add j index to ghost cell mapping
     idx += nx*jr;
+    #ifdef  MHD
+      magneticIdx += nx*jrMag;
+    #endif  //MHD
 
   }
 
@@ -211,79 +236,122 @@ __device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[], 
 
     // set index on -z face
     if (kg < n_ghost) {
-      kr = FindIndex(kg, nz, flags[4], 0, n_ghost, &a[2]);
+      kr = FindIndex(kg, nz, flags[4], 0, n_ghost, &a[2], krMag);
     }
     // set index on +z face
     else if (kg >= nz-n_ghost) {
-      kr = FindIndex(kg, nz, flags[5], 1, n_ghost, &a[2]);
+      kr = FindIndex(kg, nz, flags[5], 1, n_ghost, &a[2], krMag);
     }
     // set k index for multi-D problems
     else {
       kr = kg;
+      #ifdef  MHD
+        krMag = kg;
+      #endif  //MHD
     }
 
     // if custom z boundaries are needed, set index to -1 and return
     if (kr < 0) {
+      #ifdef  MHD
+        magneticIdx = -1;
+      #endif  //MHD
       return idx = -1;
     }
 
     // otherwise add k index to ghost cell mapping
     idx += nx*ny*kr;
-
+    #ifdef  MHD
+      magneticIdx += nx*ny*krMag;
+    #endif  //MHD
   }
   return idx;
 }
 
-__device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *a){
+__device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *a, int &idMag){
   int id;
 
   // lower face
-  if (face==0) {
+  if (face==0)
+  {
     switch(flag)
-      {
-	// periodic
-      case 1: id = ig+nx-2*n_ghost;
-	break;
-	// reflective
-      case 2: id = 2*n_ghost-ig-1;
-	*(a) = -1.0;
-	break;
-	// transmissive
-      case 3: id = n_ghost;
-	break;
-	// custom
-      case 4: id = -1;
-	break;
-	// MPI
-      case 5: id = ig;
-	break;
-	// default is periodic
-      default: id = ig+nx-2*n_ghost;
-      }
+    {
+      // periodic
+      case 1:
+        id = ig+nx-2*n_ghost;
+        break;
+      // reflective
+      case 2:
+        id = 2*n_ghost-ig-1;
+        *(a) = -1.0;
+        break;
+      // transmissive
+      case 3:
+        id = n_ghost;
+        break;
+      // custom
+      case 4:
+        id = -1;
+        break;
+      // MPI
+      case 5:
+        id = ig;
+        break;
+      // default is periodic
+      default:
+        id = ig+nx-2*n_ghost;
+    }
+    #ifdef  MHD
+      idMag = id;
+    #endif  //MHD
   }
   // upper face
-  else {
+  else
+  {
     switch(flag)
-      {
-	// periodic
-      case 1: id = ig-nx+2*n_ghost;
-	break;
-	// reflective
-      case 2: id = 2*(nx-n_ghost)-ig-1;
-	*(a) = -1.0;
-	break;
-	// transmissive
-      case 3: id = nx-n_ghost-1;
-	break;
-	// custom
-      case 4: id = -1;
-	break;
-	// MPI
-      case 5: id = ig;
-	break;
-	// default is periodic
-      default: id = ig-nx+2*n_ghost;
-      }
+    {
+      // periodic
+      case 1:
+        id = ig-nx+2*n_ghost;
+        #ifdef  MHD
+          idMag = id;
+        #endif  //MHD
+        break;
+      // reflective
+      case 2:
+        id = 2*(nx-n_ghost)-ig-1;
+        *(a) = -1.0;
+        #ifdef  MHD
+          idMag = id + 1;
+        #endif  //MHD
+      break;
+      // transmissive
+      case 3:
+        id = nx-n_ghost-1;
+        #ifdef  MHD
+          idMag = id + 1;
+        #endif  //MHD
+        break;
+      // custom
+      case 4:
+        id = -1;
+        #ifdef  MHD
+          idMag = -1;
+        #endif  //MHD
+        break;
+      // MPI
+      case 5:
+        id = ig;
+        #ifdef  MHD
+          idMag = id;
+        #endif  //MHD
+        break;
+      // default is periodic
+      default:
+        id = ig-nx+2*n_ghost;
+        #ifdef  MHD
+          idMag = id;
+        #endif  //MHD
+    }
   }
   return id;
 }

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -264,24 +264,34 @@ void Grid3D::AllocateMemory(void)
   C.Energy   = &(C.host[4*H.n_cells]);
   #ifdef SCALAR
   C.scalar  = &(C.host[5*H.n_cells]);
-  #endif
+  #endif  //SCALAR
+  #ifdef  MHD
+  C.magnetic_x = &(C.host[(5 + NSCALARS)*H.n_cells]);
+  C.magnetic_y = &(C.host[(6 + NSCALARS)*H.n_cells]);
+  C.magnetic_z = &(C.host[(7 + NSCALARS)*H.n_cells]);
+  #endif  //MHD
   #ifdef DE
   C.GasEnergy = &(C.host[(H.n_fields-1)*H.n_cells]);
-  #endif
+  #endif  //DE
 
   // allocate memory for the conserved variable arrays on the device
   CudaSafeCall( cudaMalloc((void**)&C.device, H.n_fields*H.n_cells*sizeof(Real)) );
-  C.d_density     = C.device;
-  C.d_momentum_x  = &(C.device[H.n_cells]);
-  C.d_momentum_y  = &(C.device[2*H.n_cells]);
-  C.d_momentum_z  = &(C.device[3*H.n_cells]);
-  C.d_Energy      = &(C.device[4*H.n_cells]);
+  C.d_density    = C.device;
+  C.d_momentum_x = &(C.device[H.n_cells]);
+  C.d_momentum_y = &(C.device[2*H.n_cells]);
+  C.d_momentum_z = &(C.device[3*H.n_cells]);
+  C.d_Energy     = &(C.device[4*H.n_cells]);
   #ifdef SCALAR
-  C.d_scalar      = &(C.device[5*H.n_cells]);
-  #endif
+  C.d_scalar     = &(C.device[5*H.n_cells]);
+  #endif  // SCALAR
+  #ifdef  MHD
+  C.d_magnetic_x   = &(C.device[(5 + NSCALARS)*H.n_cells]);
+  C.d_magnetic_y   = &(C.device[(6 + NSCALARS)*H.n_cells]);
+  C.d_magnetic_z   = &(C.device[(7 + NSCALARS)*H.n_cells]);
+  #endif  //MHD
   #ifdef DE
-  C.d_GasEnergy   = &(C.device[(H.n_fields-1)*H.n_cells]);
-  #endif
+  C.d_GasEnergy  = &(C.device[(H.n_fields-1)*H.n_cells]);
+  #endif  // DE
 
   // set the number of thread blocks for the GPU grid (declared in global_cuda)
   ngrid = (H.n_cells + TPB - 1) / TPB;
@@ -317,7 +327,7 @@ void Grid3D::AllocateMemory(void)
 
   #ifdef CLOUDY_COOL
   Load_Cuda_Textures();
-  #endif
+  #endif  // CLOUDY_COOL
 
 }
 

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -380,7 +380,7 @@ void Grid3D::AllocateMemory(void)
   #ifdef GRAVITY
   //Set dt for hydro and particles
   set_dt_Gravity();
-  #endif
+  #endif  //GRAVITY
 
   #ifdef CPU_TIME
   Timer.Calc_dt.End();

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -360,7 +360,7 @@ void Grid3D::AllocateMemory(void)
     #endif //max_dti_slow
 
     // Compute the time step
-    max_dti = Calc_dt_GPU(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.dx, H.dy, H.dz, gama, max_dti_slow);
+    max_dti = Calc_dt_GPU(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_cells, H.dx, H.dy, H.dz, gama, max_dti_slow);
   }
   else {
     max_dti = dti;
@@ -491,7 +491,7 @@ Real Grid3D::Update_Grid(void)
   #endif
 
   // ==Calculate the next time step with Calc_dt_GPU from hydro/hydro_cuda.h==
-  max_dti = Calc_dt_GPU(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.dx, H.dy, H.dz, gama, max_dti_slow);
+  max_dti = Calc_dt_GPU(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_cells, H.dx, H.dy, H.dz, gama, max_dti_slow);
   #ifdef COOLING_GPU
   max_dti = fmax(max_dti, cooling_max_dti);
   #endif // COOLING_GPU

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -107,6 +107,11 @@ void Grid3D::Initialize(struct parameters *P)
   H.n_fields += NSCALARS;
   #endif
 
+  // if including magnetic fields increase the number of fields
+  #ifdef  MHD
+  H.n_fields += 3;
+  #endif  //MHD
+
   // if using dual energy formalism must track internal energy - always the last field!
   #ifdef DE
   H.n_fields++;
@@ -603,7 +608,7 @@ void Grid3D::FreeMemory(void)
 
   // free the timestep arrays
   CudaSafeCall( cudaFreeHost(host_dti_array) );
-  cudaFree(dev_dti_array);  
+  cudaFree(dev_dti_array);
 
   #ifdef GRAVITY
   CudaSafeCall( cudaFreeHost(C.Grav_potential) );

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -348,18 +348,38 @@ class Grid3D
        *  \brief Array containing the total Energy of each cell in the grid */
       Real *Energy;
 
+      #ifdef SCALAR
+      /*! \var scalar
+       *  \brief Array containing the values of the passive scalar variable(s). */
+      Real *scalar;
+      #endif  // SCALAR
+
+      #ifdef MHD
+      /*! \var magnetic_x \brief Array containing the magnetic field in the x
+       *  direction of each cell in the grid. Note that this is the magnetic
+       *  field at the x-1/2 face of the cell since constrained transport
+       *  requires face centered, not cell centered, magnetic fields */
+      Real *magnetic_x;
+
+      /*! \var magnetic_y \brief Array containing the magnetic field in the y
+       *  direction of each cell in the grid. Note that this is the magnetic
+       *  field at the y-1/2 face of the cell since constrained transport
+       *  requires face centered, not cell centered, magnetic fields */
+      Real *magnetic_y;
+
+      /*! \var magnetic_z \brief Array containing the magnetic field in the z
+       *  direction of each cell in the grid. Note that this is the magnetic
+       *  field at the z-1/2 face of the cell since constrained transport
+       *  requires face centered, not cell centered, magnetic fields */
+      Real *magnetic_z;
+      #endif  // MHD
+
       #ifdef DE
       /*! \var GasEnergy
        *  \brief Array containing the internal energy of each cell, only tracked separately when using
            the dual-energy formalism. */
       Real *GasEnergy;
-      #endif
-
-      #ifdef SCALAR
-      /*! \var scalar
-       *  \brief Array containing the values of the passive scalar variable(s). */
-      Real *scalar;
-      #endif
+      #endif  // DE
 
       /*! \var grav_potential
       *  \brief Array containing the gravitational potential of each cell, only tracked separately when using  GRAVITY. */
@@ -378,7 +398,8 @@ class Grid3D
       /*! pointer to conserved variable on device */
       Real *device;
       Real *d_density, *d_momentum_x, *d_momentum_y, *d_momentum_z,
-           *d_Energy, *d_scalar, *d_GasEnergy;
+           *d_Energy, *d_scalar, *d_magnetic_x, *d_magnetic_y, *d_magnetic_z,
+           *d_GasEnergy;
 
        /*! pointer to gravitational potential on device */
       Real *d_Grav_potential;
@@ -516,7 +537,7 @@ class Grid3D
 
     /*! \fn void Constant(Real rho, Real vx, Real vy, Real vz, Real P)
      *  \brief Constant gas properties. */
-    void Constant(Real rho, Real vx, Real vy, Real vz, Real P);
+    void Constant(Real rho, Real vx, Real vy, Real vz, Real P, Real Bx, Real By, Real Bz);
 
     /*! \fn void Sound_Wave(Real rho, Real vx, Real vy, Real vz, Real P, Real A)
      *  \brief Sine wave perturbation. */
@@ -526,9 +547,13 @@ class Grid3D
      *  \brief Square wave density perturbation with amplitude A*rho in pressure equilibrium. */
     void Square_Wave(Real rho, Real vx, Real vy, Real vz, Real P, Real A);
 
-    /*! \fn void Riemann(Real rho_l, Real v_l, Real P_l, Real rho_r, Real v_r, Real P_r, Real diaph)
+    /*! \fn void Riemann(Real rho_l, Real vx_l, Real vy_l, Real vz_l, Real P_l, Real Bx_l, Real By_l, Real Bz_l,
+                         Real rho_r, Real vx_r, Real vy_r, Real vz_r, Real P_r, Real Bx_r, Real By_r, Real Bz_r,
+                         Real diaph)
      *  \brief Initialize the grid with a Riemann problem. */
-    void Riemann(Real rho_l, Real v_l, Real P_l, Real rho_r, Real v_r, Real P_r, Real diaph);
+    void Riemann(Real rho_l, Real vx_l, Real vy_l, Real vz_l, Real P_l, Real Bx_l, Real By_l, Real Bz_l,
+                 Real rho_r, Real vx_r, Real vy_r, Real vz_r, Real P_r, Real Bx_r, Real By_r, Real Bz_r,
+                 Real diaph);
 
     /*! \fn void Shu_Osher()
      *  \brief Initialize the grid with the Shu-Osher shock tube problem. See Stone 2008, Section 8.1 */

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -33,28 +33,16 @@ __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, R
  * \param[in] gamma The adiabatic index
  * \return Real The maximum inverse crossing time in the cell
  */
-__device__ __host__ inline Real hydroInverseCrossingTime(Real const &E,
-                                                         Real const &d,
-                                                         Real const &d_inv,
-                                                         Real const &vx,
-                                                         Real const &vy,
-                                                         Real const &vz,
-                                                         Real const &dx,
-                                                         Real const &dy,
-                                                         Real const &dz,
-                                                         Real const &gamma)
-{
-  // Compute pressure and sound speed
-  Real P  = (E - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
-  Real cs = sqrt(d_inv * gamma * P);
-
-  // Find maximum inverse crossing time in the cell (i.e. minimum crossing time)
-  Real cellMaxInverseDt = fmax((fabs(vx)+cs)/dx, (fabs(vy)+cs)/dy);
-  cellMaxInverseDt      = fmax(cellMaxInverseDt, (fabs(vz)+cs)/dz);
-  cellMaxInverseDt      = fmax(cellMaxInverseDt, 0.0);
-
-  return cellMaxInverseDt;
-}
+__device__ __host__ Real hydroInverseCrossingTime(Real const &E,
+                                                  Real const &d,
+                                                  Real const &d_inv,
+                                                  Real const &vx,
+                                                  Real const &vy,
+                                                  Real const &vz,
+                                                  Real const &dx,
+                                                  Real const &dy,
+                                                  Real const &dz,
+                                                  Real const &gamma);
 
 /*!
  * \brief Determine the maximum inverse crossing time in a specific cell
@@ -74,31 +62,19 @@ __device__ __host__ inline Real hydroInverseCrossingTime(Real const &E,
  * \param[in] gamma The adiabatic index
  * \return Real The maximum inverse crossing time in the cell
  */
-__device__ __host__ inline Real mhdInverseCrossingTime(Real const &E,
-                                                       Real const &d,
-                                                       Real const &d_inv,
-                                                       Real const &vx,
-                                                       Real const &vy,
-                                                       Real const &vz,
-                                                       Real const &avgBx,
-                                                       Real const &avgBy,
-                                                       Real const &avgBz,
-                                                       Real const &dx,
-                                                       Real const &dy,
-                                                       Real const &dz,
-                                                       Real const &gamma)
-{
-  // Compute the gas pressure and fast magnetosonic speed
-  Real gasP = mhdUtils::computeGasPressure(E, d, vx*d, vy*d, vz*d, avgBx, avgBy, avgBz, gamma);
-  Real cf   = mhdUtils::fastMagnetosonicSpeed(d, gasP, avgBx, avgBy, avgBz, gamma);
-
-  // Find maximum inverse crossing time in the cell (i.e. minimum crossing time)
-  Real cellMaxInverseDt = fmax((fabs(vx)+cf)/dx, (fabs(vy)+cf)/dy);
-  cellMaxInverseDt      = fmax(cellMaxInverseDt, (fabs(vz)+cf)/dz);
-  cellMaxInverseDt      = fmax(cellMaxInverseDt, 0.0);
-
-  return cellMaxInverseDt;
-}
+__device__ __host__ Real mhdInverseCrossingTime(Real const &E,
+                                                Real const &d,
+                                                Real const &d_inv,
+                                                Real const &vx,
+                                                Real const &vy,
+                                                Real const &vz,
+                                                Real const &avgBx,
+                                                Real const &avgBy,
+                                                Real const &avgBz,
+                                                Real const &dx,
+                                                Real const &dy,
+                                                Real const &dz,
+                                                Real const &gamma);
 
 __global__ void Calc_dt_1D(Real *dev_conserved, int n_cells, int n_ghost, Real dx, Real *dti_array, Real gamma);
 

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -6,6 +6,7 @@
 #define HYDRO_CUDA_H
 
 #include "../global/global.h"
+#include "../utils/mhd_utilities.h"
 
 
 __global__ void Update_Conserved_Variables_1D(Real *dev_conserved, Real *dev_F, int n_cells, int x_off, int n_ghost, Real dx, Real xbound, Real dt, Real gamma, int n_fields);
@@ -17,15 +18,97 @@ __global__ void Update_Conserved_Variables_2D(Real *dev_conserved, Real *dev_F_x
 __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, Real *Q_Rx, Real *Q_Ly, Real *Q_Ry, Real *Q_Lz, Real *Q_Rz, Real *dev_F_x, Real *dev_F_y,  Real *dev_F_z, int nx, int ny, int nz, int x_off, int y_off, int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound, Real dt, Real gamma, int n_fields, Real density_floor, Real *dev_potential );
 
 
+/*!
+ * \brief Determine the maximum inverse crossing time in a specific cell
+ *
+ * \param[in] E The energy
+ * \param[in] d The density
+ * \param[in] d_inv The inverse density
+ * \param[in] vx The velocity in the x-direction
+ * \param[in] vy The velocity in the y-direction
+ * \param[in] vz The velocity in the z-direction
+ * \param[in] dx The size of each cell in the x-direction
+ * \param[in] dy The size of each cell in the y-direction
+ * \param[in] dz The size of each cell in the z-direction
+ * \param[in] gamma The adiabatic index
+ * \return Real The maximum inverse crossing time in the cell
+ */
+__device__ __host__ inline Real hydroInverseCrossingTime(Real const &E,
+                                                         Real const &d,
+                                                         Real const &d_inv,
+                                                         Real const &vx,
+                                                         Real const &vy,
+                                                         Real const &vz,
+                                                         Real const &dx,
+                                                         Real const &dy,
+                                                         Real const &dz,
+                                                         Real const &gamma)
+{
+  // Compute pressure and sound speed
+  Real P  = (E - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
+  Real cs = sqrt(d_inv * gamma * P);
+
+  // Find maximum inverse crossing time in the cell (i.e. minimum crossing time)
+  Real cellMaxInverseDt = fmax((fabs(vx)+cs)/dx, (fabs(vy)+cs)/dy);
+  cellMaxInverseDt      = fmax(cellMaxInverseDt, (fabs(vz)+cs)/dz);
+  cellMaxInverseDt      = fmax(cellMaxInverseDt, 0.0);
+
+  return cellMaxInverseDt;
+}
+
+/*!
+ * \brief Determine the maximum inverse crossing time in a specific cell
+ *
+ * \param[in] E The energy
+ * \param[in] d The density
+ * \param[in] d_inv The inverse density
+ * \param[in] vx The velocity in the x-direction
+ * \param[in] vy The velocity in the y-direction
+ * \param[in] vz The velocity in the z-direction
+ * \param[in] avgBx The cell centered magnetic field in the x-direction
+ * \param[in] avgBy The cell centered magnetic field in the y-direction
+ * \param[in] avgBz The cell centered magnetic field in the z-direction
+ * \param[in] dx The size of each cell in the x-direction
+ * \param[in] dy The size of each cell in the y-direction
+ * \param[in] dz The size of each cell in the z-direction
+ * \param[in] gamma The adiabatic index
+ * \return Real The maximum inverse crossing time in the cell
+ */
+__device__ __host__ inline Real mhdInverseCrossingTime(Real const &E,
+                                                       Real const &d,
+                                                       Real const &d_inv,
+                                                       Real const &vx,
+                                                       Real const &vy,
+                                                       Real const &vz,
+                                                       Real const &avgBx,
+                                                       Real const &avgBy,
+                                                       Real const &avgBz,
+                                                       Real const &dx,
+                                                       Real const &dy,
+                                                       Real const &dz,
+                                                       Real const &gamma)
+{
+  // Compute the gas pressure and fast magnetosonic speed
+  Real gasP = mhdUtils::computeGasPressure(E, d, vx*d, vy*d, vz*d, avgBx, avgBy, avgBz, gamma);
+  Real cf   = mhdUtils::fastMagnetosonicSpeed(d, gasP, avgBx, avgBy, avgBz, gamma);
+
+  // Find maximum inverse crossing time in the cell (i.e. minimum crossing time)
+  Real cellMaxInverseDt = fmax((fabs(vx)+cf)/dx, (fabs(vy)+cf)/dy);
+  cellMaxInverseDt      = fmax(cellMaxInverseDt, (fabs(vz)+cf)/dz);
+  cellMaxInverseDt      = fmax(cellMaxInverseDt, 0.0);
+
+  return cellMaxInverseDt;
+}
+
 __global__ void Calc_dt_1D(Real *dev_conserved, int n_cells, int n_ghost, Real dx, Real *dti_array, Real gamma);
 
 
 __global__ void Calc_dt_2D(Real *dev_conserved, int nx, int ny, int n_ghost, Real dx, Real dy, Real *dti_array, Real gamma);
 
 
-__global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, Real dx, Real dy, Real dz, Real *dti_array, Real gamma,  Real max_dti_slow);
+__global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy, Real dz, Real *dti_array, Real gamma,  Real max_dti_slow);
 
-Real Calc_dt_GPU(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, Real dx, Real dy, Real dz, Real gamma, Real max_dti_slow);
+Real Calc_dt_GPU(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy, Real dz, Real gamma, Real max_dti_slow);
 
 __global__ void Sync_Energies_1D(Real *dev_conserved, int nx, int n_ghost, Real gamma, int n_fields);
 
@@ -65,7 +148,7 @@ __global__ void Select_Internal_Energy_2D( Real *dev_conserved, int nx, int ny, 
 
 __global__ void Select_Internal_Energy_3D( Real *dev_conserved, int nx, int ny, int nz,  int n_ghost, int n_fields );
 
-__device__ void Average_Cell_All_Fields( int i, int j, int k, int nx, int ny, int nz, int ncells, Real *conserved );
+__device__ void Average_Cell_All_Fields( int i, int j, int k, int nx, int ny, int nz, int ncells, int n_fields, Real *conserved );
 
 __device__ Real Average_Cell_Single_Field( int field_indx, int i, int j, int k, int nx, int ny, int nz, int ncells, Real *conserved );
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -9,17 +9,17 @@
 #include <ctime>
 #ifdef HDF5
 #include <hdf5.h>
-#endif
+#endif  //HDF5
 #include "../io/io.h"
 #include "../grid/grid3D.h"
 #ifdef MPI_CHOLLA
 #include "../mpi/mpi_routines.h"
-#endif
+#endif  //MPI_CHOLLA
 #include "../utils/error_handling.h"
 
 #ifdef COSMOLOGY
 #include "../cosmology/cosmology.h"
-#endif
+#endif  //COSMOLOGY
 
 using namespace std;
 
@@ -75,7 +75,7 @@ void Write_Message_To_Log_File( const char* message ){
 /* Write the initial conditions */
 void WriteData(Grid3D &G, struct parameters P, int nfile)
 {
-  
+
   cudaMemcpy(G.C.density, G.C.device, G.H.n_fields*G.H.n_cells*sizeof(Real), cudaMemcpyDeviceToHost);
 
   chprintf( "\nSaving Snapshot: %d \n", nfile );
@@ -397,10 +397,10 @@ void OutputSlices(Grid3D &G, struct parameters P, int nfile)
 
   #ifdef MPI_CHOLLA
   if (status < 0) {printf("OutputSlices: File write failed. ProcID: %d\n", procID); chexit(-1); }
-  #else
+  #else  // MPI_CHOLLA is not defined
   if (status < 0) {printf("OutputSlices: File write failed.\n"); exit(-1); }
-  #endif
-  #else
+  #endif  // MPI_CHOLLA
+  #else  // HDF5 is not defined
   printf("OutputSlices only defined for hdf5 writes.\n");
   #endif //HDF5
 }
@@ -518,6 +518,13 @@ void Grid3D::Write_Header_HDF5(hid_t file_id)
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &energy_unit);
   status = H5Aclose(attribute_id);
 
+  #ifdef MHD
+    double magnetic_field_unit = MAGNETIC_FIELD_UNIT;
+    attribute_id = H5Acreate(file_id, "magnetic_field_unit", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+    status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &magnetic_field_unit);
+    status = H5Aclose(attribute_id);
+  #endif  //MHD
+
   #ifdef COSMOLOGY
   attribute_id = H5Acreate(file_id, "H0", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &Cosmo.H0);
@@ -559,6 +566,17 @@ void Grid3D::Write_Header_HDF5(hid_t file_id)
   status = H5Awrite(attribute_id, H5T_NATIVE_INT, int_data);
   status = H5Aclose(attribute_id);
 
+  #ifdef  MHD
+    for (size_t i = 0; i < 3; i++)
+    {
+      int_data[i]++;
+    }
+
+    attribute_id = H5Acreate(file_id, "magnetic_field_dims", H5T_STD_I32BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+    status = H5Awrite(attribute_id, H5T_NATIVE_INT, int_data);
+    status = H5Aclose(attribute_id);
+  #endif  //MHD
+
   #ifdef MPI_CHOLLA
   int_data[0] = H.nx_real;
   int_data[1] = H.ny_real;
@@ -567,6 +585,16 @@ void Grid3D::Write_Header_HDF5(hid_t file_id)
   attribute_id = H5Acreate(file_id, "dims_local", H5T_STD_I32BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
   status = H5Awrite(attribute_id, H5T_NATIVE_INT, int_data);
   status = H5Aclose(attribute_id);
+
+  #ifdef  MHD
+    int_data[0] = H.nx_real + 1;
+    int_data[1] = H.ny_real + 1;
+    int_data[2] = H.nz_real + 1;
+
+    attribute_id = H5Acreate(file_id, "magnetic_field_dims_local", H5T_STD_I32BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+    status = H5Awrite(attribute_id, H5T_NATIVE_INT, int_data);
+    status = H5Aclose(attribute_id);
+  #endif  //MHD
 
   int_data[0] = nx_local_start;
   int_data[1] = ny_local_start;
@@ -794,7 +822,7 @@ void Grid3D::Write_Header_Rotated_HDF5(hid_t file_id)
   chprintf("Outputting rotation data with delta = %e, theta = %e, phi = %e, Lx = %f, Lz = %f\n",R.delta,R.theta,R.phi,R.Lx,R.Lz);
 
 }
-#endif
+#endif  //HDF5
 
 /*! \fn void Write_Grid_Text(FILE *fp)
  *  \brief Write the conserved quantities to a text output file. */
@@ -807,6 +835,9 @@ void Grid3D::Write_Grid_Text(FILE *fp)
   // 1D case
   if (H.nx>1 && H.ny==1 && H.nz==1) {
     fprintf(fp, "id\trho\tmx\tmy\tmz\tE");
+    #ifdef  MHD
+     fprintf(fp, "\tmagX\tmagY\tmagZ");
+    #endif  //MHD
     #ifdef DE
     fprintf(fp, "\tge");
     #endif
@@ -814,17 +845,32 @@ void Grid3D::Write_Grid_Text(FILE *fp)
     for (i=H.n_ghost; i < H.nx-H.n_ghost; i++) {
       id = i;
       fprintf(fp, "%d\t%f\t%f\t%f\t%f\t%f", i-H.n_ghost, C.density[id], C.momentum_x[id], C.momentum_y[id], C.momentum_z[id], C.Energy[id]);
+      #ifdef MHD
+        fprintf(fp, "\t%f\t%f\t%f", C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+      #endif  //MHD
       #ifdef DE
       fprintf(fp, "\t%f", C.GasEnergy[id]);
-      #endif
+      #endif  //DE
       fprintf(fp, "\n");
     }
+    #ifdef  MHD
+      // Save the last line of magnetic fields
+      id = H.nx-H.n_ghost;
+      fprintf(fp, "%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", id, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+      #ifdef DE
+        fprintf(fp, "\tNan");
+      #endif  //DE
+      fprintf(fp, "\n");
+    #endif  //MHD
   }
 
   // 2D case
   else if (H.nx>1 && H.ny>1 && H.nz==1) {
 
     fprintf(fp, "idx\tidy\trho\tmx\tmy\tmz\tE");
+    #ifdef  MHD
+     fprintf(fp, "\tmagX\tmagY\tmagZ");
+    #endif  //MHD
     #ifdef DE
     fprintf(fp, "\tge");
     #endif
@@ -833,17 +879,41 @@ void Grid3D::Write_Grid_Text(FILE *fp)
       for (j=H.n_ghost; j < H.ny-H.n_ghost; j++) {
         id = i + j*H.nx;
         fprintf(fp, "%d\t%d\t%f\t%f\t%f\t%f\t%f", i-H.n_ghost, j-H.n_ghost, C.density[id], C.momentum_x[id], C.momentum_y[id], C.momentum_z[id], C.Energy[id]);
+        #ifdef MHD
+          fprintf(fp, "\t%f\t%f\t%f", C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+        #endif  //MHD
         #ifdef DE
         fprintf(fp, "\t%f", C.GasEnergy[id]);
-        #endif
+        #endif  //DE
         fprintf(fp, "\n");
       }
+      #ifdef  MHD
+        // Save the last line of magnetic fields
+        id = i + (H.ny-H.n_ghost)*H.nx;
+        fprintf(fp, "%d\t%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", i-H.n_ghost, H.ny-2*H.n_ghost, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+        #ifdef DE
+          fprintf(fp, "\tNan");
+        #endif  //DE
+        fprintf(fp, "\n");
+      #endif  //MHD
     }
+    #ifdef  MHD
+      // Save the last line of magnetic fields
+      id = H.nx-H.n_ghost + (H.ny-H.n_ghost)*H.nx;
+      fprintf(fp, "%d\t%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", H.nx-2*H.n_ghost, H.ny-2*H.n_ghost, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+      #ifdef DE
+        fprintf(fp, "\tNan");
+      #endif  //DE
+      fprintf(fp, "\n");
+    #endif  //MHD
   }
 
   // 3D case
   else {
     fprintf(fp, "idx\tidy\tidz\trho\tmx\tmy\tmz\tE");
+    #ifdef  MHD
+     fprintf(fp, "\tmagX\tmagY\tmagZ");
+    #endif  //MHD
     #ifdef DE
     fprintf(fp, "\tge");
     #endif
@@ -853,13 +923,43 @@ void Grid3D::Write_Grid_Text(FILE *fp)
         for (k=H.n_ghost; k < H.nz-H.n_ghost; k++) {
           id = i + j*H.nx + k*H.nx*H.ny;
           fprintf(fp, "%d\t%d\t%d\t%f\t%f\t%f\t%f\t%f", i-H.n_ghost, j-H.n_ghost, k-H.n_ghost, C.density[id], C.momentum_x[id], C.momentum_y[id], C.momentum_z[id], C.Energy[id]);
+          #ifdef MHD
+            fprintf(fp, "\t%f\t%f\t%f", C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+          #endif  //MHD
           #ifdef DE
           fprintf(fp, "\t%f", C.GasEnergy[id]);
-          #endif
+          #endif  //DE
           fprintf(fp, "\n");
         }
+        #ifdef  MHD
+          // Save the last line of magnetic fields
+          id = i + j*H.nx + (H.nz-H.n_ghost)*H.nx*H.ny;
+          fprintf(fp, "%d\t%d\t%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", i-H.n_ghost, j-H.n_ghost, H.nz-2*H.n_ghost, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+          #ifdef DE
+            fprintf(fp, "\tNan");
+          #endif  //DE
+          fprintf(fp, "\n");
+        #endif  //MHD
       }
+      #ifdef  MHD
+        // Save the last line of magnetic fields
+        id = i + (H.ny-H.n_ghost)*H.nx + (H.nz-H.n_ghost)*H.nx*H.ny;
+        fprintf(fp, "%d\t%d\t%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", i-H.n_ghost, H.ny-2*H.n_ghost, H.nz-2*H.n_ghost, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+        #ifdef DE
+          fprintf(fp, "\tNan");
+        #endif  //DE
+        fprintf(fp, "\n");
+      #endif  //MHD
     }
+    #ifdef  MHD
+      // Save the last line of magnetic fields
+      id = (H.nx-H.n_ghost) + (H.ny-H.n_ghost)*H.nx + (H.nz-H.n_ghost)*H.nx*H.ny;
+      fprintf(fp, "%d\t%d\t%d\tNan\tNan\tNan\tNan\tNan\t%f\t%f\t%f", H.nx-2*H.n_ghost, H.ny-2*H.n_ghost, H.nz-2*H.n_ghost, C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+      #ifdef DE
+        fprintf(fp, "\tNan");
+      #endif  //DE
+      fprintf(fp, "\n");
+    #endif  //MHD
   }
 
 }
@@ -975,49 +1075,57 @@ void Grid3D::Write_Grid_Binary(FILE *fp)
 void Grid3D::Write_Grid_HDF5(hid_t file_id)
 {
   int i, j, k, id, buf_id;
-  hid_t     dataset_id, dataspace_id; 
-  hid_t     dataset_id_full, dataspace_id_full; 
+  hid_t     dataset_id, dataspace_id;
+  hid_t     dataset_id_full, dataspace_id_full;
   Real      *dataset_buffer;
   herr_t    status;
 
   bool output_energy;
   bool output_momentum;
+  bool output_magnetic;
 
   #ifdef OUTPUT_ENERGY
   output_energy = true;
-  #else
+  #else  // not OUTPUT_ENERGY
   output_energy = false;
-  #endif
+  #endif  //OUTPUT_ENERGY
 
   #ifdef OUTPUT_MOMENTUM
   output_momentum = true;
-  #else
+  #else  // not OUTPUT_MOMENTUM
   output_momentum = false;
-  #endif
-  
+  #endif  //OUTPUT_MOMENTUM
+
+  #ifdef OUTPUT_MAGNETIC
+    output_magnetic = true;
+  #else
+    output_magnetic = false;
+  #endif // OUTPUT_MAGNETIC
+
   #if defined(COOLING_GRACKLE) || defined(CHEMISTRY_GPU)
+
   bool output_metals, output_electrons, output_full_ionization;
   #ifdef OUTPUT_METALS
   output_metals = true;
-  #else
+  #else  // not OUTPUT_METALS
   output_metals = false;
-  #endif
+  #endif  //OUTPUT_METALS
   #ifdef OUTPUT_ELECTRONS
   output_electrons = true;
-  #else
+  #else  // not OUTPUT_ELECTRONS
   output_electrons = false;
-  #endif
+  #endif  //OUTPUT_ELECTRONS
   #ifdef OUTPUT_FULL_IONIZATION
   output_full_ionization = true;
-  #else
+  #else  // not OUTPUT_FULL_IONIZATION
   output_full_ionization = false;
-  #endif
+  #endif  //OUTPUT_FULL_IONIZATION
 
   #endif //COOLING_GRACKLE
 
   #if defined(GRAVITY_GPU) && defined(OUTPUT_POTENTIAL)
   CudaSafeCall( cudaMemcpy(Grav.F.potential_h, Grav.F.potential_d, Grav.n_cells_potential*sizeof(Real), cudaMemcpyDeviceToHost) );
-  #endif//GRAVITY_GPU
+  #endif//GRAVITY_GPU and OUTPUT_POTENTIAL
 
 
 
@@ -1107,7 +1215,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
       // Free the dataset id
       status = H5Dclose(dataset_id);
     }
-    #endif
+    #endif  //SCALAR
 
     #ifdef DE
     // Copy the internal energy array to the memory buffer
@@ -1120,7 +1228,48 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
     status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     // Free the dataset id
     status = H5Dclose(dataset_id);
-    #endif
+    #endif  //DE
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.nx_real+1)*sizeof(Real));
+
+      // Create the data space for the datasets
+      dims[0]++;
+      dataspace_id = H5Screate_simple(1, dims, NULL);
+
+      // Copy the x magnetic field array to the memory buffer
+      memcpy(&dataset_buffer[0], &(C.magnetic_x[H.n_ghost]), (H.nx_real+1)*sizeof(Real));
+
+      // Create a dataset id for x magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the x magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the y magnetic field array to the memory buffer
+      memcpy(&dataset_buffer[0], &(C.magnetic_y[H.n_ghost]), (H.nx_real+1)*sizeof(Real));
+
+      // Create a dataset id for y magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the y magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the x magnetic field array to the memory buffer
+      memcpy(&dataset_buffer[0], &(C.magnetic_z[H.n_ghost]), (H.nx_real+1)*sizeof(Real));
+
+      // Create a dataset id for z magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the z magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+    #endif  //MHD
 
     // Free the dataspace id
     status = H5Sclose(dataspace_id);
@@ -1243,7 +1392,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
       // Free the dataset id
       status = H5Dclose(dataset_id);
     }
-    #endif
+    #endif  //SCALAR
 
 
     #ifdef DE
@@ -1262,7 +1411,64 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
     status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     // Free the dataset id
     status = H5Dclose(dataset_id);
-    #endif
+    #endif  //DE
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.ny_real+1)*(H.nx_real+1)*sizeof(Real));
+
+      // Create the data space for the datasets
+      dims[0]++;
+      dims[1]++;
+      dataspace_id = H5Screate_simple(2, dims, NULL);
+
+      // Copy the x magnetic array to the memory buffer
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*(H.ny_real+1);
+          dataset_buffer[buf_id] = C.magnetic_x[id];
+        }
+      }
+      // Create a dataset id for x magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the x magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the y magnetic array to the memory buffer
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*(H.ny_real+1);
+          dataset_buffer[buf_id] = C.magnetic_y[id];
+        }
+      }
+      // Create a dataset id for y magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the y magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the z magnetic array to the memory buffer
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*(H.ny_real+1);
+          dataset_buffer[buf_id] = C.magnetic_z[id];
+        }
+      }
+      // Create a dataset id for z magnetic field
+      dataset_id = H5Dcreate(file_id, "/magnetic_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      // Write the z magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+    #endif  //MHD
 
     // Free the dataspace id
     status = H5Sclose(dataspace_id);
@@ -1406,7 +1612,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
       // Free the dataset id
       status = H5Dclose(dataset_id);
     }
-    #else // Write Chemistry when using GRACKLE
+    #else // COOLING_GRACKLE or CHEMISTRY_GPU. Write Chemistry when using GRACKLE
     #ifdef OUTPUT_CHEMISTRY
     for (k=0; k<H.nz_real; k++) {
       for (j=0; j<H.ny_real; j++) {
@@ -1415,10 +1621,10 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.HI_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.HI_density[id];
-          #endif
+          #endif  //CHEMISTRY_GPU
         }
       }
     }
@@ -1433,11 +1639,11 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.HII_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.HII_density[id];
-          #endif
-          
+          #endif  //CHEMISTRY_GPU
+
         }
       }
     }
@@ -1454,10 +1660,10 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.HeI_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.HeI_density[id];
-          #endif
+          #endif  //CHEMISTRY_GPU
         }
       }
     }
@@ -1473,17 +1679,17 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.HeII_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.HeII_density[id];
-          #endif
+          #endif  //CHEMISTRY_GPU
         }
       }
     }
     dataset_id = H5Dcreate(file_id, "/HeII_density", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status = H5Dclose(dataset_id);
-  
+
     for (k=0; k<H.nz_real; k++) {
       for (j=0; j<H.ny_real; j++) {
         for (i=0; i<H.nx_real; i++) {
@@ -1491,10 +1697,10 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.HeIII_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.HeIII_density[id];
-          #endif
+          #endif  //CHEMISTRY_GPU
         }
       }
     }
@@ -1509,10 +1715,10 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
           #ifdef COOLING_GRACKLE
           dataset_buffer[buf_id] = Cool.fields.e_density[id];
-          #endif
+          #endif  //COOLING_GRACKLE
           #ifdef CHEMISTRY_GPU
           dataset_buffer[buf_id] = C.e_density[id];
-          #endif
+          #endif  //CHEMISTRY_GPU
         }
       }
     }
@@ -1543,11 +1749,11 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
     #endif //OUTPUT_CHEMISTRY
 
     #ifdef OUTPUT_TEMPERATURE
-    
-    #ifdef CHEMISTRY_GPU 
-    Compute_Gas_Temperature( Chem.Fields.temperature_h, false ); 
-    #endif
-    
+
+    #ifdef CHEMISTRY_GPU
+    Compute_Gas_Temperature( Chem.Fields.temperature_h, false );
+    #endif  //CHEMISTRY_GPU
+
     // Copy the internal energy array to the memory buffer
     for (k=0; k<H.nz_real; k++) {
       for (j=0; j<H.ny_real; j++) {
@@ -1569,7 +1775,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
     status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     // Free the dataset id
     status = H5Dclose(dataset_id);
-    
+
     #endif //OUTPUT_TEMPERATURE
 
     #endif //COOLING_GRACKLE
@@ -1594,7 +1800,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
       // Free the dataset id
       status = H5Dclose(dataset_id);
     }
-    #endif
+    #endif  //DE
 
     #if defined(GRAVITY) && defined(OUTPUT_POTENTIAL)
     // Copy the potential array to the memory buffer
@@ -1615,11 +1821,80 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
     status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     // Free the dataset id
     status = H5Dclose(dataset_id);
-    #endif//GRAVITY
+    #endif//GRAVITY and OUTPUT_POTENTIAL
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.nx_real+1)*(H.ny_real+1)*(H.nz_real+1)*sizeof(Real));
+
+      // Create the data space for the datasets
+      dims[0]++;
+      dims[1]++;
+      dims[2]++;
+      dataspace_id = H5Screate_simple(3, dims, NULL);
+
+      // Copy the x magnetic field array to the memory buffer
+      for (k=0; k<H.nz_real+1; k++) {
+        for (j=0; j<H.ny_real+1; j++) {
+          for (i=0; i<H.nx_real+1; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*(H.nz_real+1) + i*(H.nz_real+1)*(H.ny_real+1);
+            dataset_buffer[buf_id] = C.magnetic_x[id];
+          }
+        }
+      }
+      if ( output_magnetic || H.Output_Complete_Data ){
+        // Create a dataset id for x magnetic field
+        dataset_id = H5Dcreate(file_id, "/magnetic_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        // Write the x magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+        status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+        // Free the dataset id
+        status = H5Dclose(dataset_id);
+      }
+
+      // Copy the y magnetic field array to the memory buffer
+      for (k=0; k<H.nz_real+1; k++) {
+        for (j=0; j<H.ny_real+1; j++) {
+          for (i=0; i<H.nx_real+1; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*(H.nz_real+1) + i*(H.nz_real+1)*(H.ny_real+1);
+            dataset_buffer[buf_id] = C.magnetic_y[id];
+          }
+        }
+      }
+      if ( output_magnetic || H.Output_Complete_Data ){
+        // Create a dataset id for y magnetic field
+        dataset_id = H5Dcreate(file_id, "/magnetic_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        // Write the y magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+        status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+        // Free the dataset id
+        status = H5Dclose(dataset_id);
+      }
+
+      // Copy the z magnetic field array to the memory buffer
+      for (k=0; k<H.nz_real+1; k++) {
+        for (j=0; j<H.ny_real+1; j++) {
+          for (i=0; i<H.nx_real+1; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*(H.nz_real+1) + i*(H.nz_real+1)*(H.ny_real+1);
+            dataset_buffer[buf_id] = C.magnetic_z[id];
+          }
+        }
+      }
+      if ( output_magnetic || H.Output_Complete_Data ){
+        // Create a dataset id for z magnetic field
+        dataset_id = H5Dcreate(file_id, "/magnetic_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        // Write the z magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+        status = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+        // Free the dataset id
+        status = H5Dclose(dataset_id);
+      }
+    #endif  //MHD
 
     // Free the dataspace id
     status = H5Sclose(dataspace_id);
-
   }
   free(dataset_buffer);
 
@@ -2335,15 +2610,15 @@ void Grid3D::Read_Grid(struct parameters P) {
   strcat(filename,".bin");
   #elif defined HDF5
   strcat(filename,".h5");
-  #endif
+  #endif  // BINARY or HDF5
   // for now assumes you will run on the same number of processors
   #ifdef MPI_CHOLLA
   #ifdef TILED_INITIAL_CONDITIONS
   sprintf(filename,"%sics_%dMpc_%d.h5", P.indir, (int) P.tile_length/1000, H.nx_real); //Everyone reads the same file
-  #else
+  #else  // TILED_INITIAL_CONDITIONS is not defined
   sprintf(filename,"%s.%d",filename,procID);
   #endif //TILED_INITIAL_CONDITIONS
-  #endif
+  #endif  //MPI_CHOLLA
 
   #if defined BINARY
   FILE *fp;
@@ -2376,7 +2651,7 @@ void Grid3D::Read_Grid(struct parameters P) {
 
   // close the file
   status = H5Fclose(file_id);
-  #endif
+  #endif  // BINARY or HDF5
 
 
 }
@@ -2624,7 +2899,7 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     // Copy the internal energy array to the grid
     id = H.n_ghost;
     memcpy(&(C.GasEnergy[id]), &dataset_buffer[0], H.nx_real*sizeof(Real));
-    #endif
+    #endif  //DE
 
     #ifdef SCALAR
     for (int s=0; s<NSCALARS; s++) {
@@ -2646,10 +2921,46 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
       id = H.n_ghost;
       memcpy(&(C.scalar[id + s*H.n_cells]), &dataset_buffer[0], H.nx_real*sizeof(Real));
     }
-    #endif
+    #endif  //SCALAR
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.nx_real+1)*sizeof(Real));
+
+      // Open the x magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_x", H5P_DEFAULT);
+      // Read the x magnetic field array into the dataset buffer // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the x magnetic field array to the grid
+      memcpy(&(C.magnetic_x[H.n_ghost]), &dataset_buffer[0], (H.nx_real+1)*sizeof(Real));
+
+      // Open the y magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_y", H5P_DEFAULT);
+      // Read the y magnetic field array into the dataset buffer // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the y magnetic field array to the grid
+      memcpy(&(C.magnetic_y[H.n_ghost]), &dataset_buffer[0], (H.nx_real+1)*sizeof(Real));
+
+      // Open the z magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_z", H5P_DEFAULT);
+      // Read the z magnetic field array into the dataset buffer // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the z magnetic field array to the grid
+      memcpy(&(C.magnetic_z[H.n_ghost]), &dataset_buffer[0], (H.nx_real+1)*sizeof(Real));
+    #endif  //MHD
 
   }
-
 
   // 2D case
   if (H.nx>1 && H.ny>1 && H.nz==1) {
@@ -2759,7 +3070,7 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
         C.GasEnergy[id] = dataset_buffer[buf_id];
       }
     }
-    #endif
+    #endif  //DE
 
 
     #ifdef SCALAR
@@ -2787,7 +3098,63 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
         }
       }
     }
-    #endif
+    #endif  //SCALAR
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.ny_real+1)*(H.nx_real+1)*sizeof(Real));
+
+      // Open the x magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_x", H5P_DEFAULT);
+      // Read the x magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the x magnetic field array to the grid
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*H.ny_real;
+          C.magnetic_x[id] = dataset_buffer[buf_id];
+        }
+      }
+
+      // Open the y magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_y", H5P_DEFAULT);
+      // Read the y magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the y magnetic field array to the grid
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*H.ny_real;
+          C.magnetic_y[id] = dataset_buffer[buf_id];
+        }
+      }
+
+      // Open the z magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_z", H5P_DEFAULT);
+      // Read the z magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      // Copy the z magnetic field array to the grid
+      for (j=0; j<H.ny_real+1; j++) {
+        for (i=0; i<H.nx_real+1; i++) {
+          id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx;
+          buf_id = j + i*H.ny_real;
+          C.magnetic_z[id] = dataset_buffer[buf_id];
+        }
+      }
+    #endif  //MHD
+
 
   }
 
@@ -2836,11 +3203,11 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     mean_l = mean_g;
     max_l = max_g;
     min_l = min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " Density  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3] \n", mean_l, min_l, max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
 
     // Open the x momentum dataset
@@ -2875,11 +3242,11 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     mean_l = mean_g;
     max_l = max_g;
     min_l = min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " abs(Momentum X)  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3 km s^-1] \n", mean_l, min_l, max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
     // Open the y momentum dataset
     dataset_id = H5Dopen(file_id, "/momentum_y", H5P_DEFAULT);
@@ -2913,11 +3280,11 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     mean_l = mean_g;
     max_l = max_g;
     min_l = min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " abs(Momentum Y)  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3 km s^-1] \n", mean_l, min_l, max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
 
     // Open the z momentum dataset
@@ -2952,11 +3319,11 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     mean_l = mean_g;
     max_l = max_g;
     min_l = min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " abs(Momentum Z)  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3 km s^-1] \n", mean_l, min_l, max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
 
     // Open the Energy dataset
@@ -2991,11 +3358,11 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     mean_l = mean_g;
     max_l = max_g;
     min_l = min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " Energy  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3 km^2 s^-2 ] \n", mean_l, min_l, max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
 
     #ifdef DE
@@ -3048,12 +3415,12 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     temp_mean_l = temp_mean_g;
     temp_max_l = temp_max_g;
     temp_min_l = temp_min_g;
-    #endif
+    #endif  //MPI_CHOLLA
 
     #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
     chprintf( " GasEnergy  Mean: %f   Min: %f   Max: %f      [ h^2 Msun kpc^-3 km^2 s^-2 ] \n", mean_l, min_l, max_l );
     chprintf( " Temperature  Mean: %f   Min: %f   Max: %f      [ K ] \n", temp_mean_l, temp_min_l, temp_max_l );
-    #endif
+    #endif  //PRINT_INITIAL_STATS and COSMOLOGY
 
     #endif//DE
 
@@ -3103,7 +3470,7 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
       chprintf( " Initial elect Fraction: %e \n", e_frac);
       #ifdef GRACKLE_METALS
       chprintf( " Initial metal Fraction: %e \n", metal_frac);
-      #endif
+      #endif  //GRACKEL_METALS
       for (k=0; k<H.nz_real; k++) {
         for (j=0; j<H.ny_real; j++) {
           for (i=0; i<H.nx_real; i++) {
@@ -3209,10 +3576,132 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
           }
         }
       }
-      #endif
+      #endif  //GRACKLE_METALS
     }
     #endif//COOLING_GRACKLE
     #endif//SCALAR
+
+    #ifdef  MHD
+      // Start by creating a dataspace and buffer that is large enough for the
+      // magnetic field since it's one larger than the rest
+      free(dataset_buffer);
+      dataset_buffer = (Real *) malloc((H.nz_real+1)*(H.ny_real+1)*(H.nx_real+1)*sizeof(Real));
+
+
+      // Open the x magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_x", H5P_DEFAULT);
+      // Read the x magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      mean_l = 0;
+      min_l = 1e65;
+      max_l = -1;
+      // Copy the x magnetic field array to the grid
+      for (k=0; k<H.nz_real; k++) {
+        for (j=0; j<H.ny_real; j++) {
+          for (i=0; i<H.nx_real; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
+            C.magnetic_x[id] = dataset_buffer[buf_id];
+            mean_l += fabs(C.magnetic_x[id]);
+            if ( fabs(C.magnetic_x[id]) > max_l ) max_l = fabs(C.magnetic_x[id]);
+            if ( fabs(C.magnetic_x[id]) < min_l ) min_l = fabs(C.magnetic_x[id]);
+          }
+        }
+      }
+      mean_l /= ( (H.nz_real+1) * (H.ny_real+1) * (H.nx_real+1) );
+
+      #if MPI_CHOLLA
+        mean_g = ReduceRealAvg( mean_l );
+        max_g = ReduceRealMax( max_l );
+        min_g = ReduceRealMin( min_l );
+        mean_l = mean_g;
+        max_l = max_g;
+        min_l = min_g;
+      #endif  //MPI_CHOLLA
+
+      #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
+        chprintf( " abs(Magnetic X)  Mean: %f   Min: %f   Max: %f      [ Msun^1/2 kpc^-1/2 s^-1] \n", mean_l, min_l, max_l );
+      #endif  //PRINT_INITIAL_STATS and COSMOLOGY
+
+      // Open the y magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_y", H5P_DEFAULT);
+      // Read the y magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      mean_l = 0;
+      min_l = 1e65;
+      max_l = -1;
+      // Copy the y magnetic field array to the grid
+      for (k=0; k<H.nz_real; k++) {
+        for (j=0; j<H.ny_real; j++) {
+          for (i=0; i<H.nx_real; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
+            C.magnetic_y[id] = dataset_buffer[buf_id];
+            mean_l += fabs(C.magnetic_y[id]);
+            if ( fabs(C.magnetic_y[id]) > max_l ) max_l = fabs(C.magnetic_y[id]);
+            if ( fabs(C.magnetic_y[id]) < min_l ) min_l = fabs(C.magnetic_y[id]);
+          }
+        }
+      }
+      mean_l /= ( (H.nz_real+1) * (H.ny_real+1) * (H.nx_real+1) );
+
+      #if MPI_CHOLLA
+        mean_g = ReduceRealAvg( mean_l );
+        max_g = ReduceRealMax( max_l );
+        min_g = ReduceRealMin( min_l );
+        mean_l = mean_g;
+        max_l = max_g;
+        min_l = min_g;
+      #endif  //MPI_CHOLLA
+
+      #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
+        chprintf( " abs(Magnetic Y)  Mean: %f   Min: %f   Max: %f      [ Msun^1/2 kpc^-1/2 s^-1] \n", mean_l, min_l, max_l );
+      #endif  //PRINT_INITIAL_STATS and COSMOLOGY
+
+      // Open the z magnetic field dataset
+      dataset_id = H5Dopen(file_id, "/magnetic_z", H5P_DEFAULT);
+      // Read the z magnetic field array into the dataset buffer  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
+      status = H5Dread(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
+      // Free the dataset id
+      status = H5Dclose(dataset_id);
+
+      mean_l = 0;
+      min_l = 1e65;
+      max_l = -1;
+      // Copy the z magnetic field array to the grid
+      for (k=0; k<H.nz_real; k++) {
+        for (j=0; j<H.ny_real; j++) {
+          for (i=0; i<H.nx_real; i++) {
+            id = (i+H.n_ghost) + (j+H.n_ghost)*H.nx + (k+H.n_ghost)*H.nx*H.ny;
+            buf_id = k + j*H.nz_real + i*H.nz_real*H.ny_real;
+            C.magnetic_z[id] = dataset_buffer[buf_id];
+            mean_l += fabs(C.magnetic_z[id]);
+            if ( fabs(C.magnetic_z[id]) > max_l ) max_l = fabs(C.magnetic_z[id]);
+            if ( fabs(C.magnetic_z[id]) < min_l ) min_l = fabs(C.magnetic_z[id]);
+          }
+        }
+      }
+      mean_l /= ( (H.nz_real+1) * (H.ny_real+1) * (H.nx_real+1) );
+
+      #if MPI_CHOLLA
+        mean_g = ReduceRealAvg( mean_l );
+        max_g = ReduceRealMax( max_l );
+        min_g = ReduceRealMin( min_l );
+        mean_l = mean_g;
+        max_l = max_g;
+        min_l = min_g;
+      #endif  //MPI_CHOLLA
+
+      #if defined(PRINT_INITIAL_STATS) && defined(COSMOLOGY)
+        chprintf( " abs(Magnetic Z)  Mean: %f   Min: %f   Max: %f      [ Msun^1/2 kpc^-1/2 s^-1] \n", mean_l, min_l, max_l );
+      #endif  //PRINT_INITIAL_STATS and COSMOLOGY
+    #endif  //MHD
   }
   free(dataset_buffer);
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -1082,7 +1082,6 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
 
   bool output_energy;
   bool output_momentum;
-  bool output_magnetic;
 
   #ifdef OUTPUT_ENERGY
   output_energy = true;
@@ -1096,14 +1095,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
   output_momentum = false;
   #endif  //OUTPUT_MOMENTUM
 
-  #ifdef OUTPUT_MAGNETIC
-    output_magnetic = true;
-  #else
-    output_magnetic = false;
-  #endif // OUTPUT_MAGNETIC
-
   #if defined(COOLING_GRACKLE) || defined(CHEMISTRY_GPU)
-
   bool output_metals, output_electrons, output_full_ionization;
   #ifdef OUTPUT_METALS
   output_metals = true;
@@ -1121,7 +1113,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
   output_full_ionization = false;
   #endif  //OUTPUT_FULL_IONIZATION
 
-  #endif //COOLING_GRACKLE
+  #endif // COOLING_GRACKLE or CHEMISTRY_GPU
 
   #if defined(GRAVITY_GPU) && defined(OUTPUT_POTENTIAL)
   CudaSafeCall( cudaMemcpy(Grav.F.potential_h, Grav.F.potential_d, Grav.n_cells_potential*sizeof(Real), cudaMemcpyDeviceToHost) );
@@ -1845,7 +1837,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           }
         }
       }
-      if ( output_magnetic || H.Output_Complete_Data ){
+      if ( H.Output_Complete_Data ){
         // Create a dataset id for x magnetic field
         dataset_id = H5Dcreate(file_id, "/magnetic_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         // Write the x magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
@@ -1864,7 +1856,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           }
         }
       }
-      if ( output_magnetic || H.Output_Complete_Data ){
+      if ( H.Output_Complete_Data ){
         // Create a dataset id for y magnetic field
         dataset_id = H5Dcreate(file_id, "/magnetic_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         // Write the y magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!
@@ -1883,7 +1875,7 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
           }
         }
       }
-      if ( output_magnetic || H.Output_Complete_Data ){
+      if ( H.Output_Complete_Data ){
         // Create a dataset id for z magnetic field
         dataset_id = H5Dcreate(file_id, "/magnetic_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
         // Write the z magnetic field array to file  // NOTE: NEED TO FIX FOR FLOAT REAL!!!

--- a/src/mpi/cuda_pack_buffers.h
+++ b/src/mpi/cuda_pack_buffers.h
@@ -1,0 +1,33 @@
+#ifdef CUDA
+#include "../utils/gpu.hpp"
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+
+
+
+
+__global__ void PackBuffers3DKernel(Real * buffer, Real * c_head, int isize, int jsize, int ksize, int nx, int ny, int idxoffset, int offset, int n_fields, int n_cells);
+
+void PackBuffers3D(Real * buffer, Real * c_head, int isize, int jsize, int ksize, int nx, int ny, int idxoffset, int offset, int n_fields, int n_cells);
+
+__global__ void UnpackBuffers3DKernel(Real * buffer, Real * c_head, int isize, int jsize, int ksize, int nx, int ny, int idxoffset, int offset, int n_fields, int n_cells);
+
+void UnpackBuffers3D(Real * buffer, Real * c_head, int isize, int jsize, int ksize, int nx, int ny, int idxoffset, int offset, int n_fields, int n_cells);
+
+void PackGhostCells(Real * c_head,
+		    int nx, int ny, int nz, int n_fields, int n_cells, int n_ghost, int flags[],
+		    int isize, int jsize, int ksize,
+		    int imin, int jmin, int kmin, int dir);
+
+__global__ void PackGhostCellsKernel(Real * c_head,
+				     int nx, int ny, int nz, int n_fields, int n_cells, int n_ghost,
+				     int f0, int f1, int f2, int f3, int f4, int f5,
+				     int isize, int jsize, int ksize,
+				     int imin, int jmin, int kmin, int dir);
+
+__device__ int SetBoundaryMapping(int ig, int jg, int kg, Real *a, int flags[],int nx, int ny, int nz, int n_ghost, int &magneticIdx);
+
+__device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *a, int &mr);
+
+
+#endif

--- a/src/riemann_solvers/hllc_cuda_tests.cu
+++ b/src/riemann_solvers/hllc_cuda_tests.cu
@@ -157,7 +157,7 @@
                                                                  ulpsDiff);
                 EXPECT_TRUE(areEqual)
                     << std::endl << customOutput << std::endl
-                    << "Difference in "                << fieldNames[i]   << std::endl
+                    << "There's a difference in "      << fieldNames[i]   << " Flux" << std::endl
                     << "The fiducial value is:       " << fiducialFlux[i] << std::endl
                     << "The test value is:           " << testFlux[i]     << std::endl
                     << "The absolute difference is:  " << absoluteDiff    << std::endl

--- a/src/riemann_solvers/hlld_cuda.cu
+++ b/src/riemann_solvers/hlld_cuda.cu
@@ -1,0 +1,915 @@
+/*!
+ * \file hlld_cuda.cu
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the implementation of the HLLD solver
+ *
+*/
+
+// External Includes
+
+// Local Includes
+#include "../utils/gpu.hpp"
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+#include "../utils/mhd_utilities.h"
+#include "../riemann_solvers/hlld_cuda.h"
+
+#ifdef DE //PRESSURE_DE
+    #include "../hydro/hydro_cuda.h"
+#endif // DE
+
+#ifdef CUDA
+    // =========================================================================
+    __global__ void Calculate_HLLD_Fluxes_CUDA(Real *dev_bounds_L,
+                                               Real *dev_bounds_R,
+                                               Real *dev_flux,
+                                               int nx,
+                                               int ny,
+                                               int nz,
+                                               int n_ghost,
+                                               Real gamma,
+                                               int direction,
+                                               int n_fields)
+    {
+        // get a thread index
+        int blockId  = blockIdx.x + blockIdx.y*gridDim.x;
+        int threadId = threadIdx.x + blockId * blockDim.x;
+        int zid = threadId / (nx*ny);
+        int yid = (threadId - zid*nx*ny) / nx;
+        int xid = threadId - zid*nx*ny - yid*nx;
+
+        // Number of cells
+        int n_cells = nx*ny*nz;
+
+        // Offsets & indices
+        int o1, o2, o3;
+        if (direction==0) {o1 = 1; o2 = 2; o3 = 3;}
+        if (direction==1) {o1 = 2; o2 = 3; o3 = 1;}
+        if (direction==2) {o1 = 3; o2 = 1; o3 = 2;}
+
+        // Thread guard to avoid overrun
+        if (xid < nx and yid < ny and zid < nz)
+        {
+            // ============================
+            // Retrieve conserved variables
+            // ============================
+            // Left interface
+            Real densityL   = dev_bounds_L[threadId];
+            Real momentumXL = dev_bounds_L[threadId + n_cells * o1];
+            Real momentumYL = dev_bounds_L[threadId + n_cells * o2];
+            Real momentumZL = dev_bounds_L[threadId + n_cells * o3];
+            Real energyL    = dev_bounds_L[threadId + n_cells * 4];
+            Real magneticXL = dev_bounds_L[threadId + n_cells * (o1 + 4 + NSCALARS)];
+            Real magneticYL = dev_bounds_L[threadId + n_cells * (o2 + 4 + NSCALARS)];
+            Real magneticZL = dev_bounds_L[threadId + n_cells * (o3 + 4 + NSCALARS)];
+
+            #ifdef SCALAR
+                Real scalarConservedL[NSCALARS];
+                for (int i=0; i<NSCALARS; i++)
+                {
+                    scalarConservedL[i] = dev_bounds_L[threadId + n_cells * (5+i)];
+                }
+            #endif // SCALAR
+            #ifdef DE
+                Real thermalEnergyConservedL = dev_bounds_L[threadId + n_cells * (n_fields-1)];
+            #endif // DE
+
+            // Right interface
+            Real densityR   = dev_bounds_R[threadId];
+            Real momentumXR = dev_bounds_R[threadId + n_cells * o1];
+            Real momentumYR = dev_bounds_R[threadId + n_cells * o2];
+            Real momentumZR = dev_bounds_R[threadId + n_cells * o3];
+            Real energyR    = dev_bounds_R[threadId + n_cells * 4];
+            Real magneticXR = dev_bounds_R[threadId + n_cells * (o1 + 4 + NSCALARS)];
+            Real magneticYR = dev_bounds_R[threadId + n_cells * (o2 + 4 + NSCALARS)];
+            Real magneticZR = dev_bounds_R[threadId + n_cells * (o3 + 4 + NSCALARS)];
+
+            #ifdef SCALAR
+                Real scalarConservedR[NSCALARS];
+                for (int i=0; i<NSCALARS; i++)
+                {
+                    scalarConservedR[i] = dev_bounds_R[threadId + n_cells * (5+i)];
+                }
+            #endif // SCALAR
+            #ifdef DE
+                Real thermalEnergyConservedR = dev_bounds_R[threadId + n_cells * (n_fields-1)];
+            #endif // DE
+
+            // Check for unphysical values
+            densityL = fmax(densityL, (Real) TINY_NUMBER);
+            densityR = fmax(densityR, (Real) TINY_NUMBER);
+            energyL  = fmax(energyL,  (Real) TINY_NUMBER);
+            energyR  = fmax(energyR,  (Real) TINY_NUMBER);
+
+            // ============================
+            // Compute primitive variables
+            // ============================
+            // Left interface
+            Real const velocityXL = momentumXL / densityL;
+            Real const velocityYL = momentumYL / densityL;
+            Real const velocityZL = momentumZL / densityL;
+
+            #ifdef DE //PRESSURE_DE
+                Real const energyKineticL = 0.5 * densityL
+                    * _hlldInternal::_dotProduct(velocityXL, velocityYL, velocityZL,
+                                                 velocityXL, velocityYL, velocityZL);
+
+                Real const energyMagneticL = 0.5
+                    * _hlldInternal::_dotProduct(magneticXL, magneticYL, magneticZL,
+                                                 magneticXL, magneticYL, magneticZL);
+
+                Real const gasPressureL   = fmax(Get_Pressure_From_DE(energyL,
+                                                                      energyL - energyKineticL - energyMagneticL,
+                                                                      thermalEnergyConservedL,
+                                                                      gamma),
+                                                 (Real) TINY_NUMBER);
+            #else
+                // Note that this function does the positive pressure check
+                // internally
+                Real const gasPressureL  = mhdUtils::computeGasPressure(energyL,
+                                                                        densityL,
+                                                                        momentumXL,
+                                                                        momentumYL,
+                                                                        momentumZL,
+                                                                        magneticXL,
+                                                                        magneticYL,
+                                                                        magneticZL,
+                                                                        gamma);
+            #endif //PRESSURE_DE
+
+            Real const totalPressureL = mhdUtils::computeTotalPressure(gasPressureL,
+                                                                       magneticXL,
+                                                                       magneticYL,
+                                                                       magneticZL);
+
+            // Right interface
+            Real const velocityXR = momentumXR / densityR;
+            Real const velocityYR = momentumYR / densityR;
+            Real const velocityZR = momentumZR / densityR;
+
+            #ifdef DE //PRESSURE_DE
+                Real const energyKineticR = 0.5 * densityR
+                    * _hlldInternal::_dotProduct(velocityXR, velocityYR, velocityZR,
+                                                 velocityXR, velocityYR, velocityZR);
+
+                Real const energyMagneticR = 0.5
+                    * _hlldInternal::_dotProduct(magneticXR, magneticYR, magneticZR,
+                                                 magneticXR, magneticYR, magneticZR);
+
+                Real const gasPressureR   = fmax(Get_Pressure_From_DE(energyR,
+                                                                      energyR - energyKineticR - energyMagneticR,
+                                                                      thermalEnergyConservedR,
+                                                                      gamma),
+                                                 (Real) TINY_NUMBER);
+            #else
+                // Note that this function does the positive pressure check
+                // internally
+                Real const gasPressureR  = mhdUtils::computeGasPressure(energyR,
+                                                                  densityR,
+                                                                  momentumXR,
+                                                                  momentumYR,
+                                                                  momentumZR,
+                                                                  magneticXR,
+                                                                  magneticYR,
+                                                                  magneticZR,
+                                                                  gamma);
+            #endif //PRESSURE_DE
+
+            Real const totalPressureR = mhdUtils::computeTotalPressure(gasPressureR,
+                                                                 magneticXR,
+                                                                 magneticYR,
+                                                                 magneticZR);
+
+            // Compute the approximate wave speeds and density in the star
+            // regions
+            Real speedL, speedR, speedM, speedStarL, speedStarR, densityStarL, densityStarR;
+            _hlldInternal::_approximateWaveSpeeds(densityL,
+                                                  momentumXL,
+                                                  momentumYL,
+                                                  momentumZL,
+                                                  velocityXL,
+                                                  velocityYL,
+                                                  velocityZL,
+                                                  gasPressureL,
+                                                  totalPressureL,
+                                                  magneticXL,
+                                                  magneticYL,
+                                                  magneticZL,
+                                                  densityR,
+                                                  momentumXR,
+                                                  momentumYR,
+                                                  momentumZR,
+                                                  velocityXR,
+                                                  velocityYR,
+                                                  velocityZR,
+                                                  gasPressureR,
+                                                  totalPressureR,
+                                                  magneticXR,
+                                                  magneticYR,
+                                                  magneticZR,
+                                                  gamma,
+                                                  speedL,
+                                                  speedR,
+                                                  speedM,
+                                                  speedStarL,
+                                                  speedStarR,
+                                                  densityStarL,
+                                                  densityStarR);
+
+            // =================================================================
+            // Compute the fluxes in the non-star states
+            // =================================================================
+            // Left state
+            Real densityFluxL, momentumFluxXL, momentumFluxYL, momentumFluxZL,
+                 magneticFluxYL, magneticFluxZL, energyFluxL;
+            _hlldInternal::_nonStarFluxes(momentumXL,
+                                          velocityXL,
+                                          velocityYL,
+                                          velocityZL,
+                                          totalPressureL,
+                                          energyL,
+                                          magneticXL,
+                                          magneticYL,
+                                          magneticZL,
+                                          densityFluxL,
+                                          momentumFluxXL,
+                                          momentumFluxYL,
+                                          momentumFluxZL,
+                                          magneticFluxYL,
+                                          magneticFluxZL,
+                                          energyFluxL);
+
+            // If we're in the L state then assign fluxes and return.
+            // In this state the flow is supersonic
+            if (speedL >= 0.0)
+            {
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityFluxL,
+                                             momentumFluxXL, momentumFluxYL, momentumFluxZL,
+                                             energyFluxL,
+                                             magneticFluxYL, magneticFluxZL);
+                #ifdef SCALAR
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId]  = (scalarConservedL[i] / densityL) * densityFluxL;
+                    }
+                #endif  // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedL / densityL) * densityFluxL;
+                #endif  // DE
+                return;
+            }
+            // Right state
+            Real densityFluxR, momentumFluxXR, momentumFluxYR, momentumFluxZR,
+                 magneticFluxYR, magneticFluxZR, energyFluxR;
+            _hlldInternal::_nonStarFluxes(momentumXR,
+                                          velocityXR,
+                                          velocityYR,
+                                          velocityZR,
+                                          totalPressureR,
+                                          energyR,
+                                          magneticXR,
+                                          magneticYR,
+                                          magneticZR,
+                                          densityFluxR,
+                                          momentumFluxXR,
+                                          momentumFluxYR,
+                                          momentumFluxZR,
+                                          magneticFluxYR,
+                                          magneticFluxZR,
+                                          energyFluxR);
+
+            // If we're in the R state then assign fluxes and return.
+            // In this state the flow is supersonic
+            if (speedR <= 0.0)
+            {
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityFluxR,
+                                             momentumFluxXR, momentumFluxYR, momentumFluxZR,
+                                             energyFluxR,
+                                             magneticFluxYR, magneticFluxZR);
+                #ifdef SCALAR
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId]  = (scalarConservedR[i] / densityR) * densityFluxR;
+                    }
+                #endif  // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedR / densityR) * densityFluxR;
+                #endif  // DE
+                return;
+            }
+
+            // =================================================================
+            // Compute the fluxes in the star states
+            // =================================================================
+            // Shared quantity
+            // note that velocityStarX = speedM
+            Real totalPressureStar = totalPressureL + densityL
+                                                      * (speedL - velocityXL)
+                                                      * (speedM - velocityXL);
+
+            // Left star state
+            Real velocityStarYL, velocityStarZL,
+                 energyStarL, magneticStarYL, magneticStarZL,
+                 densityStarFluxL,
+                 momentumStarFluxXL, momentumStarFluxYL, momentumStarFluxZL,
+                 magneticStarFluxYL, magneticStarFluxZL, energyStarFluxL;
+            _hlldInternal::_starFluxes(speedM,
+                                       speedL,
+                                       densityL,
+                                       velocityXL,
+                                       velocityYL,
+                                       velocityZL,
+                                       momentumXL,
+                                       momentumYL,
+                                       momentumZL,
+                                       energyL,
+                                       totalPressureL,
+                                       magneticXL,
+                                       magneticYL,
+                                       magneticZL,
+                                       densityStarL,
+                                       totalPressureStar,
+                                       densityFluxL,
+                                       momentumFluxXL,
+                                       momentumFluxYL,
+                                       momentumFluxZL,
+                                       energyFluxL,
+                                       magneticFluxYL,
+                                       magneticFluxZL,
+                                       velocityStarYL,
+                                       velocityStarZL,
+                                       energyStarL,
+                                       magneticStarYL,
+                                       magneticStarZL,
+                                       densityStarFluxL,
+                                       momentumStarFluxXL,
+                                       momentumStarFluxYL,
+                                       momentumStarFluxZL,
+                                       energyStarFluxL,
+                                       magneticStarFluxYL,
+                                       magneticStarFluxZL);
+
+            // If we're in the L* state then assign fluxes and return.
+            // In this state the flow is subsonic
+            if (speedStarL >= 0.0)
+            {
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityStarFluxL,
+                                             momentumStarFluxXL, momentumStarFluxYL, momentumStarFluxZL,
+                                             energyStarFluxL,
+                                             magneticStarFluxYL, magneticStarFluxZL);
+                #ifdef SCALAR
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId] = (scalarConservedL[i] / densityL) * densityStarFluxL;
+                    }
+                #endif  // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedL / densityL) * densityStarFluxL;
+                #endif  // DE
+                return;
+            }
+
+            // Right star state
+            Real velocityStarYR, velocityStarZR,
+                 energyStarR, magneticStarYR, magneticStarZR,
+                 densityStarFluxR,
+                 momentumStarFluxXR, momentumStarFluxYR, momentumStarFluxZR,
+                 magneticStarFluxYR, magneticStarFluxZR, energyStarFluxR;
+            _hlldInternal::_starFluxes(speedM,
+                                       speedR,
+                                       densityR,
+                                       velocityXR,
+                                       velocityYR,
+                                       velocityZR,
+                                       momentumXR,
+                                       momentumYR,
+                                       momentumZR,
+                                       energyR,
+                                       totalPressureR,
+                                       magneticXR,
+                                       magneticYR,
+                                       magneticZR,
+                                       densityStarR,
+                                       totalPressureStar,
+                                       densityFluxR,
+                                       momentumFluxXR,
+                                       momentumFluxYR,
+                                       momentumFluxZR,
+                                       energyFluxR,
+                                       magneticFluxYR,
+                                       magneticFluxZR,
+                                       velocityStarYR,
+                                       velocityStarZR,
+                                       energyStarR,
+                                       magneticStarYR,
+                                       magneticStarZR,
+                                       densityStarFluxR,
+                                       momentumStarFluxXR,
+                                       momentumStarFluxYR,
+                                       momentumStarFluxZR,
+                                       energyStarFluxR,
+                                       magneticStarFluxYR,
+                                       magneticStarFluxZR);
+
+            // If we're in the R* state then assign fluxes and return.
+            // In this state the flow is subsonic
+            if (speedStarR <= 0.0)
+            {
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityStarFluxR,
+                                             momentumStarFluxXR, momentumStarFluxYR, momentumStarFluxZR,
+                                             energyStarFluxR,
+                                             magneticStarFluxYR, magneticStarFluxZR);
+                #ifdef SCALAR
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId] = (scalarConservedR[i] / densityR) * densityStarFluxR;
+                    }
+                #endif  // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedR / densityR) * densityStarFluxR;
+                #endif  // DE
+                return;
+            }
+
+            // =================================================================
+            // Compute the fluxes in the double star states
+            // =================================================================
+            Real velocityDoubleStarY, velocityDoubleStarZ,
+                 magneticDoubleStarY, magneticDoubleStarZ,
+                 energyDoubleStarL, energyDoubleStarR;
+            _hlldInternal::_doubleStarState(speedM,
+                                            magneticXL,
+                                            totalPressureStar,
+                                            densityStarL,
+                                            velocityStarYL,
+                                            velocityStarZL,
+                                            energyStarL,
+                                            magneticStarYL,
+                                            magneticStarZL,
+                                            densityStarR,
+                                            velocityStarYR,
+                                            velocityStarZR,
+                                            energyStarR,
+                                            magneticStarYR,
+                                            magneticStarZR,
+                                            velocityDoubleStarY,
+                                            velocityDoubleStarZ,
+                                            magneticDoubleStarY,
+                                            magneticDoubleStarZ,
+                                            energyDoubleStarL,
+                                            energyDoubleStarR);
+
+            // Compute and return L** fluxes
+            if (speedM >= 0.0)
+            {
+                Real momentumDoubleStarFluxX, momentumDoubleStarFluxY, momentumDoubleStarFluxZ,
+                     energyDoubleStarFlux,
+                     magneticDoubleStarFluxY, magneticDoubleStarFluxZ;
+                _hlldInternal::_doubleStarFluxes(speedStarL,
+                                                 momentumStarFluxXL,
+                                                 momentumStarFluxYL,
+                                                 momentumStarFluxZL,
+                                                 energyStarFluxL,
+                                                 magneticStarFluxYL,
+                                                 magneticStarFluxZL,
+                                                 densityStarL,
+                                                 speedM,
+                                                 velocityStarYL,
+                                                 velocityStarZL,
+                                                 energyStarL,
+                                                 magneticStarYL,
+                                                 magneticStarZL,
+                                                 speedM,
+                                                 velocityDoubleStarY,
+                                                 velocityDoubleStarZ,
+                                                 energyDoubleStarL,
+                                                 magneticDoubleStarY,
+                                                 magneticDoubleStarZ,
+                                                 momentumDoubleStarFluxX,
+                                                 momentumDoubleStarFluxY,
+                                                 momentumDoubleStarFluxZ,
+                                                 energyDoubleStarFlux,
+                                                 magneticDoubleStarFluxY,
+                                                 magneticDoubleStarFluxZ);
+
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityStarFluxL,
+                                             momentumDoubleStarFluxX, momentumDoubleStarFluxY, momentumDoubleStarFluxZ,
+                                             energyDoubleStarFlux,
+                                             magneticDoubleStarFluxY, magneticDoubleStarFluxZ);
+
+                #ifdef SCALAR
+                    // Return the passive scalar fluxes
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId] = (scalarConservedL[i] / densityL) * densityStarFluxL;
+                    }
+                #endif // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedL / densityL) * densityStarFluxL;
+                #endif  // DE
+                return;
+            }
+            // Compute and return R** fluxes
+            else if (speedStarR >= 0.0)
+            {
+                Real momentumDoubleStarFluxX, momentumDoubleStarFluxY, momentumDoubleStarFluxZ,
+                     energyDoubleStarFlux,
+                     magneticDoubleStarFluxY, magneticDoubleStarFluxZ;
+                _hlldInternal::_doubleStarFluxes(speedStarR,
+                                                 momentumStarFluxXR,
+                                                 momentumStarFluxYR,
+                                                 momentumStarFluxZR,
+                                                 energyStarFluxR,
+                                                 magneticStarFluxYR,
+                                                 magneticStarFluxZR,
+                                                 densityStarR,
+                                                 speedM,
+                                                 velocityStarYR,
+                                                 velocityStarZR,
+                                                 energyStarR,
+                                                 magneticStarYR,
+                                                 magneticStarZR,
+                                                 speedM,
+                                                 velocityDoubleStarY,
+                                                 velocityDoubleStarZ,
+                                                 energyDoubleStarR,
+                                                 magneticDoubleStarY,
+                                                 magneticDoubleStarZ,
+                                                 momentumDoubleStarFluxX,
+                                                 momentumDoubleStarFluxY,
+                                                 momentumDoubleStarFluxZ,
+                                                 energyDoubleStarFlux,
+                                                 magneticDoubleStarFluxY,
+                                                 magneticDoubleStarFluxZ);
+
+                _hlldInternal::_returnFluxes(threadId, o1, o2, o3, n_cells,
+                                             dev_flux,
+                                             densityStarFluxR,
+                                             momentumDoubleStarFluxX, momentumDoubleStarFluxY, momentumDoubleStarFluxZ,
+                                             energyDoubleStarFlux,
+                                             magneticDoubleStarFluxY, magneticDoubleStarFluxZ);
+
+                #ifdef SCALAR
+                    // Return the passive scalar fluxes
+                    for (int i=0; i<NSCALARS; i++)
+                    {
+                        dev_flux[(5+i)*n_cells+threadId] = (scalarConservedR[i] / densityR) * densityStarFluxR;
+                    }
+                #endif // SCALAR
+                #ifdef DE
+                    dev_flux[(n_fields-1)*n_cells+threadId]  = (thermalEnergyConservedR / densityR) * densityStarFluxR;
+                #endif  // DE
+                return;
+            }
+        } // End thread guard
+    };
+    // =========================================================================
+
+    namespace _hlldInternal
+    {
+        // =====================================================================
+        __device__ __host__ void _approximateWaveSpeeds(Real const &densityL,
+                                                        Real const &momentumXL,
+                                                        Real const &momentumYL,
+                                                        Real const &momentumZL,
+                                                        Real const &velocityXL,
+                                                        Real const &velocityYL,
+                                                        Real const &velocityZL,
+                                                        Real const &gasPressureL,
+                                                        Real const &totalPressureL,
+                                                        Real const &magneticXL,
+                                                        Real const &magneticYL,
+                                                        Real const &magneticZL,
+                                                        Real const &densityR,
+                                                        Real const &momentumXR,
+                                                        Real const &momentumYR,
+                                                        Real const &momentumZR,
+                                                        Real const &velocityXR,
+                                                        Real const &velocityYR,
+                                                        Real const &velocityZR,
+                                                        Real const &gasPressureR,
+                                                        Real const &totalPressureR,
+                                                        Real const &magneticXR,
+                                                        Real const &magneticYR,
+                                                        Real const &magneticZR,
+                                                        Real const &gamma,
+                                                        Real &speedL,
+                                                        Real &speedR,
+                                                        Real &speedM,
+                                                        Real &speedStarL,
+                                                        Real &speedStarR,
+                                                        Real &densityStarL,
+                                                        Real &densityStarR)
+        {
+            // Get the fast magnetosonic wave speeds
+            Real magSonicL = mhdUtils::fastMagnetosonicSpeed(densityL,
+                                                             gasPressureL,
+                                                             magneticXL,
+                                                             magneticYL,
+                                                             magneticZL,
+                                                             gamma);
+            Real magSonicR = mhdUtils::fastMagnetosonicSpeed(densityR,
+                                                             gasPressureR,
+                                                             magneticXR,
+                                                             magneticYR,
+                                                             magneticZR,
+                                                             gamma);
+
+            // Compute the S_L and S_R wave speeds.
+            // Version suggested by Miyoshi & Kusano 2005 and used in Athena
+            Real magSonicMax = fmax(magSonicL, magSonicR);
+            speedL = fmin(velocityXL, velocityXR) - magSonicMax;
+            speedR = fmax(velocityXL, velocityXR) + magSonicMax;
+
+            // Compute the S_M wave speed
+            speedM = // Numerator
+                          ( momentumXR * (speedR - velocityXR)
+                          - momentumXL * (speedL - velocityXL)
+                          + (totalPressureL - totalPressureR))
+                          /
+                          // Denominator
+                          ( densityR * (speedR - velocityXR)
+                          - densityL * (speedL - velocityXL));
+
+            // Compute the densities in the star state
+            densityStarL = densityL * (speedL - velocityXL) / (speedL - speedM);
+            densityStarR = densityR * (speedR - velocityXR) / (speedR - speedM);
+
+            // Compute the S_L^* and S_R^* wave speeds
+            speedStarL = speedM - mhdUtils::alfvenSpeed(magneticXL, densityStarL);
+            speedStarR = speedM + mhdUtils::alfvenSpeed(magneticXR, densityStarR);
+        }
+        // =====================================================================
+
+        // =====================================================================
+        __device__ __host__ void _nonStarFluxes(Real const &momentumX,
+                                                Real const &velocityX,
+                                                Real const &velocityY,
+                                                Real const &velocityZ,
+                                                Real const &totalPressure,
+                                                Real const &energy,
+                                                Real const &magneticX,
+                                                Real const &magneticY,
+                                                Real const &magneticZ,
+                                                Real &densityFlux,
+                                                Real &momentumFluxX,
+                                                Real &momentumFluxY,
+                                                Real &momentumFluxZ,
+                                                Real &magneticFluxY,
+                                                Real &magneticFluxZ,
+                                                Real &energyFlux)
+        {
+            densityFlux   = momentumX;
+
+            momentumFluxX = momentumX * velocityX + totalPressure - magneticX * magneticX;
+            momentumFluxY = momentumX * velocityY - magneticX * magneticY;
+            momentumFluxZ = momentumX * velocityZ - magneticX * magneticZ;
+
+            magneticFluxY = magneticY * velocityX - magneticX * velocityY;
+            magneticFluxZ = magneticZ * velocityX - magneticX * velocityZ;
+
+            // Group transverse terms for FP associative symmetry
+            energyFlux    = velocityX * (energy + totalPressure) - magneticX
+                            * (velocityX * magneticX
+                               + ((velocityY * magneticY)
+                               + (velocityZ * magneticZ)));
+        }
+        // =====================================================================
+
+        // =====================================================================
+        __device__ __host__  void _returnFluxes(int const &threadId,
+                                                int const &o1,
+                                                int const &o2,
+                                                int const &o3,
+                                                int const &n_cells,
+                                                Real *dev_flux,
+                                                Real const &densityFlux,
+                                                Real const &momentumFluxX,
+                                                Real const &momentumFluxY,
+                                                Real const &momentumFluxZ,
+                                                Real const &energyFlux,
+                                                Real const &magneticFluxY,
+                                                Real const &magneticFluxZ)
+        {
+            dev_flux[threadId]                                 = densityFlux;
+            dev_flux[threadId + n_cells * o1]                  = momentumFluxX;
+            dev_flux[threadId + n_cells * o2]                  = momentumFluxY;
+            dev_flux[threadId + n_cells * o3]                  = momentumFluxZ;
+            dev_flux[threadId + n_cells * 4]                   = energyFlux;
+            dev_flux[threadId + n_cells * (o2 + 4 + NSCALARS)] = magneticFluxY;
+            dev_flux[threadId + n_cells * (o3 + 4 + NSCALARS)] = magneticFluxZ;
+        }
+        // =====================================================================
+
+        // =====================================================================
+        __device__ __host__ void _starFluxes(Real const &speedM,
+                                             Real const &speedSide,
+                                             Real const &density,
+                                             Real const &velocityX,
+                                             Real const &velocityY,
+                                             Real const &velocityZ,
+                                             Real const &momentumX,
+                                             Real const &momentumY,
+                                             Real const &momentumZ,
+                                             Real const &energy,
+                                             Real const &totalPressure,
+                                             Real const &magneticX,
+                                             Real const &magneticY,
+                                             Real const &magneticZ,
+                                             Real const &densityStar,
+                                             Real const &totalPressureStar,
+                                             Real const &densityFlux,
+                                             Real const &momentumFluxX,
+                                             Real const &momentumFluxY,
+                                             Real const &momentumFluxZ,
+                                             Real const &energyFlux,
+                                             Real const &magneticFluxY,
+                                             Real const &magneticFluxZ,
+                                             Real &velocityStarY,
+                                             Real &velocityStarZ,
+                                             Real &energyStar,
+                                             Real &magneticStarY,
+                                             Real &magneticStarZ,
+                                             Real &densityStarFlux,
+                                             Real &momentumStarFluxX,
+                                             Real &momentumStarFluxY,
+                                             Real &momentumStarFluxZ,
+                                             Real &energyStarFlux,
+                                             Real &magneticStarFluxY,
+                                             Real &magneticStarFluxZ)
+        {
+            // Check for and handle the degenerate case
+            if (fabs(density * (speedSide - velocityX)
+                             * (speedSide - speedM)
+                             - (magneticX * magneticX))
+                < totalPressureStar * _hlldInternal::_hlldSmallNumber)
+            {
+                velocityStarY = velocityY;
+                velocityStarZ = velocityZ;
+                magneticStarY = magneticY;
+                magneticStarZ = magneticZ;
+            }
+            else
+            {
+                Real const denom = density * (speedSide - velocityX)
+                                           * (speedSide - speedM)
+                                           - (magneticX * magneticX);
+
+                // Compute the velocity and magnetic field in the star state
+                Real coef     = magneticX  * (speedM - velocityX) / denom;
+                velocityStarY = velocityY - magneticY * coef;
+                velocityStarZ = velocityZ - magneticZ * coef;
+
+                Real tmpPower = (speedSide - velocityX);
+                tmpPower = tmpPower * tmpPower;
+                coef = (density * tmpPower - (magneticX * magneticX)) / denom;
+                magneticStarY = magneticY * coef;
+                magneticStarZ = magneticZ * coef;
+            }
+
+            energyStar = ( energy * (speedSide - velocityX)
+                        - totalPressure * velocityX
+                        + totalPressureStar * speedM
+                        + magneticX * (_hlldInternal::_dotProduct(velocityX, velocityY, velocityZ, magneticX, magneticY, magneticZ)
+                                     - _hlldInternal::_dotProduct(speedM, velocityStarY, velocityStarZ, magneticX, magneticStarY, magneticStarZ)))
+                        / (speedSide - speedM);
+
+            // Now compute the star state fluxes
+            densityStarFlux   = densityFlux   + speedSide * (densityStar - density);;
+            momentumStarFluxX = momentumFluxX + speedSide * (densityStar * speedM - momentumX);;
+            momentumStarFluxY = momentumFluxY + speedSide * (densityStar * velocityStarY - momentumY);;
+            momentumStarFluxZ = momentumFluxZ + speedSide * (densityStar * velocityStarZ - momentumZ);;
+            energyStarFlux    = energyFlux    + speedSide * (energyStar  - energy);
+            magneticStarFluxY = magneticFluxY + speedSide * (magneticStarY - magneticY);
+            magneticStarFluxZ = magneticFluxZ + speedSide * (magneticStarZ - magneticZ);
+        }
+        // =====================================================================
+
+        // =====================================================================
+        __device__ __host__ void _doubleStarState(Real const &speedM,
+                                                  Real const &magneticX,
+                                                  Real const &totalPressureStar,
+                                                  Real const &densityStarL,
+                                                  Real const &velocityStarYL,
+                                                  Real const &velocityStarZL,
+                                                  Real const &energyStarL,
+                                                  Real const &magneticStarYL,
+                                                  Real const &magneticStarZL,
+                                                  Real const &densityStarR,
+                                                  Real const &velocityStarYR,
+                                                  Real const &velocityStarZR,
+                                                  Real const &energyStarR,
+                                                  Real const &magneticStarYR,
+                                                  Real const &magneticStarZR,
+                                                  Real &velocityDoubleStarY,
+                                                  Real &velocityDoubleStarZ,
+                                                  Real &magneticDoubleStarY,
+                                                  Real &magneticDoubleStarZ,
+                                                  Real &energyDoubleStarL,
+                                                  Real &energyDoubleStarR)
+        {
+            // if Bx is zero then just return the star state
+            if (magneticX < _hlldInternal::_hlldSmallNumber * totalPressureStar)
+            {
+                velocityDoubleStarY = velocityStarYL;
+                velocityDoubleStarZ = velocityStarZL;
+                magneticDoubleStarY = magneticStarYL;
+                magneticDoubleStarZ = magneticStarZL;
+                energyDoubleStarL    = energyStarL;
+                energyDoubleStarR    = energyStarR;
+            }
+            else
+            {
+                // Setup some variables we'll need later
+                Real sqrtDL = sqrt(densityStarL);
+                Real sqrtDR = sqrt(densityStarR);
+                Real inverseDensities = 1.0 / (sqrtDL + sqrtDR);
+                Real magXSign = copysign(1.0, magneticX);
+
+                // All we need to do now is compute the transverse velocities
+                // and magnetic fields along with the energy
+
+                // Double Star velocities
+                velocityDoubleStarY = inverseDensities * (sqrtDL * velocityStarYL
+                                      + sqrtDR * velocityStarYR
+                                      + magXSign * (magneticStarYR - magneticStarYL));
+                velocityDoubleStarZ = inverseDensities * (sqrtDL * velocityStarZL
+                                      + sqrtDR * velocityStarZR
+                                      + magXSign * (magneticStarZR - magneticStarZL));
+
+                // Double star magnetic fields
+                magneticDoubleStarY = inverseDensities * (sqrtDL * magneticStarYR
+                                      + sqrtDR * magneticStarYL
+                                      + magXSign * (sqrtDL * sqrtDR) * (velocityStarYR - velocityStarYL));
+                magneticDoubleStarZ = inverseDensities * (sqrtDL * magneticStarZR
+                                      + sqrtDR * magneticStarZL
+                                      + magXSign * (sqrtDL * sqrtDR) * (velocityStarZR - velocityStarZL));
+
+                // Double star energy
+                Real velDblStarDotMagDblStar = _hlldInternal::_dotProduct(speedM,
+                                                                          velocityDoubleStarY,
+                                                                          velocityDoubleStarZ,
+                                                                          magneticX,
+                                                                          magneticDoubleStarY,
+                                                                          magneticDoubleStarZ);
+                energyDoubleStarL = energyStarL - sqrtDL * magXSign
+                    * (_hlldInternal::_dotProduct(speedM, velocityStarYL, velocityStarZL, magneticX, magneticStarYL, magneticStarZL)
+                    - velDblStarDotMagDblStar);
+                energyDoubleStarR = energyStarR + sqrtDR * magXSign
+                    * (_hlldInternal::_dotProduct(speedM, velocityStarYR, velocityStarZR, magneticX, magneticStarYR, magneticStarZR)
+                    - velDblStarDotMagDblStar);
+            }
+        }
+        // =====================================================================
+
+        // =====================================================================
+        __device__ __host__ void _doubleStarFluxes(Real const &speedStarSide,
+                                                   Real const &momentumStarFluxX,
+                                                   Real const &momentumStarFluxY,
+                                                   Real const &momentumStarFluxZ,
+                                                   Real const &energyStarFlux,
+                                                   Real const &magneticStarFluxY,
+                                                   Real const &magneticStarFluxZ,
+                                                   Real const &densityStar,
+                                                   Real const &velocityStarX,
+                                                   Real const &velocityStarY,
+                                                   Real const &velocityStarZ,
+                                                   Real const &energyStar,
+                                                   Real const &magneticStarY,
+                                                   Real const &magneticStarZ,
+                                                   Real const &velocityDoubleStarX,
+                                                   Real const &velocityDoubleStarY,
+                                                   Real const &velocityDoubleStarZ,
+                                                   Real const &energyDoubleStar,
+                                                   Real const &magneticDoubleStarY,
+                                                   Real const &magneticDoubleStarZ,
+                                                   Real &momentumDoubleStarFluxX,
+                                                   Real &momentumDoubleStarFluxY,
+                                                   Real &momentumDoubleStarFluxZ,
+                                                   Real &energyDoubleStarFlux,
+                                                   Real &magneticDoubleStarFluxY,
+                                                   Real &magneticDoubleStarFluxZ)
+        {
+            momentumDoubleStarFluxX = momentumStarFluxX + speedStarSide * (velocityDoubleStarX - velocityStarX) * densityStar;
+            momentumDoubleStarFluxY = momentumStarFluxY + speedStarSide * (velocityDoubleStarY - velocityStarY) * densityStar;
+            momentumDoubleStarFluxZ = momentumStarFluxZ + speedStarSide * (velocityDoubleStarZ - velocityStarZ) * densityStar;
+            energyDoubleStarFlux    = energyStarFlux    + speedStarSide * (energyDoubleStar    - energyStar);
+            magneticDoubleStarFluxY = magneticStarFluxY + speedStarSide * (magneticDoubleStarY - magneticStarY);
+            magneticDoubleStarFluxZ = magneticStarFluxZ + speedStarSide * (magneticDoubleStarZ - magneticStarZ);
+        }
+        // =====================================================================
+
+    } // _hlldInternal namespace
+
+
+#endif // CUDA

--- a/src/riemann_solvers/hlld_cuda.h
+++ b/src/riemann_solvers/hlld_cuda.h
@@ -1,0 +1,395 @@
+/*!
+ * \file hlld_cuda.cu
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the declaration of the HLLD solver
+ *
+ */
+
+#pragma once
+
+// External Includes
+
+// Local Includes
+#include "../global/global.h"
+
+#ifdef CUDA
+
+    /*!
+     * \brief Compute the HLLD fluxes from Miyoshi & Kusano 2005
+     *
+     * \param[in]  dev_bounds_L
+     * \param[in]  dev_bounds_R
+     * \param[out] dev_flux
+     * \param[in]  nx
+     * \param[in]  ny
+     * \param[in]  nz
+     * \param[in]  n_ghost
+     * \param[in]  gamma
+     * \param[in]  dir
+     * \param[in]  n_fields
+     */
+    __global__ void Calculate_HLLD_Fluxes_CUDA(Real *dev_bounds_L,
+                                               Real *dev_bounds_R,
+                                               Real *dev_flux,
+                                               int nx,
+                                               int ny,
+                                               int nz,
+                                               int n_ghost,
+                                               Real gamma,
+                                               int direction,
+                                               int n_fields);
+
+    /*!
+     * \brief Namespace to hold private functions used within the HLLD
+     * solver
+     *
+     */
+    namespace _hlldInternal
+    {
+        /*!
+         * \brief Used for some comparisons. Value was chosen to match what is
+         * used in Athena
+         */
+        Real static const _hlldSmallNumber = 1.0e-8;
+
+        /*!
+         * \brief Compute the left, right, star, and middle wave speeds. Also
+         * returns the densities in the star states
+         *
+         * \param[in] densityL Density, left side
+         * \param[in] momentumXL Momentum in the X-direction, left side
+         * \param[in] momentumYL Momentum in the Y-direction, left side
+         * \param[in] momentumZL Momentum in the Z-direction, left side
+         * \param[in] velocityXL Velocity in the X-direction, left side
+         * \param[in] velocityYL Velocity in the Y-direction, left side
+         * \param[in] velocityZL Velocity in the Z-direction, left side
+         * \param[in] gasPressureL Gas pressure, left side
+         * \param[in] totalPressureL Total MHD pressure, left side
+         * \param[in] magneticXL Magnetic field in the X-direction, left side
+         * \param[in] magneticYL Magnetic field in the Y-direction, left side
+         * \param[in] magneticZL Magnetic field in the Z-direction, left side
+         * \param[in] densityR Density, right side
+         * \param[in] momentumXR Momentum in the X-direction, right side
+         * \param[in] momentumYR Momentum in the Y-direction, right side
+         * \param[in] momentumZR Momentum in the Z-direction, right side
+         * \param[in] velocityXR Velocity in the X-direction, right side
+         * \param[in] velocityYR Velocity in the Y-direction, right side
+         * \param[in] velocityZR Velocity in the Z-direction, right side
+         * \param[in] gasPressureR Gas pressure, right side
+         * \param[in] totalPressureR Total MHD pressure, right side
+         * \param[in] magneticXR Magnetic field in the X-direction, right side
+         * \param[in] magneticYR Magnetic field in the Y-direction, right side
+         * \param[in] magneticZR Magnetic field in the Z-direction, right side
+         * \param[in] gamma Adiabatic index
+         * \param[out] speedL Approximate speed of the left most wave
+         * \param[out] speedR Approximate speed of the right most wave
+         * \param[out] speedM Speed of the middle wave
+         * \param[out] speedStarL Speed of the left star state wave
+         * \param[out] speedStarR Speed of the right star state wave
+         * \param[out] densityStarL Density in left star region
+         * \param[out] densityStarR Density in right star region
+         */
+        __device__ __host__ void _approximateWaveSpeeds(Real const &densityL,
+                                                        Real const &momentumXL,
+                                                        Real const &momentumYL,
+                                                        Real const &momentumZL,
+                                                        Real const &velocityXL,
+                                                        Real const &velocityYL,
+                                                        Real const &velocityZL,
+                                                        Real const &gasPressureL,
+                                                        Real const &totalPressureL,
+                                                        Real const &magneticXL,
+                                                        Real const &magneticYL,
+                                                        Real const &magneticZL,
+                                                        Real const &densityR,
+                                                        Real const &momentumXR,
+                                                        Real const &momentumYR,
+                                                        Real const &momentumZR,
+                                                        Real const &velocityXR,
+                                                        Real const &velocityYR,
+                                                        Real const &velocityZR,
+                                                        Real const &gasPressureR,
+                                                        Real const &totalPressureR,
+                                                        Real const &magneticXR,
+                                                        Real const &magneticYR,
+                                                        Real const &magneticZR,
+                                                        Real const &gamma,
+                                                        Real &speedL,
+                                                        Real &speedR,
+                                                        Real &speedM,
+                                                        Real &speedStarL,
+                                                        Real &speedStarR,
+                                                        Real &densityStarL,
+                                                        Real &densityStarR);
+
+        /*!
+         * \brief Compute the fluxes in the left or right non-star state
+         *
+         * \param[in] momentumX Momentum in the X-direction
+         * \param[in] velocityX Velocity in the X-direction
+         * \param[in] velocityY Velocity in the Y-direction
+         * \param[in] velocityZ Velocity in the Z-direction
+         * \param[in] totalPressure Total MHD pressure
+         * \param[in] energy Energy
+         * \param[in] magneticX Magnetic field in -direction
+         * \param[in] magneticY Magnetic field in -direction
+         * \param[in] magneticZ Magnetic field in -direction
+         * \param[out] densityFlux The density flux
+         * \param[out] momentumFluxX The momentum flux in the X-direction
+         * \param[out] momentumFluxY The momentum flux in the Y-direction
+         * \param[out] momentumFluxZ The momentum flux in the Z-direction
+         * \param[out] magneticFluxY The magnetic field flux in the Y-direction
+         * \param[out] magneticFluxZ The magnetic field flux in the Z-direction
+         * \param[out] energyFlux The energy flux
+         */
+        __device__ __host__ void _nonStarFluxes(Real const &momentumX,
+                                                Real const &velocityX,
+                                                Real const &velocityY,
+                                                Real const &velocityZ,
+                                                Real const &totalPressure,
+                                                Real const &energy,
+                                                Real const &magneticX,
+                                                Real const &magneticY,
+                                                Real const &magneticZ,
+                                                Real &densityFlux,
+                                                Real &momentumFluxX,
+                                                Real &momentumFluxY,
+                                                Real &momentumFluxZ,
+                                                Real &magneticFluxY,
+                                                Real &magneticFluxZ,
+                                                Real &energyFlux);
+
+        /*!
+         * \brief Assign the given flux values to the dev_flux array
+         *
+         * \param[in] threadId The thread ID
+         * \param[in] o1 Offset to get indexing right
+         * \param[in] o2 Offset to get indexing right
+         * \param[in] o3 Offset to get indexing right
+         * \param[in] n_cells Number of cells
+         * \param[out] dev_flux The flux array
+         * \param[in] densityFlux The density flux
+         * \param[in] momentumFluxX The momentum flux in the X-direction
+         * \param[in] momentumFluxY The momentum flux in the Y-direction
+         * \param[in] momentumFluxZ The momentum flux in the Z-direction
+         * \param[in] magneticFluxY The magnetic field flux in the X-direction
+         * \param[in] magneticFluxZ The magnetic field flux in the Y-direction
+         * \param[in] energyFlux The energy flux
+         */
+        __device__ __host__ void _returnFluxes(int const &threadId,
+                                               int const &o1,
+                                               int const &o2,
+                                               int const &o3,
+                                               int const &n_cells,
+                                               Real *dev_flux,
+                                               Real const &densityFlux,
+                                               Real const &momentumFluxX,
+                                               Real const &momentumFluxY,
+                                               Real const &momentumFluxZ,
+                                               Real const &magneticFluxY,
+                                               Real const &magneticFluxZ,
+                                               Real const &energyFlux);
+
+        /*!
+         * \brief Compute the fluxes in the left or right star state
+         *
+         * \param[in] speedM Speed of the central wave
+         * \param[in] speedSide Speed of the non-star wave on the side being computed
+         * \param[in] density Density
+         * \param[in] velocityX Velocity in the X-direction
+         * \param[in] velocityY Velocity in the Y-direction
+         * \param[in] velocityZ Velocity in the Z-direction
+         * \param[in] momentumX Momentum in the X-direction
+         * \param[in] momentumY Momentum in the Y-direction
+         * \param[in] momentumZ Momentum in the Z-direction
+         * \param[in] energy Energy
+         * \param[in] totalPressure Total MHD pressure
+         * \param[in] magneticX Magnetic field in the X-direction
+         * \param[in] magneticY Magnetic field in the Y-direction
+         * \param[in] magneticZ Magnetic field in the Z-direction
+         * \param[in] densityStar Density in the star state
+         * \param[in] totalPressureStar Total MHD pressure in the star state
+         * \param[in] densityFlux Density Flux from the non-star state
+         * \param[in] momentumFluxX Momentum flux from the non-star state in the X-direction
+         * \param[in] momentumFluxY Momentum flux from the non-star state in the Y-direction
+         * \param[in] momentumFluxZ Momentum flux from the non-star state in the Z-direction
+         * \param[in] energyFlux Energy flux from the non-star state
+         * \param[in] magneticFluxY Magnetic flux from the non-star state in the X-direction
+         * \param[in] magneticFluxZ Magnetic flux from the non-star state in the Y-direction
+         * \param[out] velocityStarY Velocity in the star state in the Y-direction
+         * \param[out] velocityStarZ Velocity in the star state in the Z-direction
+         * \param[out] energyStar Energy in the star state
+         * \param[out] magneticStarY Magnetic field in the star state in the X-direction
+         * \param[out] magneticStarZ Magnetic field in the star state in the Y-direction
+         * \param[out] densityStarFlux Density flux in the star state
+         * \param[out] momentumStarFluxX Momentum flux in the star state in the X-direction
+         * \param[out] momentumStarFluxY Momentum flux in the star state in the Y-direction
+         * \param[out] momentumStarFluxZ Momentum flux in the star state in the Z-direction
+         * \param[out] energyStarFlux Energy flux in the star state
+         * \param[out] magneticStarFluxY Magnetic field flux in the star state in the X-direction
+         * \param[out] magneticStarFluxZ Magnetic field flux in the star state in the Y-direction
+         *
+         */
+        __device__ __host__ void _starFluxes(Real const &speedM,
+                                             Real const &speedSide,
+                                             Real const &density,
+                                             Real const &velocityX,
+                                             Real const &velocityY,
+                                             Real const &velocityZ,
+                                             Real const &momentumX,
+                                             Real const &momentumY,
+                                             Real const &momentumZ,
+                                             Real const &energy,
+                                             Real const &totalPressure,
+                                             Real const &magneticX,
+                                             Real const &magneticY,
+                                             Real const &magneticZ,
+                                             Real const &densityStar,
+                                             Real const &totalPressureStar,
+                                             Real const &densityFlux,
+                                             Real const &momentumFluxX,
+                                             Real const &momentumFluxY,
+                                             Real const &momentumFluxZ,
+                                             Real const &energyFlux,
+                                             Real const &magneticFluxY,
+                                             Real const &magneticFluxZ,
+                                             Real &velocityStarY,
+                                             Real &velocityStarZ,
+                                             Real &energyStar,
+                                             Real &magneticStarY,
+                                             Real &magneticStarZ,
+                                             Real &densityStarFlux,
+                                             Real &momentumStarFluxX,
+                                             Real &momentumStarFluxY,
+                                             Real &momentumStarFluxZ,
+                                             Real &energyStarFlux,
+                                             Real &magneticStarFluxY,
+                                             Real &magneticStarFluxZ);
+
+        /*!
+         * \brief Compute the dot product of a and b.
+         *
+         * \param[in] a1 The first element of a
+         * \param[in] a2 The second element of a
+         * \param[in] a3 The third element of a
+         * \param[in] b1 The first element of b
+         * \param[in] b2 The second element of b
+         * \param[in] b3 The third element of b
+         *
+         * \return Real The dot product of a and b
+         */
+        inline __device__ __host__ Real _dotProduct(Real const &a1,
+                                                    Real const &a2,
+                                                    Real const &a3,
+                                                    Real const &b1,
+                                                    Real const &b2,
+                                                    Real const &b3)
+        {return a1*b1 + ((a2*b2) + (a3*b3));};
+
+        /*!
+         * \brief Compute the double star state
+         *
+         * \param[in] speedM
+         * \param[in] magneticX
+         * \param[in] totalPressureStar
+         * \param[in] densityStarL
+         * \param[in] velocityStarYL
+         * \param[in] velocityStarZL
+         * \param[in] energyStarL
+         * \param[in] magneticStarYL
+         * \param[in] magneticStarZL
+         * \param[in] densityStarR
+         * \param[in] velocityStarYR
+         * \param[in] velocityStarZR
+         * \param[in] energyStarR
+         * \param[in] magneticStarYR
+         * \param[in] magneticStarZR
+         * \param[out] velocityDoubleStarY
+         * \param[out] velocityDoubleStarZ
+         * \param[out] magneticDoubleStarY
+         * \param[out] magneticDoubleStarZ
+         * \param[out] energyDoubleStarL
+         * \param[out] energyDoubleStarR
+         */
+        __device__ __host__ void _doubleStarState(Real const &speedM,
+                                                  Real const &magneticX,
+                                                  Real const &totalPressureStar,
+                                                  Real const &densityStarL,
+                                                  Real const &velocityStarYL,
+                                                  Real const &velocityStarZL,
+                                                  Real const &energyStarL,
+                                                  Real const &magneticStarYL,
+                                                  Real const &magneticStarZL,
+                                                  Real const &densityStarR,
+                                                  Real const &velocityStarYR,
+                                                  Real const &velocityStarZR,
+                                                  Real const &energyStarR,
+                                                  Real const &magneticStarYR,
+                                                  Real const &magneticStarZR,
+                                                  Real &velocityDoubleStarY,
+                                                  Real &velocityDoubleStarZ,
+                                                  Real &magneticDoubleStarY,
+                                                  Real &magneticDoubleStarZ,
+                                                  Real &energyDoubleStarL,
+                                                  Real &energyDoubleStarR);
+
+        /*!
+         * \brief Compute the double star state fluxes
+         *
+         * \param[in] speedStarSide The star speed on the side being computed
+         * \param[in] momentumStarFluxX
+         * \param[in] momentumStarFluxY
+         * \param[in] momentumStarFluxZ
+         * \param[in] energyStarFlux
+         * \param[in] magneticStarFluxY
+         * \param[in] magneticStarFluxZ
+         * \param[in] densityStar
+         * \param[in] velocityStarX
+         * \param[in] velocityStarY
+         * \param[in] velocityStarZ
+         * \param[in] energyStar
+         * \param[in] magneticStarY
+         * \param[in] magneticStarZ
+         * \param[in] velocityDoubleStarX
+         * \param[in] velocityDoubleStarY
+         * \param[in] velocityDoubleStarZ
+         * \param[in] energyDoubleStar
+         * \param[in] magneticDoubleStarY
+         * \param[in] magneticDoubleStarZ
+         * \param[out] momentumDoubleStarFluxX
+         * \param[out] momentumDoubleStarFluxY
+         * \param[out] momentumDoubleStarFluxZ
+         * \param[out] energyDoubleStarFlux
+         * \param[out] magneticDoubleStarFluxY
+         * \param[out] magneticDoubleStarFluxZ
+         */
+        __device__ __host__ void _doubleStarFluxes(Real const &speedStarSide,
+                                                   Real const &momentumStarFluxX,
+                                                   Real const &momentumStarFluxY,
+                                                   Real const &momentumStarFluxZ,
+                                                   Real const &energyStarFlux,
+                                                   Real const &magneticStarFluxY,
+                                                   Real const &magneticStarFluxZ,
+                                                   Real const &densityStar,
+                                                   Real const &velocityStarX,
+                                                   Real const &velocityStarY,
+                                                   Real const &velocityStarZ,
+                                                   Real const &energyStar,
+                                                   Real const &magneticStarY,
+                                                   Real const &magneticStarZ,
+                                                   Real const &velocityDoubleStarX,
+                                                   Real const &velocityDoubleStarY,
+                                                   Real const &velocityDoubleStarZ,
+                                                   Real const &energyDoubleStar,
+                                                   Real const &magneticDoubleStarY,
+                                                   Real const &magneticDoubleStarZ,
+                                                   Real &momentumDoubleStarFluxX,
+                                                   Real &momentumDoubleStarFluxY,
+                                                   Real &momentumDoubleStarFluxZ,
+                                                   Real &energyDoubleStarFlux,
+                                                   Real &magneticDoubleStarFluxY,
+                                                   Real &magneticDoubleStarFluxZ);
+
+    } // _hlldInternal namespace
+
+#endif //CUDA

--- a/src/riemann_solvers/hlld_cuda_tests.cu
+++ b/src/riemann_solvers/hlld_cuda_tests.cu
@@ -2268,6 +2268,8 @@
     {
         testParams const parameters;
 
+        double const fixedEpsilon = 7E-12;
+
         std::vector<double> const fiducialVelocityDoubleStarY{-1.5775383335759607, 3.803188977150934};
         std::vector<double> const fiducialVelocityDoubleStarZ{-3.4914062207842482, -4.2662645349592765};
         std::vector<double> const fiducialMagneticDoubleStarY{45.259313435283325, 71.787329583230417};
@@ -2324,7 +2326,8 @@
                                            parameters.names.at(i) + ", EnergyDoubleStarL");
             testingUtilities::checkResults(fiducialEnergyDoubleStarR[i],
                                            testEnergyDoubleStarR,
-                                           parameters.names.at(i) + ", EnergyDoubleStarR");
+                                           parameters.names.at(i) + ", EnergyDoubleStarR",
+                                           fixedEpsilon);
         }
     }
 

--- a/src/riemann_solvers/hlld_cuda_tests.cu
+++ b/src/riemann_solvers/hlld_cuda_tests.cu
@@ -1,0 +1,2578 @@
+/*!
+* \file hlld_cuda_tests.cpp
+* \author Robert 'Bob' Caddy (rvc@pitt.edu)
+* \brief Test the code units within hlld_cuda.cu
+*
+*/
+
+// STL Includes
+#include <cmath>
+#include <stdexcept>
+#include <algorithm>
+#include <valarray>
+
+// External Includes
+#include <gtest/gtest.h>    // Include GoogleTest and related libraries/headers
+
+// Local Includes
+#include "../global/global_cuda.h"
+#include "../utils/gpu.hpp"
+#include "../utils/testing_utilities.h"
+#include "../utils/mhd_utilities.h"
+#include "../riemann_solvers/hlld_cuda.h"   // Include code to test
+
+#if defined(CUDA) && defined(HLLD)
+    // =========================================================================
+    // Integration tests for the entire HLLD solver. Unit tests are below
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test fixture for simple testing of the HLLD Riemann Solver.
+    Effectively takes the left state, right state, fiducial fluxes, and
+    custom user output then performs all the required running and testing
+    *
+    */
+    class tMHDCalculateHLLDFluxesCUDA : public ::testing::Test
+    {
+    protected:
+        // =====================================================================
+        /*!
+        * \brief Compute and return the HLLD fluxes
+        *
+        * \param[in] leftState The state on the left side in conserved
+        * variables. In order the elements are: density, x-momentum,
+        * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+        * y-magnetic field, z-magnetic field.
+        * \param[in] rightState The state on the right side in conserved
+        * variables. In order the elements are: density, x-momentum,
+        * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+        * y-magnetic field, z-magnetic field.
+        * \param[in] gamma The adiabatic index
+        * \param[in] direction Which plane the interface is. 0 = plane normal to
+        * X, 1 = plane normal to Y, 2 = plane normal to Z. Defaults to 0.
+        * \return std::vector<double>
+        */
+        std::vector<Real> computeFluxes(std::vector<Real> stateLeft,
+                                        std::vector<Real> stateRight,
+                                        Real const &gamma,
+                                        int const &direction=0)
+        {
+
+            // Rearrange X, Y, and Z values if a different direction is chosen
+            // besides default
+            stateLeft  = _cycleXYZ(stateLeft, direction);
+            stateRight = _cycleXYZ(stateRight, direction);
+
+            // Simulation Paramters
+            int const nx        = 1;  // Number of cells in the x-direction?
+            int const ny        = 1;  // Number of cells in the y-direction?
+            int const nz        = 1;  // Number of cells in the z-direction?
+            int const nGhost    = 0;  // Isn't actually used it appears
+            int nFields         = 8;  // Total number of conserved fields
+            #ifdef  SCALAR
+                nFields += NSCALARS;
+            #endif  // SCALAR
+            #ifdef  DE
+                nFields++;
+            #endif  //DE
+
+            // Launch Parameters
+            dim3 const dimGrid (1,1,1);  // How many blocks in the grid
+            dim3 const dimBlock(1,1,1);  // How many threads per block
+
+            // Create the std::vector to store the fluxes and declare the device
+            // pointers
+            std::vector<Real> testFlux(nFields);
+            Real *devConservedLeft;
+            Real *devConservedRight;
+            Real *devTestFlux;
+
+            // Allocate device arrays and copy data
+            CudaSafeCall(cudaMalloc(&devConservedLeft,  nFields*sizeof(Real)));
+            CudaSafeCall(cudaMalloc(&devConservedRight, nFields*sizeof(Real)));
+            CudaSafeCall(cudaMalloc(&devTestFlux,       nFields*sizeof(Real)));
+
+            CudaSafeCall(cudaMemcpy(devConservedLeft,
+                         stateLeft.data(),
+                         nFields*sizeof(Real),
+                         cudaMemcpyHostToDevice));
+            CudaSafeCall(cudaMemcpy(devConservedRight,
+                         stateRight.data(),
+                         nFields*sizeof(Real),
+                         cudaMemcpyHostToDevice));
+
+            // Run kernel
+            hipLaunchKernelGGL(Calculate_HLLD_Fluxes_CUDA,
+                               dimGrid,
+                               dimBlock,
+                               0,
+                               0,
+                               devConservedLeft,   // the "left" interface
+                               devConservedRight,  // the "right" interface
+                               devTestFlux,
+                               nx,
+                               ny,
+                               nz,
+                               nGhost,
+                               gamma,
+                               direction,
+                               nFields);
+
+            CudaCheckError();
+            CudaSafeCall(cudaMemcpy(testFlux.data(),
+                                    devTestFlux,
+                                    nFields*sizeof(Real),
+                                    cudaMemcpyDeviceToHost));
+
+            // Make sure to sync with the device so we have the results
+            cudaDeviceSynchronize();
+            CudaCheckError();
+
+            return testFlux;
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+        * \brief Check if the fluxes are correct
+        *
+        * \param[in] fiducialFlux The fiducial flux in conserved variables. In
+        * order the elements are: density, x-momentum,
+        * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+        * y-magnetic field, z-magnetic field.
+        * \param[in] scalarFlux The fiducial flux in the passive scalars
+        * \param[in] thermalEnergyFlux The fiducial flux in the dual energy
+        * thermal energy
+        * \param[in] testFlux The test flux in conserved variables. In order the
+        * elements are: density, x-momentum,
+        * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+        * y-magnetic field, z-magnetic field.
+        * \param[in] customOutput Any custom output the user would like to
+        * print. It will print after the default GTest output but before the
+        * values that failed are printed
+        * \param[in] direction Which plane the interface is. 0 = plane normal to
+        * X, 1 = plane normal to Y, 2 = plane normal to Z. Defaults to 0.
+        */
+        void checkResults(std::vector<Real> fiducialFlux,
+                          std::vector<Real> scalarFlux,
+                          Real thermalEnergyFlux,
+                          std::vector<Real> const &testFlux,
+                          std::string const &customOutput = "",
+                          int const &direction=0)
+        {
+            // Field names
+            std::vector<std::string> fieldNames{"Densities",
+                                                "X Momentum",
+                                                "Y Momentum",
+                                                "Z Momentum",
+                                                "Energies",
+                                                "X Magnetic Field",
+                                                "Y Magnetic Field",
+                                                "Z Magnetic Field"};
+            #ifdef  DE
+                fieldNames.push_back("Thermal energy (dual energy)");
+                fiducialFlux.push_back(thermalEnergyFlux);
+            #endif  //DE
+            #ifdef  SCALAR
+                std::vector<std::string> scalarNames{"Scalar 1", "Scalar 2", "Scalar 3"};
+                fieldNames.insert(fieldNames.begin()+5,
+                                  scalarNames.begin(),
+                                  scalarNames.begin() + NSCALARS);
+
+                fiducialFlux.insert(fiducialFlux.begin()+5,
+                                    scalarFlux.begin(),
+                                    scalarFlux.begin() + NSCALARS);
+            #endif  //SCALAR
+
+            // Rearrange X, Y, and Z values if a different direction is chosen
+            // besides default
+            fiducialFlux = _cycleXYZ(fiducialFlux, direction);
+
+            ASSERT_TRUE(    (fiducialFlux.size() == testFlux.size())
+                        and (fiducialFlux.size() == fieldNames.size()))
+                << "The fiducial flux, test flux, and field name vectors are not all the same length" << std::endl
+                << "fiducialFlux.size() = " << fiducialFlux.size() << std::endl
+                << "testFlux.size() = "     << testFlux.size()     << std::endl
+                << "fieldNames.size() = "   << fieldNames.size()   << std::endl;
+
+            // Check for equality
+            for (size_t i = 0; i < fieldNames.size(); i++)
+            {
+                // Check for equality and if not equal return difference
+                double absoluteDiff;
+                int64_t ulpsDiff;
+
+                bool areEqual = testingUtilities::nearlyEqualDbl(fiducialFlux[i],
+                                                                 testFlux[i],
+                                                                 absoluteDiff,
+                                                                 ulpsDiff);
+                EXPECT_TRUE(areEqual)
+                    << std::endl << customOutput << std::endl
+                    << "There's a difference in "      << fieldNames[i]   << " Flux" << std::endl
+                    << "The direction is:       "      << direction       << " (0=X, 1=Y, 2=Z)" << std::endl
+                    << "The fiducial value is:       " << fiducialFlux[i] << std::endl
+                    << "The test value is:           " << testFlux[i]     << std::endl
+                    << "The absolute difference is:  " << absoluteDiff    << std::endl
+                    << "The ULP difference is:       " << ulpsDiff        << std::endl;
+            }
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+         * \brief Convert a vector of quantities in primitive variables  to
+         * conserved variables
+         *
+         * \param[in] input The state in primitive variables. In order the
+         * elements are: density, x-momentum,
+         * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+         * y-magnetic field, z-magnetic field.
+         * \return std::vector<Real> The state in conserved variables. In order
+         * the elements are: density, x-momentum,
+         * y-momentum, z-momentum, energy, passive scalars, x-magnetic field,
+         * y-magnetic field, z-magnetic field.
+         */
+        std::vector<Real> primitive2Conserved(std::vector<Real> const &input,
+                                              double const &gamma,
+                                              std::vector<Real> const &primitiveScalars)
+        {
+            std::vector<Real> output(input.size());
+            output.at(0) = input.at(0);  // Density
+            output.at(1) = input.at(1) * input.at(0);  // X Velocity to momentum
+            output.at(2) = input.at(2) * input.at(0);  // Y Velocity to momentum
+            output.at(3) = input.at(3) * input.at(0);  // Z Velocity to momentum
+            output.at(4) = mhdUtils::computeEnergy(input.at(4),
+                                                   input.at(0),
+                                                   input.at(1),
+                                                   input.at(2),
+                                                   input.at(3),
+                                                   input.at(5),
+                                                   input.at(6),
+                                                   input.at(7),
+                                                   gamma);  // Pressure to Energy
+            output.at(5) = input.at(5);  // X Magnetic Field
+            output.at(6) = input.at(6);  // Y Magnetic Field
+            output.at(7) = input.at(7);  // Z Magnetic Field
+
+            #ifdef SCALAR
+                std::vector<Real> conservedScalar(primitiveScalars.size());
+                std::transform(primitiveScalars.begin(),
+                               primitiveScalars.end(),
+                               conservedScalar.begin(),
+                               [&](Real const &c){ return c*output.at(0); });
+                output.insert(output.begin()+5,
+                              conservedScalar.begin(),
+                              conservedScalar.begin() + NSCALARS);
+            #endif //SCALAR
+            #ifdef  DE
+                output.push_back(mhdUtils::computeThermalEnergy(output.at(4),
+                                                                output.at(0),
+                                                                output.at(1),
+                                                                output.at(2),
+                                                                output.at(3),
+                                                                output.at(5 + NSCALARS),
+                                                                output.at(6 + NSCALARS),
+                                                                output.at(7 + NSCALARS),
+                                                                gamma));
+            #endif  //DE
+            return output;
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+         * \brief On test start make sure that the number of NSCALARS is allowed
+         *
+         */
+        void SetUp()
+        {
+            #ifdef  SCALAR
+                ASSERT_LE(NSCALARS, 3) << "Only up to 3 passive scalars are currently supported in HLLD tests. NSCALARS = " << NSCALARS;
+                ASSERT_GE(NSCALARS, 1) << "There must be at least 1 passive scalar to test with passive scalars. NSCALARS = " << NSCALARS;
+            #endif  //SCALAR
+        }
+        // =====================================================================
+    private:
+        // =====================================================================
+        /*!
+         * \brief Cyclically permute the vector quantities in the list of
+         * conserved variables so that the same interfaces and fluxes can be
+         * used to test the HLLD solver in all 3 directions.
+         *
+         * \param[in,out] conservedVec The std::vector of conserved variables to
+         * be cyclically permutated
+         * \param[in] direction Which plane the interface is. 0 = plane normal
+         * to X, 1 = plane normal to Y, 2 = plane normal to Z
+         *
+         * \return std::vector<Real> The cyclically permutated list of conserved
+         * variables
+         */
+        std::vector<Real> inline _cycleXYZ(std::vector<Real> conservedVec,
+                                           int const &direction)
+        {
+            switch (direction)
+            {
+            case 0:  // Plane normal to X. Default case, do nothing
+                ;
+                break;
+            case 1:  // Plane normal to Y
+            case 2:  // Plane normal to Z
+                // Fall through for both Y and Z normal planes
+                {
+                    size_t shift = 3 - direction;
+                    auto momentumBegin = conservedVec.begin()+1;
+                    auto magneticBegin = conservedVec.begin()+5;
+                    #ifdef  SCALAR
+                        magneticBegin += NSCALARS;
+                    #endif  //SCALAR
+
+                    std::rotate(momentumBegin, momentumBegin+shift, momentumBegin+3);
+                    std::rotate(magneticBegin, magneticBegin+shift, magneticBegin+3);
+                }
+                break;
+            default:
+                throw std::invalid_argument(("Invalid Value of `direction`"
+                    " passed to `_cycleXYZ`. Value passed was "
+                     + std::to_string(direction) + ", should be 0, 1, or 2."));
+                break;
+            }
+            return conservedVec;
+        }
+        // =====================================================================
+    };
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver using various states and waves from
+    * the Brio & Wu Shock tube
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           BrioAndWuShockTubeCorrectInputExpectCorrectOutput)
+    {
+        // Constant Values
+        Real const gamma = 2.;
+        Real const Vz    = 0.0;
+        Real const Bx    = 0.75;
+        Real const Bz    = 0.0;
+        std::vector<Real> const primitiveScalar{1.1069975296, 2.2286185018, 3.3155141875};
+
+        // States
+        std::vector<Real> const                       // | Density | X-Velocity | Y-Velocity | Z-Velocity | Pressure | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            leftICs                = primitive2Conserved({1.0,       0.0,         0.0,        Vz,           1.0,       Bx,                1.0     ,          Bz},               gamma,            primitiveScalar),
+            leftFastRareLeftSide   = primitive2Conserved({0.978576,  0.038603,   -0.011074,   Vz,           0.957621,  Bx,                0.970288,          Bz},               gamma,            primitiveScalar),
+            leftFastRareRightSide  = primitive2Conserved({0.671655,  0.647082,   -0.238291,   Vz,           0.451115,  Bx,                0.578240,          Bz},               gamma,            primitiveScalar),
+            compoundLeftSide       = primitive2Conserved({0.814306,  0.506792,   -0.911794,   Vz,           0.706578,  Bx,               -0.108819,          Bz},               gamma,            primitiveScalar),
+            compoundPeak           = primitive2Conserved({0.765841,  0.523701,   -1.383720,   Vz,           0.624742,  Bx,               -0.400787,          Bz},               gamma,            primitiveScalar),
+            compoundRightSide      = primitive2Conserved({0.695211,  0.601089,   -1.583720,   Vz,           0.515237,  Bx,               -0.537027,          Bz},               gamma,            primitiveScalar),
+            contactLeftSide        = primitive2Conserved({0.680453,  0.598922,   -1.584490,   Vz,           0.515856,  Bx,               -0.533616,          Bz},               gamma,            primitiveScalar),
+            contactRightSide       = primitive2Conserved({0.231160,  0.599261,   -1.584820,   Vz,           0.516212,  Bx,               -0.533327,          Bz},               gamma,            primitiveScalar),
+            slowShockLeftSide      = primitive2Conserved({0.153125,  0.086170,   -0.683303,   Vz,           0.191168,  Bx,               -0.850815,          Bz},               gamma,            primitiveScalar),
+            slowShockRightSide     = primitive2Conserved({0.117046, -0.238196,   -0.165561,   Vz,           0.087684,  Bx,               -0.903407,          Bz},               gamma,            primitiveScalar),
+            rightFastRareLeftSide  = primitive2Conserved({0.117358, -0.228756,   -0.158845,   Vz,           0.088148,  Bx,               -0.908335,          Bz},               gamma,            primitiveScalar),
+            rightFastRareRightSide = primitive2Conserved({0.124894, -0.003132,   -0.002074,   Vz,           0.099830,  Bx,               -0.999018,          Bz},               gamma,            primitiveScalar),
+            rightICs               = primitive2Conserved({0.128,     0.0,         0.0,        Vz,           0.1,       Bx,               -1.0,               Bz},               gamma,            primitiveScalar);
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            // Initial Condition Checks
+            {
+                std::string const outputString {"Left State:  Left Brio & Wu state\n"
+                                                "Right State: Left Brio & Wu state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 1.21875, -0.75, 0, 0, 0.0, 0, 0};
+                std::vector<Real> const scalarFlux{0, 0, 0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Brio & Wu state\n"
+                                                "Right State: Right Brio & Wu state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 0.31874999999999998, 0.75, 0, 0, 0.0, 0, 0};
+                std::vector<Real> const scalarFlux{0, 0, 0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Brio & Wu state\n"
+                                                "Right State: Right Brio & Wu state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.20673357746080057, 0.4661897584603672, 0.061170028480309613, 0, 0.064707291981509041, 0.0, 1.0074980455427278, 0};
+                std::vector<Real> const scalarFlux{0.22885355953447648, 0.46073027567244362, 0.6854281091039145};
+                Real thermalEnergyFlux = 0.20673357746080046;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Brio & Wu state\n"
+                                                "Right State: Left Brio & Wu state\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.20673357746080057, 0.4661897584603672, 0.061170028480309613, 0, -0.064707291981509041, 0.0, -1.0074980455427278, 0};
+                std::vector<Real> const scalarFlux{-0.22885355953447648, -0.46073027567244362, -0.6854281091039145};
+                Real thermalEnergyFlux = -0.20673357746080046;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+
+            // Cross wave checks
+            {
+                std::string const outputString {"Left State:  Left of left fast rarefaction\n"
+                                                "Right State: Right of left fast rarefaction\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.4253304970883941, 0.47729308161522394, -0.55321646324583107, 0, 0.92496835095531071, 0.0, 0.53128887284876058, 0};
+                std::vector<Real> const scalarFlux{0.47083980954039228, 0.94789941519098619, 1.4101892974729979};
+                Real thermalEnergyFlux = 0.41622256825457099;
+                std::vector<Real> const testFluxes = computeFluxes(leftFastRareLeftSide,
+                                                                   leftFastRareRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of left fast rarefaction\n"
+                                                "Right State: Left of left fast rarefaction\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.070492123816403796, 1.2489600267034342, -0.71031457071286608, 0, 0.21008080091470105, 0.0, 0.058615131833681167, 0};
+                std::vector<Real> const scalarFlux{0.078034606921016325, 0.15710005136841393, 0.23371763662029341};
+                Real thermalEnergyFlux = 0.047345816580591255;
+                std::vector<Real> const testFluxes = computeFluxes(leftFastRareRightSide,
+                                                                   leftFastRareLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of compound wave\n"
+                                                "Right State: Right of compound wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.4470171023231666, 0.60747660800918468, -0.20506357956052623, 0, 0.72655525704800772, 0.0, 0.76278089951123285, 0};
+                std::vector<Real> const scalarFlux{0.4948468279606959, 0.99623058485843297, 1.482091544807598};
+                Real thermalEnergyFlux = 0.38787931087981475;
+                std::vector<Real> const testFluxes = computeFluxes(compoundLeftSide,
+                                                                   compoundRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of compound wave\n"
+                                                "Right State: Left of compound wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.38496850292724116, 0.66092864409611585, -0.3473204105316457, 0, 0.89888639514227009, 0.0, 0.71658566275120927, 0};
+                std::vector<Real> const scalarFlux{0.42615918171426637, 0.85794792823389721, 1.2763685331959034};
+                Real thermalEnergyFlux = 0.28530908823756074;
+                std::vector<Real> const testFluxes = computeFluxes(compoundRightSide,
+                                                                   compoundLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of Compound Wave\n"
+                                                "Right State: Peak of Compound Wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.41864266180405574, 0.63505764056357727, -0.1991008813536404, 0, 0.73707474818824525, 0.0, 0.74058225030218761, 0};
+                std::vector<Real> const scalarFlux{0.46343639240225803, 0.93299478173931882, 1.388015684704111};
+                Real thermalEnergyFlux = 0.36325864563467081;
+                std::vector<Real> const testFluxes = computeFluxes(compoundLeftSide,
+                                                                   compoundPeak,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Peak of Compound Wave\n"
+                                                "Right State: Left of Compound Wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.39520761138156862, 0.6390998385557225, -0.35132701297727598, 0, 0.89945171879176522, 0.0, 0.71026545717401468, 0};
+                std::vector<Real> const scalarFlux{0.43749384947851333, 0.88076699477714815, 1.3103164425435772};
+                Real thermalEnergyFlux = 0.32239432669410983;
+                std::vector<Real> const testFluxes = computeFluxes(compoundPeak,
+                                                                   compoundLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Peak of Compound Wave\n"
+                                                "Right State: Right of Compound Wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.4285899590904928, 0.6079309920345296, -0.26055320217638239, 0, 0.75090757444649436, 0.0, 0.85591904930227747, 0};
+                std::vector<Real> const scalarFlux{0.47444802592454061, 0.95516351251477749, 1.4209960899845735};
+                Real thermalEnergyFlux = 0.34962629086469987;
+                std::vector<Real> const testFluxes = computeFluxes(compoundPeak,
+                                                                   compoundRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of Compound Wave\n"
+                                                "Right State: Peak of Compound Wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.39102247793946454, 0.65467021266207581, -0.25227691377588229, 0, 0.76271525822813691, 0.0, 0.83594460438033491, 0};
+                std::vector<Real> const scalarFlux{0.43286091709705776, 0.8714399289555731, 1.2964405732397004};
+                Real thermalEnergyFlux = 0.28979582956267347;
+                std::vector<Real> const testFluxes = computeFluxes(compoundRightSide,
+                                                                   compoundPeak,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of contact discontinuity\n"
+                                                "Right State: Right of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.40753761783585118, 0.62106392255463172, -0.2455554035355339, 0, 0.73906344777217226, 0.0, 0.8687394222350926, 0};
+                std::vector<Real> const scalarFlux{0.45114313616335622, 0.90824587528847567, 1.3511967538747176};
+                Real thermalEnergyFlux = 0.30895701155896288;
+                std::vector<Real> const testFluxes = computeFluxes(contactLeftSide,
+                                                                   contactRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of contact discontinuity\n"
+                                                "Right State: Left of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.13849588572126192, 0.46025037934770729, 0.18052412687974539, 0, 0.35385590617992224, 0.0, 0.86909622543144227, 0};
+                std::vector<Real> const scalarFlux{0.15331460335320088, 0.30865449334158279, 0.45918507401922254};
+                Real thermalEnergyFlux = 0.30928031735570188;
+                std::vector<Real> const testFluxes = computeFluxes(contactRightSide,
+                                                                   contactLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Slow shock left side\n"
+                                                "Right State: Slow shock right side\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{3.5274134848883865e-05, 0.32304849716274459, 0.60579784881286636, 0, -0.32813070621836449, 0.0, 0.40636483121437972, 0};
+                std::vector<Real> const scalarFlux{3.9048380136491711e-05, 7.8612589559210735e-05, 0.00011695189454326261};
+                Real thermalEnergyFlux = 4.4037784886918126e-05;
+                std::vector<Real> const testFluxes = computeFluxes(slowShockLeftSide,
+                                                                   slowShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Slow shock right side\n"
+                                                "Right State: Slow shock left side\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.016514307834939734, 0.16452009375678914, 0.71622171077118635, 0, -0.37262428139914472, 0.0, 0.37204015363322052, 0};
+                std::vector<Real> const scalarFlux{-0.018281297976332211, -0.036804091985367396, -0.054753421923485097};
+                Real thermalEnergyFlux = -0.020617189878790236;
+                std::vector<Real> const testFluxes = computeFluxes(slowShockRightSide,
+                                                                   slowShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right fast rarefaction left side\n"
+                                                "Right State: Right fast rarefaction right side\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.026222824218991747, 0.22254903570732654, 0.68544334213642255, 0, -0.33339172106895454, 0.0, 0.32319665359522443, 0};
+                std::vector<Real> const scalarFlux{-0.029028601629558917, -0.058440671223894146, -0.086942145734385745};
+                Real thermalEnergyFlux = -0.020960370728633469;
+                std::vector<Real> const testFluxes = computeFluxes(rightFastRareLeftSide,
+                                                                   rightFastRareRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right fast rarefaction right side\n"
+                                                "Right State: Right fast rarefaction left side\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.001088867226159973, 0.32035322820305906, 0.74922357263343131, 0, -0.0099746892805345766, 0.0, 0.0082135595470345102, 0};
+                std::vector<Real> const scalarFlux{-0.0012053733294214947, -0.0024266696462237609, -0.0036101547366371614};
+                Real thermalEnergyFlux = -0.00081785194236053073;
+                std::vector<Real> const testFluxes = computeFluxes(rightFastRareRightSide,
+                                                                   rightFastRareLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver using various states and waves from
+    * the Dai & Woodward Shock tube
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           DaiAndWoodwardShockTubeCorrectInputExpectCorrectOutput)
+    {
+        // Constant Values
+        Real const gamma = 5./3.;
+        Real const coef = 1. / (std::sqrt(4. * M_PI));
+        Real const Bx = 4. * coef;
+        std::vector<Real> const primitiveScalar{1.1069975296, 2.2286185018, 3.3155141875};
+
+        // States
+        std::vector<Real> const                       // | Density | X-Velocity | Y-Velocity | Z-Velocity | Pressure | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            leftICs                 = primitive2Conserved({1.08,     0.0,         0.0,         0.0,         1.0,       Bx,                3.6*coef,          2*coef},           gamma,            primitiveScalar),
+            leftFastShockLeftSide   = primitive2Conserved({1.09406,  1.176560,    0.021003,    0.506113,    0.970815,  1.12838,           1.105355,          0.614087},         gamma,            primitiveScalar),
+            leftFastShockRightSide  = primitive2Conserved({1.40577,  0.693255,    0.210562,    0.611423,    1.494290,  1.12838,           1.457700,          0.809831},         gamma,            primitiveScalar),
+            leftRotationLeftSide    = primitive2Conserved({1.40086,  0.687774,    0.215124,    0.609161,    1.485660,  1.12838,           1.458735,          0.789960},         gamma,            primitiveScalar),
+            leftRotationRightSide   = primitive2Conserved({1.40119,  0.687504,    0.330268,    0.334140,    1.486570,  1.12838,           1.588975,          0.475782},         gamma,            primitiveScalar),
+            leftSlowShockLeftSide   = primitive2Conserved({1.40519,  0.685492,    0.326265,    0.333664,    1.493710,  1.12838,           1.575785,          0.472390},         gamma,            primitiveScalar),
+            leftSlowShockRightSide  = primitive2Conserved({1.66488,  0.578545,    0.050746,    0.250260,    1.984720,  1.12838,           1.344490,          0.402407},         gamma,            primitiveScalar),
+            contactLeftSide         = primitive2Conserved({1.65220,  0.578296,    0.049683,    0.249962,    1.981250,  1.12838,           1.346155,          0.402868},         gamma,            primitiveScalar),
+            contactRightSide        = primitive2Conserved({1.49279,  0.578276,    0.049650,    0.249924,    1.981160,  1.12838,           1.346180,          0.402897},         gamma,            primitiveScalar),
+            rightSlowShockLeftSide  = primitive2Conserved({1.48581,  0.573195,    0.035338,    0.245592,    1.956320,  1.12838,           1.370395,          0.410220},         gamma,            primitiveScalar),
+            rightSlowShockRightSide = primitive2Conserved({1.23813,  0.450361,   -0.275532,    0.151746,    1.439000,  1.12838,           1.609775,          0.482762},         gamma,            primitiveScalar),
+            rightRotationLeftSide   = primitive2Conserved({1.23762,  0.450102,   -0.274410,    0.145585,    1.437950,  1.12838,           1.606945,          0.493879},         gamma,            primitiveScalar),
+            rightRotationRightSide  = primitive2Conserved({1.23747,  0.449993,   -0.180766,   -0.090238,    1.437350,  1.12838,           1.503855,          0.752090},         gamma,            primitiveScalar),
+            rightFastShockLeftSide  = primitive2Conserved({1.22305,  0.424403,   -0.171402,   -0.085701,    1.409660,  1.12838,           1.447730,          0.723864},         gamma,            primitiveScalar),
+            rightFastShockRightSide = primitive2Conserved({1.00006,  0.000121,   -0.000057,   -0.000028,    1.000100,  1.12838,           1.128435,          0.564217},         gamma,            primitiveScalar),
+            rightICs                = primitive2Conserved({1.0,      0.0,         0.0,         1.0,         0.2,       Bx,                4*coef,            2*coef},           gamma,            primitiveScalar);
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            // Initial Condition Checks
+            {
+                std::string const outputString {"Left State:  Left Dai & Woodward state\n"
+                                                "Right State: Left Dai & Woodward state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 1.0381971863420549, -1.1459155902616465, -0.63661977236758127, 0, 0.0, 0, -1.1102230246251565e-16};
+                std::vector<Real> const scalarFlux{0,0,0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Dai & Woodward state\n"
+                                                "Right State: Right Dai & Woodward state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 0.35915494309189522, -1.2732395447351625, -0.63661977236758127, -0.63661977236758172, 0.0, 2.2204460492503131e-16, -1.1283791670955123};
+                std::vector<Real> const scalarFlux{0,0,0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Dai & Woodward state\n"
+                                                "Right State: Right Dai & Woodward state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.17354924587196074, 0.71614983677687327, -1.1940929411768009, -1.1194725181819352, -0.11432087006939984, 0.0, 0.056156000248263505, -0.42800560867873094};
+                std::vector<Real> const scalarFlux{0.19211858644420357, 0.38677506032368902, 0.57540498691841158};
+                Real thermalEnergyFlux = 0.24104061926661174;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Dai & Woodward state\n"
+                                                "Right State: Left Dai & Woodward state\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.17354924587196074, 0.71614983677687327, -1.1940929411768009, -0.14549552299758384, -0.47242308031148195, 0.0, -0.056156000248263505, -0.55262526758377528};
+                std::vector<Real> const scalarFlux{-0.19211858644420357, -0.38677506032368902, -0.57540498691841158};
+                Real thermalEnergyFlux = -0.24104061926661174;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+
+            // Cross wave checks
+            {
+                std::string const outputString {"Left State:  Left of left fast shock\n"
+                                                "Right State: Right of left fast shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.96813688187727132, 3.0871217875403394, -1.4687093290523414, -0.33726008721080036, 4.2986213406773457, 0.0, 0.84684181393860269, -0.087452560407274671};
+                std::vector<Real> const scalarFlux{1.0717251365527865, 2.157607767226648, 3.2098715673061045};
+                Real thermalEnergyFlux = 1.2886155333980993;
+                std::vector<Real> const testFluxes = computeFluxes(leftFastShockLeftSide,
+                                                                   leftFastShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of left fast shock\n"
+                                                "Right State: Left of left fast shock\n"
+                                                "HLLD State: Left Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1.3053938862274184, 2.4685129176021858, -1.181892850065283, -0.011160487372167127, 5.1797404608257249, 0.0, 1.1889903073770265, 0.10262704114294516};
+                std::vector<Real> const scalarFlux{1.4450678072086958, 2.9092249669830292, 4.3280519500627666};
+                Real thermalEnergyFlux = 2.081389946702628;
+                std::vector<Real> const testFluxes = computeFluxes(leftFastShockRightSide,
+                                                                   leftFastShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of left rotation/Alfven wave\n"
+                                                "Right State: Right of left rotation/Alfven wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.96326128304298586, 2.8879592118317445, -1.4808188010794987, -0.20403672861184916, 4.014027751838869, 0.0, 0.7248753989305099, -0.059178137562467162};
+                std::vector<Real> const scalarFlux{1.0663278606879119, 2.1467419174572049, 3.1937064501984724};
+                Real thermalEnergyFlux = 1.5323573637968553;
+                std::vector<Real> const testFluxes = computeFluxes(leftRotationLeftSide,
+                                                                   leftRotationRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of left rotation/Alfven wave\n"
+                                                "Right State: Left of left rotation/Alfven wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.96353754504060063, 2.8875487093397085, -1.4327309336053695, -0.31541343522923493, 3.9739842521208342, 0.0, 0.75541746728406312, -0.13479771672887678};
+                std::vector<Real> const scalarFlux{1.0666336820367937, 2.1473576000564334, 3.1946224007710313};
+                Real thermalEnergyFlux = 1.5333744977458499;
+                std::vector<Real> const testFluxes = computeFluxes(leftRotationRightSide,
+                                                                   leftRotationLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of left slow shock\n"
+                                                "Right State: Right of left slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.88716095730727451, 2.9828594399125663, -1.417062582518549, -0.21524331343191233, 3.863474778369334, 0.0, 0.71242370728996041, -0.05229712416644372};
+                std::vector<Real> const scalarFlux{0.98208498809672407, 1.9771433235295921, 2.9413947405483505};
+                Real thermalEnergyFlux = 1.4145715457049737;
+                std::vector<Real> const testFluxes = computeFluxes(leftSlowShockLeftSide,
+                                                                   leftSlowShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of left slow shock\n"
+                                                "Right State: Left of left slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1.042385440439527, 2.7732383399777376, -1.5199872074603551, -0.21019362664841068, 4.1322001036232585, 0.0, 0.72170937317481543, -0.049474715634396704};
+                std::vector<Real> const scalarFlux{1.1539181074575644, 2.323079478570472, 3.4560437166206879};
+                Real thermalEnergyFlux = 1.8639570701934713;
+                std::vector<Real> const testFluxes = computeFluxes(leftSlowShockRightSide,
+                                                                   leftSlowShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of contact discontinuity\n"
+                                                "Right State: Right of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.95545795601418737, 2.8843900822429749, -1.4715039715239722, -0.21575736014726318, 4.0078718055059257, 0.0, 0.72241353110189066, -0.049073560388753337};
+                std::vector<Real> const scalarFlux{1.0576895969443709, 2.1293512784652289, 3.1678344087247892};
+                Real thermalEnergyFlux = 1.7186185770667382;
+                std::vector<Real> const testFluxes = computeFluxes(contactLeftSide,
+                                                                   contactRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of contact discontinuity\n"
+                                                "Right State: Left of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.86324813554422819, 2.8309913324581251, -1.4761428591480787, -0.23887765947428419, 3.9892942559102793, 0.0, 0.72244123046603836, -0.049025527032060034};
+                std::vector<Real> const scalarFlux{0.95561355347926669, 1.9238507665182214, 2.8621114407298114};
+                Real thermalEnergyFlux = 1.7184928987481187;
+                std::vector<Real> const testFluxes = computeFluxes(contactRightSide,
+                                                                   contactLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of right slow shock\n"
+                                                "Right State: Right of right slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.81125524370350677, 2.901639500435365, -1.5141545346789429, -0.262600896007809, 3.8479660419540087, 0.0, 0.7218977970017596, -0.049091614519593846};
+                std::vector<Real> const scalarFlux{0.89805755065482806, 1.8079784457999033, 2.6897282701827465};
+                Real thermalEnergyFlux = 1.6022319728249694;
+                std::vector<Real> const testFluxes = computeFluxes(rightSlowShockLeftSide,
+                                                                   rightSlowShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of right slow shock\n"
+                                                "Right State: Left of right slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.60157947557836688, 2.3888357198399746, -1.9910500022202977, -0.45610948442354332, 3.5359430988850069, 0.0, 1.0670963294022622, 0.05554893654378229};
+                std::vector<Real> const scalarFlux{0.66594699332331575, 1.3406911495770899, 1.994545286188885};
+                Real thermalEnergyFlux = 1.0487665253534804;
+                std::vector<Real> const testFluxes = computeFluxes(rightSlowShockRightSide,
+                                                                   rightSlowShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of right rotation/Alfven wave\n"
+                                                "Right State: Right of right rotation/Alfven wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.55701691287884714, 2.4652223621237814, -1.9664615862227277, -0.47490477894092042, 3.3900659850690529, 0.0, 1.0325648885587542, 0.059165409025635551};
+                std::vector<Real> const scalarFlux{0.61661634650230224, 1.2413781978573175, 1.8467974773272691};
+                Real thermalEnergyFlux = 0.9707694646266285;
+                std::vector<Real> const testFluxes = computeFluxes(rightRotationLeftSide,
+                                                                   rightRotationRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of right rotation/Alfven wave\n"
+                                                "Right State: Left of right rotation/Alfven wave\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.55689116371132596, 2.4648517303940851, -1.7972202655166787, -0.90018282739798461, 3.3401033852664566, 0.0, 0.88105841856465605, 0.43911718823267476};
+                std::vector<Real> const scalarFlux{0.61647714248450702, 1.2410979509359938, 1.8463805541782863};
+                Real thermalEnergyFlux = 0.9702629326292449;
+                std::vector<Real> const testFluxes = computeFluxes(rightRotationRightSide,
+                                                                   rightRotationLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of right fast shock\n"
+                                                "Right State: Right of right fast shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.48777637414577313, 2.3709438477809708, -1.7282900552525988, -0.86414423547773778, 2.8885015704245069, 0.0, 0.77133731061645838, 0.38566794697432505};
+                std::vector<Real> const scalarFlux{0.53996724117661621, 1.0870674521621893, 1.6172294888076189};
+                Real thermalEnergyFlux = 0.84330016382608752;
+                std::vector<Real> const testFluxes = computeFluxes(rightFastShockLeftSide,
+                                                                   rightFastShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of right fast shock\n"
+                                                "Right State: Left of right fast shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.040639426423817904, 1.0717156491947966, -1.2612066401572222, -0.63060225433149875, 0.15803727234007203, 0.0, 0.042555541396817498, 0.021277678888288909};
+                std::vector<Real> const scalarFlux{0.044987744655527385, 0.090569777630660403, 0.13474059488003065};
+                Real thermalEnergyFlux = 0.060961577855018087;
+                std::vector<Real> const testFluxes = computeFluxes(rightFastShockRightSide,
+                                                                   rightFastShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver using various states and waves from
+    * the Ryu & Jones 4d Shock tube
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           RyuAndJones4dShockTubeCorrectInputExpectCorrectOutput)
+    {
+        // Constant Values
+        Real const gamma = 5./3.;
+        Real const Bx = 0.7;
+        std::vector<Real> const primitiveScalar{1.1069975296, 2.2286185018, 3.3155141875};
+
+        // States
+        std::vector<Real> const                           // | Density | X-Velocity | Y-Velocity |  Z-Velocity |  Pressure | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            leftICs                    = primitive2Conserved({1.0,       0.0,         0.0,          0.0,          1.0,       Bx,                0.0,               0.0},              gamma,            primitiveScalar),
+            hydroRareLeftSide          = primitive2Conserved({0.990414,  0.012415,    1.458910e-58, 6.294360e-59, 0.984076,  Bx,                1.252355e-57,      5.366795e-58},     gamma,            primitiveScalar),
+            hydroRareRightSide         = primitive2Conserved({0.939477,  0.079800,    1.557120e-41, 7.505190e-42, 0.901182,  Bx,                1.823624e-40,      8.712177e-41},     gamma,            primitiveScalar),
+            switchOnSlowShockLeftSide  = primitive2Conserved({0.939863,  0.079142,    1.415730e-02, 7.134030e-03, 0.901820,  Bx,                2.519650e-02,      1.290082e-02},     gamma,            primitiveScalar),
+            switchOnSlowShockRightSide = primitive2Conserved({0.651753,  0.322362,    8.070540e-01, 4.425110e-01, 0.490103,  Bx,                6.598380e-01,      3.618000e-01},     gamma,            primitiveScalar),
+            contactLeftSide            = primitive2Conserved({0.648553,  0.322525,    8.072970e-01, 4.426950e-01, 0.489951,  Bx,                6.599295e-01,      3.618910e-01},     gamma,            primitiveScalar),
+            contactRightSide           = primitive2Conserved({0.489933,  0.322518,    8.073090e-01, 4.426960e-01, 0.489980,  Bx,                6.599195e-01,      3.618850e-01},     gamma,            primitiveScalar),
+            slowShockLeftSide          = primitive2Conserved({0.496478,  0.308418,    8.060830e-01, 4.420150e-01, 0.489823,  Bx,                6.686695e-01,      3.666915e-01},     gamma,            primitiveScalar),
+            slowShockRightSide         = primitive2Conserved({0.298260, -0.016740,    2.372870e-01, 1.287780e-01, 0.198864,  Bx,                8.662095e-01,      4.757390e-01},     gamma,            primitiveScalar),
+            rotationLeftSide           = primitive2Conserved({0.298001, -0.017358,    2.364790e-01, 1.278540e-01, 0.198448,  Bx,                8.669425e-01,      4.750845e-01},     gamma,            primitiveScalar),
+            rotationRightSide          = primitive2Conserved({0.297673, -0.018657,    1.059540e-02, 9.996860e-01, 0.197421,  Bx,                9.891580e-01,      1.024949e-04},     gamma,            primitiveScalar),
+            fastRareLeftSide           = primitive2Conserved({0.297504, -0.020018,    1.137420e-02, 1.000000e+00, 0.197234,  Bx,                9.883860e-01, -    4.981931e-17},     gamma,            primitiveScalar),
+            fastRareRightSide          = primitive2Conserved({0.299996, -0.000033,    1.855120e-05, 1.000000e+00, 0.199995,  Bx,                9.999865e-01,      1.737190e-16},     gamma,            primitiveScalar),
+            rightICs                   = primitive2Conserved({0.3,       0.0,         0.0,          1.0,          0.2,       Bx,                1.0,               0.0},              gamma,            primitiveScalar);
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            // Initial Condition Checks
+            {
+                std::string const outputString {"Left State:  Left Ryu & Jones 4d state\n"
+                                                "Right State: Left Ryu & Jones 4d state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 0.75499999999999989, 0, 0, 2.2204460492503131e-16, 0.0, 0, 0};
+                std::vector<Real> const scalarFlux{0,0,0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Ryu & Jones 4d state\n"
+                                                "Right State: Right Ryu & Jones 4d state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-5.5511151231257827e-17, 0.45500000000000013, -0.69999999999999996, -5.5511151231257827e-17, 0, 0.0, 0, -0.69999999999999996};
+                std::vector<Real> const scalarFlux{-6.1450707278254418e-17, -1.2371317869019906e-16, -1.8404800947169341e-16};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Ryu & Jones 4d state\n"
+                                                "Right State: Right Ryu & Jones 4d state\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.092428729855986602, 0.53311593977445149, -0.39622049648437296, -0.21566989083797167, -0.13287876964320211, 0.0, -0.40407579574102892, -0.21994567048141428};
+                std::vector<Real> const scalarFlux{0.10231837561464294, 0.20598837745492582, 0.30644876517012837};
+                Real thermalEnergyFlux = 0.13864309478397996;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Ryu & Jones 4d state\n"
+                                                "Right State: Left Ryu & Jones 4d state\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.092428729855986602, 0.53311593977445149, -0.39622049648437296, 0.21566989083797167, 0.13287876964320211, 0.0, 0.40407579574102892, -0.21994567048141428};
+                std::vector<Real> const scalarFlux{-0.10231837561464294, -0.20598837745492582, -0.30644876517012837};
+                Real thermalEnergyFlux = -0.13864309478397996;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+
+            // Cross wave checks
+            {
+                std::string const outputString {"Left State:  Left side of pure hydrodynamic rarefaction\n"
+                                                "Right State: Right side of pure hydrodynamic rarefaction\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.074035256375659553, 0.66054553664209648, -6.1597070943493028e-41, -2.9447391900433873e-41, 0.1776649658235645, 0.0, -6.3466063324344113e-41, -3.0340891384335242e-41};
+                std::vector<Real> const scalarFlux{0.081956845911157775, 0.16499634214430131, 0.24546494288869905};
+                Real thermalEnergyFlux = 0.11034221894046368;
+                std::vector<Real> const testFluxes = computeFluxes(hydroRareLeftSide,
+                                                                   hydroRareRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right side of pure hydrodynamic rarefaction\n"
+                                                "Right State: Left side of pure hydrodynamic rarefaction\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.013336890338886076, 0.74071279157971992, -6.1745213352160876e-41, -2.9474651270630147e-41, 0.033152482405470307, 0.0, 6.2022392844946449e-41, 2.9606965476795895e-41};
+                std::vector<Real> const scalarFlux{0.014763904657692993, 0.029722840565719184, 0.044218649135708464};
+                Real thermalEnergyFlux = 0.019189877201961154;
+                std::vector<Real> const testFluxes = computeFluxes(hydroRareRightSide,
+                                                                   hydroRareLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of switch on slow shock\n"
+                                                "Right State: Right of switch on slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.19734622040826083, 0.47855039640569758, -0.3392293209655618, -0.18588204716255491, 0.10695446263054809, 0.0, -0.3558357543098733, -0.19525093130352045};
+                std::vector<Real> const scalarFlux{0.21846177846784187, 0.43980943806215089, 0.65430419361309078};
+                Real thermalEnergyFlux = 0.2840373040888583;
+                std::vector<Real> const testFluxes = computeFluxes(switchOnSlowShockLeftSide,
+                                                                   switchOnSlowShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of switch on slow shock\n"
+                                                "Right State: Left of switch on slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.097593254768855386, 0.76483698872352757, -0.02036438492698419, -0.010747481940703562, 0.25327551496496836, 0.0, -0.002520109973016129, -0.00088262199017708799};
+                std::vector<Real> const scalarFlux{0.10803549193474633, 0.21749813322875222, 0.32357182079044206};
+                Real thermalEnergyFlux = 0.1100817647375162;
+                std::vector<Real> const testFluxes = computeFluxes(switchOnSlowShockRightSide,
+                                                                   switchOnSlowShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of contact discontinuity\n"
+                                                "Right State: Right of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.2091677440314007, 0.5956612619664029, -0.29309091669513981, -0.16072556008504282, 0.19220050968424285, 0.0, -0.35226977371803297, -0.19316940226499904};
+                std::vector<Real> const scalarFlux{0.23154817591476573, 0.46615510432814616, 0.69349862290347741};
+                Real thermalEnergyFlux = 0.23702444986592192;
+                std::vector<Real> const testFluxes = computeFluxes(contactLeftSide,
+                                                                   contactRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of contact discontinuity\n"
+                                                "Right State: Left of contact discontinuity\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.15801775068597168, 0.57916072367837657, -0.33437339604094024, -0.18336617461176744, 0.16789791355547545, 0.0, -0.3522739911439669, -0.19317084712861482};
+                std::vector<Real> const scalarFlux{0.17492525964231936, 0.35216128279157616, 0.52391009427617696};
+                Real thermalEnergyFlux = 0.23704936434506069;
+                std::vector<Real> const testFluxes = computeFluxes(contactRightSide,
+                                                                   contactLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of slow shock\n"
+                                                "Right State: Right of slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.11744487326715558, 0.66868230621718128, -0.35832022960458892, -0.19650694834641164, 0.057880816021092185, 0.0, -0.37198011453582402, -0.20397277844271294};
+                std::vector<Real> const scalarFlux{0.13001118457092631, 0.26173981750473918, 0.38939014356639379};
+                Real thermalEnergyFlux = 0.1738058891582446;
+                std::vector<Real> const testFluxes = computeFluxes(slowShockLeftSide,
+                                                                   slowShockRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of slow shock\n"
+                                                "Right State: Left of slow shock\n"
+                                                "HLLD State: Left Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.038440990187426027, 0.33776683678923869, -0.62583241538732792, -0.3437911783906169, -0.13471828103488348, 0.0, -0.15165427985881363, -0.082233932588833825};
+                std::vector<Real> const scalarFlux{0.042554081172858457, 0.085670301959209896, 0.12745164834795927};
+                Real thermalEnergyFlux = 0.038445630017261548;
+                std::vector<Real> const testFluxes = computeFluxes(slowShockRightSide,
+                                                                   slowShockLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of rotation/Alfven wave\n"
+                                                "Right State: Right of rotation/Alfven wave\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.0052668366104996478, 0.44242247672452317, -0.60785196341731951, -0.33352435102145184, -0.21197843894720192, 0.0, -0.18030635192654354, -0.098381113757603278};
+                std::vector<Real> const scalarFlux{-0.0058303751166299484, -0.011737769516117116, -0.017462271505355991};
+                Real thermalEnergyFlux = -0.0052395622905745485;
+                std::vector<Real> const testFluxes = computeFluxes(rotationLeftSide,
+                                                                   rotationRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of rotation/Alfven wave\n"
+                                                "Right State: Left of rotation/Alfven wave\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.005459628948343731, 0.4415038084184626, -0.69273580053867279, -0.0051834737482743809, -0.037389286119015486, 0.0, -0.026148289294373184, -0.69914753968916865};
+                std::vector<Real> const scalarFlux{-0.0060437957583491572, -0.012167430087241717, -0.018101477236719343};
+                Real thermalEnergyFlux = -0.0054536013916442853;
+                std::vector<Real> const testFluxes = computeFluxes(rotationRightSide,
+                                                                   rotationLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left of fast rarefaction\n"
+                                                "Right State: Right of fast rarefaction\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.0059354802028144249, 0.44075681881443612, -0.69194176811725872, -0.0059354802028144804, -0.040194357552219451, 0.0, -0.027710302430178135, -0.70000000000000007};
+                std::vector<Real> const scalarFlux{-0.0065705619215052757, -0.013227920997059845, -0.019679168822056604};
+                Real thermalEnergyFlux = -0.0059354109546219782;
+                std::vector<Real> const testFluxes = computeFluxes(fastRareLeftSide,
+                                                                   fastRareRightSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right of fast rarefaction\n"
+                                                "Right State: Left of fast rarefaction\n"
+                                                "HLLD State: Right Double Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-3.0171858819483255e-05, 0.45503057873272706, -0.69998654276213712, -3.0171858819427744e-05, -0.00014827469339251387, 0.0, -8.2898844654399895e-05, -0.69999999999999984};
+                std::vector<Real> const scalarFlux{-3.340017317660794e-05, -6.7241562798797897e-05, -0.00010003522597924373};
+                Real thermalEnergyFlux = -3.000421709818028e-05;
+                std::vector<Real> const testFluxes = computeFluxes(fastRareRightSide,
+                                                                   fastRareLeftSide,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver using various states and waves from
+    * the Einfeldt Strong Rarefaction (EFR)
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           EinfeldtStrongRarefactionCorrectInputExpectCorrectOutput)
+    {
+        // Constant Values
+        Real const gamma = 5./3.;
+        Real const V0 = 2.;
+        Real const Vy = 0.0;
+        Real const Vz = 0.0;
+        Real const Bx = 0.0;
+        Real const Bz = 0.0;
+
+        std::vector<Real> const primitiveScalar{1.1069975296, 2.2286185018, 3.3155141875};
+
+        // States
+        std::vector<Real> const                       // | Density | X-Velocity | Y-Velocity | Z-Velocity | Pressure | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            leftICs                = primitive2Conserved({1.0,      -V0,          Vy,          Vz,          0.45,      Bx,                0.5,               Bz},               gamma,            primitiveScalar),
+            leftRarefactionCenter  = primitive2Conserved({0.368580, -1.180830,    Vy,          Vz,          0.111253,  Bx,                0.183044,          Bz},               gamma,            primitiveScalar),
+            leftVxTurnOver         = primitive2Conserved({0.058814, -0.125475,    Vy,          Vz,          0.008819,  Bx,                0.029215,          Bz},               gamma,            primitiveScalar),
+            midPoint               = primitive2Conserved({0.034658,  0.000778,    Vy,          Vz,          0.006776,  Bx,                0.017333,          Bz},               gamma,            primitiveScalar),
+            rightVxTurnOver        = primitive2Conserved({0.062587,  0.152160,    Vy,          Vz,          0.009521,  Bx,                0.031576,          Bz},               gamma,            primitiveScalar),
+            rightRarefactionCenter = primitive2Conserved({0.316485,  1.073560,    Vy,          Vz,          0.089875,  Bx,                0.159366,          Bz},               gamma,            primitiveScalar),
+            rightICs               = primitive2Conserved({1.0,       V0,          Vy,          Vz,          0.45,      Bx,                0.5,               Bz},               gamma,            primitiveScalar);
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            // Initial Condition Checks
+            {
+                std::string const outputString {"Left State:  Left Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Left Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Right"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-2, 4.5750000000000002, -0, -0, -6.75, 0.0, -1, -0};
+                std::vector<Real> const scalarFlux{-2.2139950592000002, -4.4572370036000004, -6.6310283749999996};
+                Real thermalEnergyFlux = -1.3499999999999996;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Right Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Left"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{2, 4.5750000000000002, 0, 0, 6.75, 0.0, 1, 0};
+                std::vector<Real> const scalarFlux{2.2139950592000002, 4.4572370036000004, 6.6310283749999996};
+                Real thermalEnergyFlux = 1.3499999999999996;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Right Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, -1.4249999999999998, -0, -0, 0, 0.0, 0, -0};
+                std::vector<Real> const scalarFlux{0,0,0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Left Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0, 10.574999999999999, 0, 0, 0, 0.0, 0, 0};
+                std::vector<Real> const scalarFlux{0,0,0};
+                Real thermalEnergyFlux = 0.0;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+
+            // Intermediate state checks
+            {
+                std::string const outputString {"Left State:  Left Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Left rarefaction center\n"
+                                                "HLLD State: Right"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.43523032140000006, 0.64193857338676208, -0, -0, -0.67142479846795033, 0.0, -0.21614384652000002, -0};
+                std::vector<Real> const scalarFlux{-0.48179889059681413, -0.9699623468164007, -1.4430123054318851};
+                Real thermalEnergyFlux = -0.19705631998499995;
+                std::vector<Real> const testFluxes = computeFluxes(leftICs,
+                                                                   leftRarefactionCenter,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left rarefaction center\n"
+                                                "Right State: Left Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Right"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-2, 4.5750000000000002, -0, -0, -6.75, 0.0, -1, -0};
+                std::vector<Real> const scalarFlux{-2.2139950592000002, -4.4572370036000004, -6.6310283749999996};
+                Real thermalEnergyFlux = -1.3499999999999996;
+                std::vector<Real> const testFluxes = computeFluxes(leftRarefactionCenter,
+                                                                   leftICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left rarefaction center\n"
+                                                "Right State: Left Vx turnover point\n"
+                                                "HLLD State: Right Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.023176056428381629, -2.0437812714100764e-05, 0, 0, -0.00098843768795337005, 0.0, -0.011512369309265979, 0};
+                std::vector<Real> const scalarFlux{-0.025655837212088663, -0.051650588155052128, -0.076840543898599858};
+                Real thermalEnergyFlux = -0.0052127803322822184;
+                std::vector<Real> const testFluxes = computeFluxes(leftRarefactionCenter,
+                                                                   leftVxTurnOver,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Vx turnover point\n"
+                                                "Right State: Left rarefaction center\n"
+                                                "HLLD State: Right Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.43613091609689758, 0.64135749005731213, 0, 0, -0.67086080671260462, 0.0, -0.21659109937066717, 0};
+                std::vector<Real> const scalarFlux{-0.48279584670145054, -0.9719694288205295, -1.445998239926636};
+                Real thermalEnergyFlux = -0.19746407621898149;
+                std::vector<Real> const testFluxes = computeFluxes(leftVxTurnOver,
+                                                                   leftRarefactionCenter,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Left Vx turnover point\n"
+                                                "Right State: Midpoint\n"
+                                                "HLLD State: Right Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.0011656375857387598, 0.0062355370788444902, 0, 0, -0.00055517615333601446, 0.0, -0.0005829533231464588, 0};
+                std::vector<Real> const scalarFlux{-0.0012903579278217153, -0.0025977614899708843, -0.0038646879530001054};
+                Real thermalEnergyFlux = -0.00034184143405415065;
+                std::vector<Real> const testFluxes = computeFluxes(leftVxTurnOver,
+                                                                   midPoint,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Midpoint\n"
+                                                "Right State: Left Vx turnover point\n"
+                                                "HLLD State: Right Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-0.0068097924351817191, 0.010501781004354172, 0, 0, -0.0027509360975397175, 0.0, -0.0033826654536986789, 0};
+                std::vector<Real> const scalarFlux{-0.0075384234028349319, -0.015176429414463658, -0.022577963432775162};
+                Real thermalEnergyFlux = -0.001531664896602873;
+                std::vector<Real> const testFluxes = computeFluxes(midPoint,
+                                                                   leftVxTurnOver,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Midpoint\n"
+                                                "Right State: Right Vx turnover point\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.0013952100758668729, 0.0061359407125797273, 0, 0, 0.00065984543596031629, 0.0, 0.00069776606396793105, 0};
+                std::vector<Real> const scalarFlux{ 0.001544494107257657, 0.0031093909889746947, 0.0046258388010795683};
+                Real thermalEnergyFlux = 0.00040916715364737997;
+                std::vector<Real> const testFluxes = computeFluxes(midPoint,
+                                                                   rightVxTurnOver,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Vx turnover point\n"
+                                                "Right State: Midpoint\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.0090024688079190333, 0.011769373146023688, 0, 0, 0.003725251767222792, 0.0, 0.0045418689996141555, 0};
+                std::vector<Real> const scalarFlux{0.0099657107306674268, 0.020063068547205749, 0.029847813055181766};
+                Real thermalEnergyFlux = 0.0020542406295284269;
+                std::vector<Real> const testFluxes = computeFluxes(rightVxTurnOver,
+                                                                   midPoint,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Vx turnover point\n"
+                                                "Right State: Right rarefaction center\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.023310393229073981, 0.0033086897645311728, 0, 0, 0.0034208520409618887, 0.0, 0.011760413130542123, 0};
+                std::vector<Real> const scalarFlux{0.025804547718589466, 0.051949973634547723, 0.077285939467198722};
+                Real thermalEnergyFlux = 0.0053191138878843835;
+                std::vector<Real> const testFluxes = computeFluxes(rightVxTurnOver,
+                                                                   rightRarefactionCenter,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right rarefaction center\n"
+                                                "Right State: Right Vx turnover point\n"
+                                                "HLLD State: Left Star"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.33914253809565298, 0.46770133685446141, 0, 0, 0.46453338019960133, 0.0, 0.17077520175095764, 0};
+                std::vector<Real> const scalarFlux{0.37542995185416178, 0.75581933514738364, 1.1244318966408966};
+                Real thermalEnergyFlux = 0.1444638874418068;
+                std::vector<Real> const testFluxes = computeFluxes(rightRarefactionCenter,
+                                                                   rightVxTurnOver,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right rarefaction center\n"
+                                                "Right State: Right Einfeldt Strong Rarefaction state\n"
+                                                "HLLD State: Left"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{0.33976563660000003, 0.46733255780629601, 0, 0, 0.46427650313257612, 0.0, 0.17108896296000001, 0};
+                std::vector<Real> const scalarFlux{0.37611972035917141, 0.75720798400261535, 1.1264977885722693};
+                Real thermalEnergyFlux = 0.14472930749999999;
+                std::vector<Real> const testFluxes = computeFluxes(rightRarefactionCenter,
+                                                                   rightICs,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Right Einfeldt Strong Rarefaction state\n"
+                                                "Right State: Right rarefaction center\n"
+                                                "HLLD State: Left"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{2, 4.5750000000000002, 0, 0, 6.75, 0.0, 1, 0};
+                std::vector<Real> const scalarFlux{2.2139950592000002, 4.4572370036000004, 6.6310283749999996};
+                Real thermalEnergyFlux = 1.3499999999999996;
+                std::vector<Real> const testFluxes = computeFluxes(rightICs,
+                                                                   rightRarefactionCenter,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver with the degenerate state
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           DegenerateStateCorrectInputExpectCorrectOutput)
+    {
+        // Constant Values
+        Real const gamma = 5./3.;
+        std::vector<Real> const primitiveScalar{1.1069975296, 2.2286185018, 3.3155141875};
+
+        // State
+        std::vector<Real> const      // | Density | X-Velocity | Y-Velocity | Z-Velocity | Pressure | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            state = primitive2Conserved({1.0,       1.0,         1.0,         1.0,         1.0,       3.0E4,             1.0,               1.0},              gamma,            primitiveScalar);
+
+        std::vector<Real> const fiducialFlux{1, -449999997, -29999, -29999, -59994, 0.0, -29999, -29999};
+        std::vector<Real> const scalarFlux{1.1069975296000001, 2.2286185018000002, 3.3155141874999998};
+        Real thermalEnergyFlux = 1.5;
+        std::string const outputString {"Left State:  Degenerate state\n"
+                                        "Right State: Degenerate state\n"
+                                        "HLLD State: Left Double Star State"};
+
+        // Compute the fluxes and check for correctness
+        // Order of Fluxes is rho, vec(V), E, vec(B)
+        // If you run into issues with the energy try 0.001953125 instead.
+        // That's what I got when running the Athena solver on its own. Running
+        // the Athena solver with theses tests gave me -0.00080700946455175148
+        // though
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            std::vector<Real> const testFluxes = computeFluxes(state,
+                                                               state,
+                                                               gamma,
+                                                               direction);
+            checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver with all zeroes
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           AllZeroesExpectAllZeroes)
+    {
+        // Constant Values
+        Real const gamma = 5./3.;
+
+        // State
+        size_t numElements = 8;
+        #ifdef SCALAR
+            numElements += 3;
+        #endif // SCALAR
+
+        std::vector<Real> const state(numElements, 0.0);
+        std::vector<Real> const fiducialFlux(8,0.0);
+        std::vector<Real> const scalarFlux(3,0.0);
+        Real thermalEnergyFlux = 0.0;
+
+        std::string const outputString {"Left State:  All zeroes\n"
+                                        "Right State: All zeroes\n"
+                                        "HLLD State: Right Star State"};
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            // Compute the fluxes and check for correctness
+            // Order of Fluxes is rho, vec(V), E, vec(B)
+            std::vector<Real> const testFluxes = computeFluxes(state,
+                                                               state,
+                                                               gamma,
+                                                               direction);
+            checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+    * \brief Test the HLLD Riemann Solver with negative pressure, energy, and
+      density.
+    *
+    */
+    TEST_F(tMHDCalculateHLLDFluxesCUDA,
+           UnphysicalValuesExpectAutomaticFix)
+    {
+        // Constant Values
+        Real const gamma                  = 5./3.;
+
+        // States
+        std::vector<Real>                // | Density | X-Momentum | Y-Momentum | Z-Momentum | Energy   | X-Magnetic Field | Y-Magnetic Field | Z-Magnetic Field | Adiabatic Index | Passive Scalars |
+            negativePressure              = { 1.0,      1.0,         1.0,         1.0,         1.5,       1.0,               1.0,               1.0},
+            negativeEnergy                = { 1.0,      1.0,         1.0,         1.0,        -(5-gamma), 1.0,               1.0,               1.0},
+            negativeDensity               = {-1.0,      1.0,         1.0,         1.0,         1.0,       1.0,               1.0,               1.0},
+            negativeDensityEnergyPressure = {-1.0,     -1.0,        -1.0,        -1.0,         -gamma,    1.0,               1.0,               1.0},
+            negativeDensityPressure       = {-1.0,      1.0,         1.0,         1.0,        -1.0,       1.0,               1.0,               1.0};
+
+        #ifdef SCALAR
+            std::vector<Real> const conservedScalar{1.1069975296, 2.2286185018, 3.3155141875};
+            negativePressure.insert(negativePressure.begin()+5, conservedScalar.begin(), conservedScalar.begin() + NSCALARS);
+            negativeEnergy.insert(negativeEnergy.begin()+5, conservedScalar.begin(), conservedScalar.begin() + NSCALARS);
+            negativeDensity.insert(negativeDensity.begin()+5, conservedScalar.begin(), conservedScalar.begin() + NSCALARS);
+            negativeDensityEnergyPressure.insert(negativeDensityEnergyPressure.begin()+5, conservedScalar.begin(), conservedScalar.begin() + NSCALARS);
+            negativeDensityPressure.insert(negativeDensityPressure.begin()+5, conservedScalar.begin(), conservedScalar.begin() + NSCALARS);
+        #endif  // SCALAR
+        #ifdef  DE
+            negativePressure.push_back(mhdUtils::computeThermalEnergy(negativePressure.at(4),negativePressure.at(0),negativePressure.at(1),negativePressure.at(2),negativePressure.at(3),negativePressure.at(5 + NSCALARS),negativePressure.at(6 + NSCALARS),negativePressure.at(7 + NSCALARS),gamma));
+            negativeEnergy.push_back(mhdUtils::computeThermalEnergy(negativeEnergy.at(4),negativeEnergy.at(0),negativeEnergy.at(1),negativeEnergy.at(2),negativeEnergy.at(3),negativeEnergy.at(5 + NSCALARS),negativeEnergy.at(6 + NSCALARS),negativeEnergy.at(7 + NSCALARS),gamma));
+            negativeDensity.push_back(mhdUtils::computeThermalEnergy(negativeDensity.at(4),negativeDensity.at(0),negativeDensity.at(1),negativeDensity.at(2),negativeDensity.at(3),negativeDensity.at(5 + NSCALARS),negativeDensity.at(6 + NSCALARS),negativeDensity.at(7 + NSCALARS),gamma));
+            negativeDensityEnergyPressure.push_back(mhdUtils::computeThermalEnergy(negativeDensityEnergyPressure.at(4),negativeDensityEnergyPressure.at(0),negativeDensityEnergyPressure.at(1),negativeDensityEnergyPressure.at(2),negativeDensityEnergyPressure.at(3),negativeDensityEnergyPressure.at(5 + NSCALARS),negativeDensityEnergyPressure.at(6 + NSCALARS),negativeDensityEnergyPressure.at(7 + NSCALARS),gamma));
+            negativeDensityPressure.push_back(mhdUtils::computeThermalEnergy(negativeDensityPressure.at(4),negativeDensityPressure.at(0),negativeDensityPressure.at(1),negativeDensityPressure.at(2),negativeDensityPressure.at(3),negativeDensityPressure.at(5 + NSCALARS),negativeDensityPressure.at(6 + NSCALARS),negativeDensityPressure.at(7 + NSCALARS),gamma));
+        #endif  //DE
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            {
+                std::string const outputString {"Left State:  Negative Pressure\n"
+                                                "Right State: Negative Pressure\n"
+                                                "HLLD State: Left Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1, 1.5, 0, 0, -1.6254793235168146e-16, 0, 0, 0};
+                std::vector<Real> const scalarFlux{1.1069975296000001, 2.2286185018000002, 3.3155141874999998};
+                Real thermalEnergyFlux = -1.5;
+                std::vector<Real> const testFluxes = computeFluxes(negativePressure,
+                                                                   negativePressure,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Negative Energy\n"
+                                                "Right State: Negative Energy\n"
+                                                "HLLD State: Left Star State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1, 1.5, 0, 0, -1.5, 0, 0, 0};
+                std::vector<Real> const scalarFlux{1.1069975296000001, 2.2286185018000002, 3.3155141874999998};
+                Real thermalEnergyFlux = -6.333333333333333;
+                std::vector<Real> const testFluxes = computeFluxes(negativeEnergy,
+                                                                   negativeEnergy,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Negative Density\n"
+                                                "Right State: Negative Density\n"
+                                                "HLLD State: Left State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1, 1E+20, 1e+20, 1e+20, -5e+19, 0, 0, 0};
+                std::vector<Real> const scalarFlux{1.1069975296000002e+20, 2.2286185018000002e+20, 3.3155141874999997e+20};
+                Real thermalEnergyFlux = -1.5000000000000001e+40;
+                std::vector<Real> const testFluxes = computeFluxes(negativeDensity,
+                                                                   negativeDensity,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Negative Density, Energy, and Pressure\n"
+                                                "Right State: Negative Density, Energy, and Pressure\n"
+                                                "HLLD State: Right State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{-1, 1E+20, 1E+20, 1E+20, 1.5E+20, 0, 0, 0};
+                std::vector<Real> const scalarFlux{-1.1069975296000002e+20, -2.2286185018000002e+20, -3.3155141874999997e+20};
+                Real thermalEnergyFlux = 1.5000000000000001e+40;
+                std::vector<Real> const testFluxes = computeFluxes(negativeDensityEnergyPressure,
+                                                                   negativeDensityEnergyPressure,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+            {
+                std::string const outputString {"Left State:  Negative Density and Pressure\n"
+                                                "Right State: Negative Density and Pressure\n"
+                                                "HLLD State: Left State"};
+                // Compute the fluxes and check for correctness
+                // Order of Fluxes is rho, vec(V), E, vec(B)
+                std::vector<Real> const fiducialFlux{1, 1e+20, 1e+20, 1e+20, -1.5e+20, 0, 0, 0};
+                std::vector<Real> const scalarFlux{1.1069975296000002e+20, 2.2286185018000002e+20, 3.3155141874999997e+20};
+                Real thermalEnergyFlux = -1.5000000000000001e+40;
+                std::vector<Real> const testFluxes = computeFluxes(negativeDensityPressure,
+                                                                   negativeDensityPressure,
+                                                                   gamma,
+                                                                   direction);
+                checkResults(fiducialFlux, scalarFlux, thermalEnergyFlux, testFluxes, outputString, direction);
+            }
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    // End of integration tests for the entire HLLD solver. Unit tests are below
+    // =========================================================================
+
+    // =========================================================================
+    // Unit tests for the contents of the _hlldInternal namespace
+    // =========================================================================
+    /*!
+     * \brief A struct to hold some basic test values
+     *
+     */
+    namespace
+    {
+        struct testParams
+        {
+            // List of cases
+            std::vector<std::string> names{"Case 1", "Case 2"};
+
+            // Conserved Variables
+            double gamma = 5./3.;
+            std::valarray<double> densityL  {21.50306776645775  , 48.316634031589935};
+            std::valarray<double> densityR  {81.1217731762265   , 91.02955738853635};
+            std::valarray<double> momentumXL{38.504606872151484 , 18.984145880030045};
+            std::valarray<double> momentumXR{ 8.201811315045326 , 85.24863367778745};
+            std::valarray<double> momentumYL{ 7.1046427940455015, 33.76182584816693};
+            std::valarray<double> momentumYR{13.874767484202021 , 33.023492551299974};
+            std::valarray<double> momentumZL{32.25700338919422  , 89.52561861038686};
+            std::valarray<double> momentumZR{33.85305318830181  ,  8.664313303796256};
+            std::valarray<double> energyL   {65.75120838109942  , 38.461354599479826};
+            std::valarray<double> energyR   {18.88982523270516  , 83.65639784178894};
+            std::valarray<double> magneticXL{92.75101068883114  , 31.588767769990532};
+            std::valarray<double> magneticXR{93.66196246448985  , 84.3529879134052};
+            std::valarray<double> magneticYL{12.297499156516622 , 63.74471969570406};
+            std::valarray<double> magneticYR{84.9919141787549   , 35.910258841630984};
+            std::valarray<double> magneticZL{46.224045698787776 , 37.70326455170754};
+            std::valarray<double> magneticZR{34.852095153095384 , 24.052685003977757};
+            // Star States
+            std::valarray<double> densityStarL  {28.520995251761526 , 54.721668215064945};
+            std::valarray<double> densityStarR  {49.09069570738605  , 72.68000504460609};
+            std::valarray<double> momentumStarXL{48.96082367518151  , 97.15439466280228};
+            std::valarray<double> momentumStarXR{65.74705433463932  , 94.5689655974538};
+            std::valarray<double> momentumStarYL{44.910034185328996 , 78.60179936059853};
+            std::valarray<double> momentumStarYR{51.642522487399276 , 44.63864007208728};
+            std::valarray<double> momentumStarZL{39.78163555990428  , 63.01612978428839};
+            std::valarray<double> momentumStarZR{33.47900698769427  , 52.19410653341197};
+            std::valarray<double> energyStarL   { 6.579867455284738 , 30.45043664908369};
+            std::valarray<double> energyStarR   {90.44484278669114  , 61.33664731346812};
+            std::valarray<double> magneticStarXL{49.81491527582234  , 62.379765828560906};
+            std::valarray<double> magneticStarXR{67.77402751903804  , 64.62226739788758};
+            std::valarray<double> magneticStarYL{62.09348829143065  , 54.27916744403672};
+            std::valarray<double> magneticStarYR{26.835645069149873 , 98.97444628327318};
+            std::valarray<double> magneticStarZL{62.765890944643196 , 93.26765455509641};
+            std::valarray<double> magneticStarZR{ 7.430231695917344 , 10.696380763901459};
+            // Double Star State
+            std::valarray<double> momentumDoubleStarXL{75.42525315887075  , 83.87480678359029};
+            std::valarray<double> momentumDoubleStarYL{22.56132540660678  , 76.11074421934487};
+            std::valarray<double> momentumDoubleStarZL{27.83908778933224  , 28.577101567661465};
+            std::valarray<double> energyDoubleStar    {45.83202455707669  , 55.4553014145573};
+            std::valarray<double> magneticDoubleStarY {20.943239839455895 , 83.8514810487021};
+            std::valarray<double> magneticDoubleStarZ {83.3802438268807   , 80.36671251730783};
+            // Fluxes
+            std::valarray<double> densityFluxL     {12.939239309626116 , 81.71524586517073};
+            std::valarray<double> momentumFluxXL   {65.05481464917627  , 56.09885069707803};
+            std::valarray<double> momentumFluxYL   {73.67692845586782  ,  2.717246983403787};
+            std::valarray<double> momentumFluxZL   {16.873647595664387 , 39.70132983192873};
+            std::valarray<double> energyFluxL      {52.71888731972469  , 81.63926176158796};
+            std::valarray<double> magneticFluxXL   {67.7412464028116   , 42.85301340921149};
+            std::valarray<double> magneticFluxYL   {58.98928445415967  , 57.04344459221359};
+            std::valarray<double> magneticFluxZL   {29.976925743532302 , 97.73329827141359};
+            std::valarray<double> momentumStarFluxX{74.90125547448865  , 26.812722601652684};
+            std::valarray<double> momentumStarFluxY{16.989138610622945 , 48.349566649914976};
+            std::valarray<double> momentumStarFluxZ{38.541822734846185 , 61.22843961052538};
+            std::valarray<double> energyStarFlux   {19.095105176247017 , 45.43224973313112};
+            std::valarray<double> magneticStarFluxY{96.23964526624277  , 33.05337536594796};
+            std::valarray<double> magneticStarFluxZ{86.22516928268347  , 15.62102082410738};
+
+            // Derived/Primitive variables
+            std::valarray<double> velocityXL     = momentumXL / densityL;
+            std::valarray<double> velocityXR     = momentumXR / densityR;
+            std::valarray<double> velocityYL     = momentumYL / densityL;
+            std::valarray<double> velocityYR     = momentumYR / densityR;
+            std::valarray<double> velocityZL     = momentumZL / densityL;
+            std::valarray<double> velocityZR     = momentumZR / densityR;
+            std::valarray<double> totalPressureStarL{66.80958736783934  , 72.29644038317676};
+            std::vector<double> gasPressureL;
+            std::vector<double> gasPressureR;
+            std::vector<double> totalPressureL;
+            std::vector<double> totalPressureR;
+            // Star State
+            std::valarray<double> velocityStarXL = momentumStarXL / densityStarL;
+            std::valarray<double> velocityStarXR = momentumStarXR / densityStarR;
+            std::valarray<double> velocityStarYL = momentumStarYL / densityStarL;
+            std::valarray<double> velocityStarYR = momentumStarYR / densityStarR;
+            std::valarray<double> velocityStarZL = momentumStarZL / densityStarL;
+            std::valarray<double> velocityStarZR = momentumStarZR / densityStarR;
+            // Double Star State
+            std::valarray<double> velocityDoubleStarXL = momentumDoubleStarXL / densityStarL;
+            std::valarray<double> velocityDoubleStarYL = momentumDoubleStarYL / densityStarL;
+            std::valarray<double> velocityDoubleStarZL = momentumDoubleStarZL / densityStarL;
+            // Other
+            std::valarray<double> speedM            {68.68021569453585  , 70.08236749169825};
+            std::valarray<double> speedSide         {70.37512772923496  ,  3.6579130085113265};
+            testParams()
+            {
+                for (size_t i = 0; i < names.size(); i++)
+                {
+                    gasPressureL.push_back(mhdUtils::computeGasPressure(energyL[i], densityL[i], momentumXL[i], momentumYL[i], momentumZL[i], magneticXL[i], magneticYL[i], magneticZL[i], gamma));
+                    gasPressureR.push_back(mhdUtils::computeGasPressure(energyR[i], densityR[i], momentumXR[i], momentumYR[i], momentumZR[i], magneticXR[i], magneticYR[i], magneticZR[i], gamma));
+                    totalPressureL.push_back(mhdUtils::computeTotalPressure(gasPressureL.back(), magneticXL[i], magneticYL[i], magneticZL[i]));
+                    totalPressureR.push_back(mhdUtils::computeTotalPressure(gasPressureL.back(), magneticXR[i], magneticYR[i], magneticZR[i]));
+                }
+            }
+        };
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_approximateWaveSpeeds function
+     *
+     */
+    TEST(tMHDHlldInternalApproximateWaveSpeeds,
+         CorrectInputExpectCorrectOutput)
+    {
+        testParams const parameters;
+        std::vector<double> const fiducialSpeedL      {-22.40376497145191, -11.190385012513822};
+        std::vector<double> const fiducialSpeedR      {24.295526347371595, 12.519790189404299};
+        std::vector<double> const fiducialSpeedM      {-0.81760587897407833, -0.026643804611559244};
+        std::vector<double> const fiducialSpeedStarL  {-19.710500632936679, -4.4880642018724357};
+        std::vector<double> const fiducialSpeedStarR  {9.777062240423124, 9.17474383484066};
+        std::vector<double> const fiducialDensityStarL{24.101290139122913, 50.132466596958501};
+        std::vector<double> const fiducialDensityStarR{78.154104734671265, 84.041595114910123};
+
+        double testSpeedL = 0;
+        double testSpeedR = 0;
+        double testSpeedM = 0;
+        double testSpeedStarL = 0;
+        double testSpeedStarR = 0;
+        double testDensityStarL = 0;
+        double testDensityStarR = 0;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_approximateWaveSpeeds(parameters.densityL[i],
+                                                  parameters.momentumXL[i],
+                                                  parameters.momentumYL[i],
+                                                  parameters.momentumZL[i],
+                                                  parameters.velocityXL[i],
+                                                  parameters.velocityYL[i],
+                                                  parameters.velocityZL[i],
+                                                  parameters.gasPressureL[i],
+                                                  parameters.totalPressureL[i],
+                                                  parameters.magneticXL[i],
+                                                  parameters.magneticYL[i],
+                                                  parameters.magneticZL[i],
+                                                  parameters.densityR[i],
+                                                  parameters.momentumXR[i],
+                                                  parameters.momentumYR[i],
+                                                  parameters.momentumZR[i],
+                                                  parameters.velocityXR[i],
+                                                  parameters.velocityYR[i],
+                                                  parameters.velocityZR[i],
+                                                  parameters.gasPressureR[i],
+                                                  parameters.totalPressureR[i],
+                                                  parameters.magneticXR[i],
+                                                  parameters.magneticYR[i],
+                                                  parameters.magneticZR[i],
+                                                  parameters.gamma,
+                                                  testSpeedL,
+                                                  testSpeedR,
+                                                  testSpeedM,
+                                                  testSpeedStarL,
+                                                  testSpeedStarR,
+                                                  testDensityStarL,
+                                                  testDensityStarR);
+            // Now check results
+            testingUtilities::checkResults(fiducialSpeedL[i],
+                                           testSpeedL,
+                                           parameters.names.at(i) + ", SpeedL");
+            testingUtilities::checkResults(fiducialSpeedR.at(i),
+                                           testSpeedR,
+                                           parameters.names.at(i) + ", SpeedR");
+            testingUtilities::checkResults(fiducialSpeedM.at(i),
+                                           testSpeedM,
+                                           parameters.names.at(i) + ", SpeedM");
+            testingUtilities::checkResults(fiducialSpeedStarL.at(i),
+                                           testSpeedStarL,
+                                           parameters.names.at(i) + ", SpeedStarL");
+            testingUtilities::checkResults(fiducialSpeedStarR.at(i),
+                                           testSpeedStarR,
+                                           parameters.names.at(i) + ", SpeedStarR");
+            testingUtilities::checkResults(fiducialDensityStarL.at(i),
+                                           testDensityStarL,
+                                           parameters.names.at(i) + ", DensityStarL");
+            testingUtilities::checkResults(fiducialDensityStarR.at(i),
+                                           testDensityStarR,
+                                           parameters.names.at(i) + ", DensityStarR");
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_starFluxes function in the non-degenerate
+     * case
+     *
+     */
+     TEST(tMHDHlldInternalStarFluxes,
+          CorrectInputNonDegenerateExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialVelocityStarY    {12.831290892281075, 12.92610185957192};
+        std::vector<double> const fiducialVelocityStarZ    {48.488664548015286, 9.0850326944201107};
+        std::vector<double> const fiducialEnergyStar       {1654897.6912410262, 956.83439334487116};
+        std::vector<double> const fiducialMagneticStarY    {-186.47142421374559, 2.6815421494204679};
+        std::vector<double> const fiducialMagneticStarZ    {-700.91191100481922, 1.5860591049546646};
+        std::vector<double> const fiducialDensityStarFlux  {506.82678248238807, 105.14430372486369};
+        std::vector<double> const fiducialMomentumStarFluxX{135208.06632708258, 14014.840899433098};
+        std::vector<double> const fiducialMomentumStarFluxY{25328.25203616685, 2466.5997745560339};
+        std::vector<double> const fiducialMomentumStarFluxZ{95071.711914347878, 1530.7490710422007};
+        std::vector<double> const fiducialEnergyStarFlux   {116459061.8691024, 3440.9679468544314};
+        std::vector<double> const fiducialMagneticStarFluxY{-13929.399086330559, -166.32034689537392};
+        std::vector<double> const fiducialMagneticStarFluxZ{-52549.811458376971, -34.380297363339892};
+
+        double testVelocityStarY;
+        double testVelocityStarZ;
+        double testEnergyStar;
+        double testMagneticStarY;
+        double testMagneticStarZ;
+        double testDensityStarFlux;
+        double testMomentumStarFluxX;
+        double testMomentumStarFluxY;
+        double testMomentumStarFluxZ;
+        double testEnergyStarFlux;
+        double testMagneticStarFluxY;
+        double testMagneticStarFluxZ;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_starFluxes(parameters.speedM[i],
+                                       parameters.speedSide[i],
+                                       parameters.densityL[i],
+                                       parameters.velocityXL[i],
+                                       parameters.velocityYL[i],
+                                       parameters.velocityZL[i],
+                                       parameters.momentumXL[i],
+                                       parameters.momentumYL[i],
+                                       parameters.momentumZL[i],
+                                       parameters.energyL[i],
+                                       parameters.totalPressureL[i],
+                                       parameters.magneticXL[i],
+                                       parameters.magneticYL[i],
+                                       parameters.magneticZL[i],
+                                       parameters.densityStarL[i],
+                                       parameters.totalPressureStarL[i],
+                                       parameters.densityFluxL[i],
+                                       parameters.momentumFluxXL[i],
+                                       parameters.momentumFluxYL[i],
+                                       parameters.momentumFluxZL[i],
+                                       parameters.energyFluxL[i],
+                                       parameters.magneticFluxYL[i],
+                                       parameters.magneticFluxZL[i],
+                                       testVelocityStarY,
+                                       testVelocityStarZ,
+                                       testEnergyStar,
+                                       testMagneticStarY,
+                                       testMagneticStarZ,
+                                       testDensityStarFlux,
+                                       testMomentumStarFluxX,
+                                       testMomentumStarFluxY,
+                                       testMomentumStarFluxZ,
+                                       testEnergyStarFlux,
+                                       testMagneticStarFluxY,
+                                       testMagneticStarFluxZ);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialVelocityStarY[i],
+                                            testVelocityStarY,
+                                            parameters.names.at(i) + ", VelocityStarY");
+            testingUtilities::checkResults(fiducialVelocityStarZ[i],
+                                            testVelocityStarZ,
+                                            parameters.names.at(i) + ", VelocityStarZ");
+            testingUtilities::checkResults(fiducialEnergyStar[i],
+                                           testEnergyStar,
+                                           parameters.names.at(i) + ", EnergyStar");
+            testingUtilities::checkResults(fiducialMagneticStarY[i],
+                                            testMagneticStarY,
+                                            parameters.names.at(i) + ", MagneticStarY");
+            testingUtilities::checkResults(fiducialMagneticStarZ[i],
+                                            testMagneticStarZ,
+                                            parameters.names.at(i) + ", MagneticStarZ");
+            testingUtilities::checkResults(fiducialDensityStarFlux[i],
+                                            testDensityStarFlux,
+                                            parameters.names.at(i) + ", DensityStarFlux");
+            testingUtilities::checkResults(fiducialMomentumStarFluxX[i],
+                                            testMomentumStarFluxX,
+                                            parameters.names.at(i) + ", MomentumStarFluxX");
+            testingUtilities::checkResults(fiducialMomentumStarFluxY[i],
+                                            testMomentumStarFluxY,
+                                            parameters.names.at(i) + ", MomentumStarFluxY");
+            testingUtilities::checkResults(fiducialMomentumStarFluxZ[i],
+                                            testMomentumStarFluxZ,
+                                            parameters.names.at(i) + ", MomentumStarFluxZ");
+            testingUtilities::checkResults(fiducialEnergyStarFlux[i],
+                                            testEnergyStarFlux,
+                                            parameters.names.at(i) + ", EnergyStarFlux");
+            testingUtilities::checkResults(fiducialMagneticStarFluxY[i],
+                                            testMagneticStarFluxY,
+                                            parameters.names.at(i) + ", MagneticStarFluxY");
+            testingUtilities::checkResults(fiducialMagneticStarFluxZ[i],
+                                            testMagneticStarFluxZ,
+                                            parameters.names.at(i) + ", MagneticStarFluxZ");
+        }
+    }
+
+    /*!
+     * \brief Test the _hlldInternal::_starFluxes function in the degenerate
+     * case
+     *
+     */
+     TEST(tMHDHlldInternalStarFluxes,
+          CorrectInputDegenerateExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        // Used to get us into the degenerate case
+        double const totalPressureStarMultiplier = 1E15;
+
+        std::vector<double> const fiducialVelocityStarY    {0.33040135813215948, 0.69876195899931859};
+        std::vector<double> const fiducialVelocityStarZ    {1.500111692877206, 1.8528943583250035};
+        std::vector<double> const fiducialEnergyStar       {2.7072182962581443e+18, -76277716432851392};
+        std::vector<double> const fiducialMagneticStarY    {12.297499156516622, 63.744719695704063};
+        std::vector<double> const fiducialMagneticStarZ    {46.224045698787776, 37.703264551707541};
+        std::vector<double> const fiducialDensityStarFlux  {506.82678248238807, 105.14430372486369};
+        std::vector<double> const fiducialMomentumStarFluxX{135208.06632708258, 14014.840899433098};
+        std::vector<double> const fiducialMomentumStarFluxY{236.85804348470396, 19.08858135095122};
+        std::vector<double> const fiducialMomentumStarFluxZ{757.76012607552047, 83.112898961023902};
+        std::vector<double> const fiducialEnergyStarFlux   {1.9052083339008875e+20, -2.7901725119926531e+17};
+        std::vector<double> const fiducialMagneticStarFluxY{58.989284454159673, 57.043444592213589};
+        std::vector<double> const fiducialMagneticStarFluxZ{29.976925743532302, 97.733298271413588};
+
+        double testVelocityStarY;
+        double testVelocityStarZ;
+        double testEnergyStar;
+        double testMagneticStarY;
+        double testMagneticStarZ;
+        double testDensityStarFlux;
+        double testMomentumStarFluxX;
+        double testMomentumStarFluxY;
+        double testMomentumStarFluxZ;
+        double testEnergyStarFlux;
+        double testMagneticStarFluxY;
+        double testMagneticStarFluxZ;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_starFluxes(parameters.speedM[i],
+                                        parameters.speedSide[i],
+                                        parameters.densityL[i],
+                                        parameters.velocityXL[i],
+                                        parameters.velocityYL[i],
+                                        parameters.velocityZL[i],
+                                        parameters.momentumXL[i],
+                                        parameters.momentumYL[i],
+                                        parameters.momentumZL[i],
+                                        parameters.energyL[i],
+                                        parameters.totalPressureL[i],
+                                        parameters.magneticXL[i],
+                                        parameters.magneticYL[i],
+                                        parameters.magneticZL[i],
+                                        parameters.densityStarL[i],
+                                        parameters.totalPressureStarL[i] * totalPressureStarMultiplier,
+                                        parameters.densityFluxL[i],
+                                        parameters.momentumFluxXL[i],
+                                        parameters.momentumFluxYL[i],
+                                        parameters.momentumFluxZL[i],
+                                        parameters.energyFluxL[i],
+                                        parameters.magneticFluxYL[i],
+                                        parameters.magneticFluxZL[i],
+                                        testVelocityStarY,
+                                        testVelocityStarZ,
+                                        testEnergyStar,
+                                        testMagneticStarY,
+                                        testMagneticStarZ,
+                                        testDensityStarFlux,
+                                        testMomentumStarFluxX,
+                                        testMomentumStarFluxY,
+                                        testMomentumStarFluxZ,
+                                        testEnergyStarFlux,
+                                        testMagneticStarFluxY,
+                                        testMagneticStarFluxZ);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialVelocityStarY[i],
+                                            testVelocityStarY,
+                                            parameters.names.at(i) + ", VelocityStarY");
+            testingUtilities::checkResults(fiducialVelocityStarZ[i],
+                                            testVelocityStarZ,
+                                            parameters.names.at(i) + ", VelocityStarZ");
+            testingUtilities::checkResults(fiducialEnergyStar[i],
+                                            testEnergyStar,
+                                            parameters.names.at(i) + ", EnergyStar");
+            testingUtilities::checkResults(fiducialMagneticStarY[i],
+                                            testMagneticStarY,
+                                            parameters.names.at(i) + ", MagneticStarY");
+            testingUtilities::checkResults(fiducialMagneticStarZ[i],
+                                            testMagneticStarZ,
+                                            parameters.names.at(i) + ", MagneticStarZ");
+            testingUtilities::checkResults(fiducialDensityStarFlux[i],
+                                            testDensityStarFlux,
+                                            parameters.names.at(i) + ", DensityStarFlux");
+            testingUtilities::checkResults(fiducialMomentumStarFluxX[i],
+                                            testMomentumStarFluxX,
+                                            parameters.names.at(i) + ", MomentumStarFluxX");
+            testingUtilities::checkResults(fiducialMomentumStarFluxY[i],
+                                            testMomentumStarFluxY,
+                                            parameters.names.at(i) + ", MomentumStarFluxY");
+            testingUtilities::checkResults(fiducialMomentumStarFluxZ[i],
+                                            testMomentumStarFluxZ,
+                                            parameters.names.at(i) + ", MomentumStarFluxZ");
+            testingUtilities::checkResults(fiducialEnergyStarFlux[i],
+                                            testEnergyStarFlux,
+                                            parameters.names.at(i) + ", EnergyStarFlux");
+            testingUtilities::checkResults(fiducialMagneticStarFluxY[i],
+                                            testMagneticStarFluxY,
+                                            parameters.names.at(i) + ", MagneticStarFluxY");
+            testingUtilities::checkResults(fiducialMagneticStarFluxZ[i],
+                                            testMagneticStarFluxZ,
+                                            parameters.names.at(i) + ", MagneticStarFluxZ");
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_nonStarFluxes function
+     *
+     */
+    TEST(tMHDHlldInternalNonStarFluxes,
+         CorrectInputExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialDensityFlux  {38.504606872151484, 18.984145880030045};
+        std::vector<double> const fiducialMomentumFluxX{-3088.4810263278778, 2250.9966820900618};
+        std::vector<double> const fiducialMomentumFluxY{-1127.8835013070616, -2000.3517480656785};
+        std::vector<double> const fiducialMomentumFluxZ{-4229.5657456907293, -1155.8240512956793};
+        std::vector<double> const fiducialMagneticFluxY{-8.6244637840856555, 2.9729840344910059};
+        std::vector<double> const fiducialMagneticFluxZ{-56.365490339906408, -43.716615275067923};
+        std::vector<double> const fiducialEnergyFlux   {-12344.460641662206, -2717.2127176227905};
+
+        double testDensityFlux;
+        double testMomentumFluxX;
+        double testMomentumFluxY;
+        double testMomentumFluxZ;
+        double testMagneticFluxY;
+        double testMagneticFluxZ;
+        double testEnergyFlux;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_nonStarFluxes(parameters.momentumXL[i],
+                                          parameters.velocityXL[i],
+                                          parameters.velocityYL[i],
+                                          parameters.velocityZL[i],
+                                          parameters.totalPressureL[i],
+                                          parameters.energyL[i],
+                                          parameters.magneticXL[i],
+                                          parameters.magneticYL[i],
+                                          parameters.magneticZL[i],
+                                          testDensityFlux,
+                                          testMomentumFluxX,
+                                          testMomentumFluxY,
+                                          testMomentumFluxZ,
+                                          testMagneticFluxY,
+                                          testMagneticFluxZ,
+                                          testEnergyFlux);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialDensityFlux[i],
+                                            testDensityFlux,
+                                            parameters.names.at(i) + ", DensityFlux");
+            testingUtilities::checkResults(fiducialMomentumFluxX[i],
+                                           testMomentumFluxX,
+                                           parameters.names.at(i) + ", MomentumFluxX");
+            testingUtilities::checkResults(fiducialMomentumFluxY[i],
+                                           testMomentumFluxY,
+                                           parameters.names.at(i) + ", MomentumFluxY");
+            testingUtilities::checkResults(fiducialMomentumFluxZ[i],
+                                           testMomentumFluxZ,
+                                           parameters.names.at(i) + ", MomentumFluxZ");
+            testingUtilities::checkResults(fiducialMagneticFluxY[i],
+                                           testMagneticFluxY,
+                                           parameters.names.at(i) + ", MagneticFluxY");
+            testingUtilities::checkResults(fiducialMagneticFluxZ[i],
+                                           testMagneticFluxZ,
+                                           parameters.names.at(i) + ", MagneticFluxZ");
+            testingUtilities::checkResults(fiducialEnergyFlux[i],
+                                           testEnergyFlux,
+                                           parameters.names.at(i) + ", EnergyFlux");
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_dotProduct function
+     *
+     */
+    TEST(tMHDHlldInternalDotProduct,
+         CorrectInputExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialDotProduct{5149.7597411033557,6127.2319832451567};
+
+        double testDotProduct;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            testDotProduct = _hlldInternal::_dotProduct(parameters.momentumXL[i],
+                                                        parameters.momentumYL[i],
+                                                        parameters.momentumZL[i],
+                                                        parameters.magneticXL[i],
+                                                        parameters.magneticYL[i],
+                                                        parameters.magneticZL[i]);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialDotProduct[i],
+                                           testDotProduct,
+                                           parameters.names.at(i) + ", DotProduct");
+            }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_doubleStarState function. Non-degenerate
+     * state
+     *
+    */
+    TEST(tMHDHlldInternalDoubleStarState,
+         CorrectInputNonDegenerateExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialVelocityDoubleStarY{-1.5775383335759607, 3.803188977150934};
+        std::vector<double> const fiducialVelocityDoubleStarZ{-3.4914062207842482, -4.2662645349592765};
+        std::vector<double> const fiducialMagneticDoubleStarY{45.259313435283325, 71.787329583230417};
+        std::vector<double> const fiducialMagneticDoubleStarZ{36.670978215630669, 53.189673238238178};
+        std::vector<double> const fiducialEnergyDoubleStarL  {-2048.1953674500514, -999.79694164635089};
+        std::vector<double> const fiducialEnergyDoubleStarR  {1721.0582276783764, 252.04716752257781};
+
+        double testVelocityDoubleStarY;
+        double testVelocityDoubleStarZ;
+        double testMagneticDoubleStarY;
+        double testMagneticDoubleStarZ;
+        double testEnergyDoubleStarL;
+        double testEnergyDoubleStarR;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_doubleStarState(parameters.speedM[i],
+                                            parameters.magneticXL[i],
+                                            parameters.totalPressureStarL[i],
+                                            parameters.densityStarL[i],
+                                            parameters.velocityStarYL[i],
+                                            parameters.velocityStarZL[i],
+                                            parameters.energyStarL[i],
+                                            parameters.magneticStarYL[i],
+                                            parameters.magneticStarZL[i],
+                                            parameters.densityStarR[i],
+                                            parameters.velocityStarYR[i],
+                                            parameters.velocityStarZR[i],
+                                            parameters.energyStarR[i],
+                                            parameters.magneticStarYR[i],
+                                            parameters.magneticStarZR[i],
+                                            testVelocityDoubleStarY,
+                                            testVelocityDoubleStarZ,
+                                            testMagneticDoubleStarY,
+                                            testMagneticDoubleStarZ,
+                                            testEnergyDoubleStarL,
+                                            testEnergyDoubleStarR);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialVelocityDoubleStarY[i],
+                                           testVelocityDoubleStarY,
+                                           parameters.names.at(i) + ", VelocityDoubleStarY");
+            testingUtilities::checkResults(fiducialVelocityDoubleStarZ[i],
+                                           testVelocityDoubleStarZ,
+                                           parameters.names.at(i) + ", VelocityDoubleStarZ");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarY[i],
+                                           testMagneticDoubleStarY,
+                                           parameters.names.at(i) + ", MagneticDoubleStarY");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarZ[i],
+                                           testMagneticDoubleStarZ,
+                                           parameters.names.at(i) + ", MagneticDoubleStarZ");
+            testingUtilities::checkResults(fiducialEnergyDoubleStarL[i],
+                                           testEnergyDoubleStarL,
+                                           parameters.names.at(i) + ", EnergyDoubleStarL");
+            testingUtilities::checkResults(fiducialEnergyDoubleStarR[i],
+                                           testEnergyDoubleStarR,
+                                           parameters.names.at(i) + ", EnergyDoubleStarR");
+        }
+    }
+
+    /*!
+     * \brief Test the _hlldInternal::_doubleStarState function in the
+     * degenerate state.
+     *
+    */
+    TEST(tMHDHlldInternalDoubleStarState,
+         CorrectInputDegenerateExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialVelocityDoubleStarY{1.5746306813243216, 1.4363926014039052};
+        std::vector<double> const fiducialVelocityDoubleStarZ{1.3948193325212686, 1.1515754515491903};
+        std::vector<double> const fiducialMagneticDoubleStarY{62.093488291430653, 54.279167444036723};
+        std::vector<double> const fiducialMagneticDoubleStarZ{62.765890944643196, 93.267654555096414};
+        std::vector<double> const fiducialEnergyDoubleStarL  {6.579867455284738, 30.450436649083692};
+        std::vector<double> const fiducialEnergyDoubleStarR  {90.44484278669114, 61.33664731346812};
+
+        double testVelocityDoubleStarY;
+        double testVelocityDoubleStarZ;
+        double testMagneticDoubleStarY;
+        double testMagneticDoubleStarZ;
+        double testEnergyDoubleStarL;
+        double testEnergyDoubleStarR;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_doubleStarState(parameters.speedM[i],
+                                            0.0,
+                                            parameters.totalPressureStarL[i],
+                                            parameters.densityStarL[i],
+                                            parameters.velocityStarYL[i],
+                                            parameters.velocityStarZL[i],
+                                            parameters.energyStarL[i],
+                                            parameters.magneticStarYL[i],
+                                            parameters.magneticStarZL[i],
+                                            parameters.densityStarR[i],
+                                            parameters.velocityStarYR[i],
+                                            parameters.velocityStarZR[i],
+                                            parameters.energyStarR[i],
+                                            parameters.magneticStarYR[i],
+                                            parameters.magneticStarZR[i],
+                                            testVelocityDoubleStarY,
+                                            testVelocityDoubleStarZ,
+                                            testMagneticDoubleStarY,
+                                            testMagneticDoubleStarZ,
+                                            testEnergyDoubleStarL,
+                                            testEnergyDoubleStarR);
+            // Now check results
+            testingUtilities::checkResults(fiducialVelocityDoubleStarY[i],
+                                            testVelocityDoubleStarY,
+                                            parameters.names.at(i) + ", VelocityDoubleStarY");
+            testingUtilities::checkResults(fiducialVelocityDoubleStarZ[i],
+                                            testVelocityDoubleStarZ,
+                                            parameters.names.at(i) + ", VelocityDoubleStarZ");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarY[i],
+                                            testMagneticDoubleStarY,
+                                            parameters.names.at(i) + ", MagneticDoubleStarY");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarZ[i],
+                                            testMagneticDoubleStarZ,
+                                            parameters.names.at(i) + ", MagneticDoubleStarZ");
+            testingUtilities::checkResults(fiducialEnergyDoubleStarL[i],
+                                            testEnergyDoubleStarL,
+                                            parameters.names.at(i) + ", EnergyDoubleStarL");
+            testingUtilities::checkResults(fiducialEnergyDoubleStarR[i],
+                                            testEnergyDoubleStarR,
+                                            parameters.names.at(i) + ", EnergyDoubleStarR");
+        }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_doubleStarFluxes function
+     *
+     */
+    TEST(tMHDHlldInternalDoubleStarFluxes,
+         CorrectInputExpectCorrectOutput)
+    {
+        testParams const parameters;
+
+        std::vector<double> const fiducialMomentumDoubleStarFluxX{1937.3388606704509, -21.762854649386174};
+        std::vector<double> const fiducialMomentumDoubleStarFluxY{-1555.8040962754276, 39.237503643804175};
+        std::vector<double> const fiducialMomentumDoubleStarFluxZ{-801.91650203165148, -64.746529703562871};
+        std::vector<double> const fiducialEnergyDoubleStarFlux   {2781.4706748628528, 136.89786983482355};
+        std::vector<double> const fiducialMagneticDoubleStarFluxY{-2799.7143456312342, 141.2263259922299};
+        std::vector<double> const fiducialMagneticDoubleStarFluxZ{1536.9628864256708, -31.569502877970095};
+
+
+        double testMomentumDoubleStarFluxX;
+        double testMomentumDoubleStarFluxY;
+        double testMomentumDoubleStarFluxZ;
+        double testEnergyDoubleStarFlux;
+        double testMagneticDoubleStarFluxY;
+        double testMagneticDoubleStarFluxZ;
+
+        for (size_t i = 0; i < parameters.names.size(); i++)
+        {
+            _hlldInternal::_doubleStarFluxes(parameters.speedSide[i],
+                                             parameters.momentumStarFluxX[i],
+                                             parameters.momentumStarFluxY[i],
+                                             parameters.momentumStarFluxZ[i],
+                                             parameters.energyStarFlux[i],
+                                             parameters.magneticStarFluxY[i],
+                                             parameters.magneticStarFluxZ[i],
+                                             parameters.densityStarL[i],
+                                             parameters.velocityStarXL[i],
+                                             parameters.velocityStarYL[i],
+                                             parameters.velocityStarZL[i],
+                                             parameters.energyStarL[i],
+                                             parameters.magneticStarYL[i],
+                                             parameters.magneticStarZL[i],
+                                             parameters.velocityDoubleStarXL[i],
+                                             parameters.velocityDoubleStarYL[i],
+                                             parameters.velocityDoubleStarZL[i],
+                                             parameters.energyDoubleStar[i],
+                                             parameters.magneticDoubleStarY[i],
+                                             parameters.magneticDoubleStarZ[i],
+                                             testMomentumDoubleStarFluxX,
+                                             testMomentumDoubleStarFluxY,
+                                             testMomentumDoubleStarFluxZ,
+                                             testEnergyDoubleStarFlux,
+                                             testMagneticDoubleStarFluxY,
+                                             testMagneticDoubleStarFluxZ);
+
+            // Now check results
+            testingUtilities::checkResults(fiducialMomentumDoubleStarFluxX[i],
+                                           testMomentumDoubleStarFluxX,
+                                           parameters.names.at(i) + ", MomentumDoubleStarFluxX");
+            testingUtilities::checkResults(fiducialMomentumDoubleStarFluxY[i],
+                                           testMomentumDoubleStarFluxY,
+                                           parameters.names.at(i) + ", MomentumDoubleStarFluxY");
+            testingUtilities::checkResults(fiducialMomentumDoubleStarFluxZ[i],
+                                           testMomentumDoubleStarFluxZ,
+                                           parameters.names.at(i) + ", MomentumDoubleStarFluxZ");
+            testingUtilities::checkResults(fiducialEnergyDoubleStarFlux[i],
+                                           testEnergyDoubleStarFlux,
+                                           parameters.names.at(i) + ", EnergyDoubleStarFlux");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarFluxY[i],
+                                           testMagneticDoubleStarFluxY,
+                                           parameters.names.at(i) + ", MagneticDoubleStarFluxY");
+            testingUtilities::checkResults(fiducialMagneticDoubleStarFluxZ[i],
+                                           testMagneticDoubleStarFluxZ,
+                                           parameters.names.at(i) + ", MagneticDoubleStarFluxZ");
+            }
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Test the _hlldInternal::_returnFluxes function
+     *
+     */
+    TEST(tMHDHlldInternalReturnFluxes,
+         CorrectInputExpectCorrectOutput)
+    {
+        double const dummyValue    = 999;
+        double const densityFlux   = 1;
+        double const momentumFluxX = 2;
+        double const momentumFluxY = 3;
+        double const momentumFluxZ = 4;
+        double const energyFlux    = 5;
+        double const magneticFluxY = 6;
+        double const magneticFluxZ = 7;
+
+        int threadId = 0;
+        int n_cells = 10;
+        int nFields = 8;  // Total number of conserved fields
+        #ifdef  SCALAR
+            nFields += NSCALARS;
+        #endif  // SCALAR
+        #ifdef  DE
+            nFields++;
+        #endif  //DE
+
+        // Lambda for finding indices and check if they're correct
+        auto findIndex = [](std::vector<double> const &vec,
+                            double const &num,
+                            int const &fidIndex,
+                            std::string const &name)
+        {
+            int index = std::distance(vec.begin(), std::find(vec.begin(), vec.end(), num));
+            // EXPECT_EQ(fidIndex, index) << "Error in " << name << " index" << std::endl;
+
+            return index;
+        };
+
+        for (size_t direction = 0; direction < 3; direction++)
+        {
+            int o1, o2, o3;
+            if (direction==0) {o1 = 1; o2 = 2; o3 = 3;}
+            if (direction==1) {o1 = 2; o2 = 3; o3 = 1;}
+            if (direction==2) {o1 = 3; o2 = 1; o3 = 2;}
+
+            std::vector<double> testFluxArray(nFields*n_cells, dummyValue);
+
+            // Fiducial Indices
+            int const fiducialDensityIndex   = threadId;
+            int const fiducialMomentumIndexX = threadId + n_cells * o1;
+            int const fiducialMomentumIndexY = threadId + n_cells * o2;
+            int const fiducialMomentumIndexZ = threadId + n_cells * o3;
+            int const fiducialEnergyIndex    = threadId + n_cells * 4;
+            int const fiducialMagneticYIndex = threadId + n_cells * (o2 + 4 + NSCALARS);
+            int const fiducialMagneticZIndex = threadId + n_cells * (o3 + 4 + NSCALARS);
+
+            _hlldInternal::_returnFluxes(threadId,
+                                         o1,
+                                         o2,
+                                         o3,
+                                         n_cells,
+                                         testFluxArray.data(),
+                                         densityFlux,
+                                         momentumFluxX,
+                                         momentumFluxY,
+                                         momentumFluxZ,
+                                         energyFlux,
+                                         magneticFluxY,
+                                         magneticFluxZ);
+
+            // Find the indices for the various fields
+            int densityLoc    = findIndex(testFluxArray, densityFlux,   fiducialDensityIndex,   "density");
+            int momentumXLocX = findIndex(testFluxArray, momentumFluxX, fiducialMomentumIndexX,  "momentum X");
+            int momentumYLocY = findIndex(testFluxArray, momentumFluxY, fiducialMomentumIndexY,  "momentum Y");
+            int momentumZLocZ = findIndex(testFluxArray, momentumFluxZ, fiducialMomentumIndexZ,  "momentum Z");
+            int energyLoc     = findIndex(testFluxArray, energyFlux,    fiducialEnergyIndex,    "energy");
+            int magneticYLoc  = findIndex(testFluxArray, magneticFluxY, fiducialMagneticYIndex, "magnetic Y");
+            int magneticZLoc  = findIndex(testFluxArray, magneticFluxZ, fiducialMagneticZIndex, "magnetic Z");
+
+            for (size_t i = 0; i < testFluxArray.size(); i++)
+            {
+                // Skip the already checked indices
+                if ((i != densityLoc)    and
+                    (i != momentumXLocX) and
+                    (i != momentumYLocY) and
+                    (i != momentumZLocZ) and
+                    (i != energyLoc)     and
+                    (i != magneticYLoc)  and
+                    (i != magneticZLoc))
+                {
+                    EXPECT_EQ(dummyValue, testFluxArray.at(i))
+                        << "Unexpected value at index that _returnFluxes shouldn't be touching" << std::endl
+                        << "Index     = " << i         << std::endl
+                        << "Direction = " << direction << std::endl;
+                }
+            }
+        }
+    }
+    // =========================================================================
+#endif  // CUDA & HLLD

--- a/src/system_tests/input_files/tHYDROSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
@@ -37,13 +37,17 @@ outdir=./
 # density of left state
 rho_l=1.0
 # velocity of left state
-v_l=0.0
+vx_l=0.0
+vy_l=0.0
+vz_l=0.0
 # pressure of left state
 P_l=1.0
 # density of right state
 rho_r=0.1
 # velocity of right state
-v_r=0.0
+vx_r=0.0
+vy_r=0.0
+vz_r=0.0
 # pressure of right state
 P_r=0.1
 # location of initial discontinuity

--- a/src/utils/mhd_utilities.cpp
+++ b/src/utils/mhd_utilities.cpp
@@ -1,0 +1,18 @@
+/*!
+ * \file mhd_utilities.cpp
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the implementation of various utility functions for MHD
+ *
+ */
+
+// STL Includes
+
+// External Includes
+
+// Local Includes
+#include "../utils/mhd_utilities.h"
+
+namespace mhdUtils
+{
+
+} // end  namespace mhdUtils

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -1,0 +1,259 @@
+/*!
+ * \file mhd_utilities.h
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the declaration of various utility functions for MHD
+ *
+ */
+
+#pragma once
+
+// STL Includes
+
+// External Includes
+
+// Local Includes
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+#include "../utils/gpu.hpp"
+
+/*!
+ * \brief Namespace for MHD utilities
+ *
+ */
+namespace mhdUtils
+{
+    namespace // Anonymouse namespace
+    {
+        // =====================================================================
+        /*!
+         * \brief Compute the fast or slow magnetosonic wave speeds
+         *
+         * \param density The density
+         * \param gasPressure The gas pressure
+         * \param magneticX Magnetic field in the x-direction
+         * \param magneticY Magnetic field in the y-direction
+         * \param magneticZ Magnetic field in the z-direction
+         * \param gamma The adiabatic index
+         * \param waveChoice Which speed to compute. If +1 then compute the
+         * speed of the fast magnetosonic wave, if -1 then the speed of the slow
+         * magnetosonic wave
+         * \return Real The speed of the fast or slow magnetosonic wave
+         */
+        inline __host__ __device__ Real _magnetosonicSpeed(Real const &density,
+                                                           Real const &gasPressure,
+                                                           Real const &magneticX,
+                                                           Real const &magneticY,
+                                                           Real const &magneticZ,
+                                                           Real const &gamma,
+                                                           Real const &waveChoice)
+        {
+            // Compute the sound speed
+            Real bXSquared = magneticX * magneticX;
+            Real bSquared  = bXSquared + ((magneticY*magneticY) + (magneticZ*magneticZ));
+
+            Real term1 = gamma * gasPressure + bSquared;
+
+            Real term2 = (term1*term1) - 4. * gamma * gasPressure * bXSquared;
+            term2      = sqrt(term2);
+
+            return sqrt( (term1 + waveChoice * term2) / (2.0 * fmax(density, TINY_NUMBER)) );
+        }
+        // =====================================================================
+    }// Anonymouse namespace
+
+    // =========================================================================
+    /*!
+     * \brief Compute the MHD energy in the cell
+     *
+     * \param[in] pressure The gas pressure
+     * \param[in] density The density
+     * \param[in] velocityX Velocity in the x-direction
+     * \param[in] velocityY Velocity in the y-direction
+     * \param[in] velocityZ Velocity in the z-direction
+     * \param[in] magneticX Magnetic field in the x-direction
+     * \param[in] magneticY Magnetic field in the y-direction
+     * \param[in] magneticZ Magnetic field in the z-direction
+     * \param[in] gamma The adiabatic index
+     * \return Real The energy within a cell
+     */
+    inline __host__ __device__ Real computeEnergy(Real const &pressure,
+                                                  Real const &density,
+                                                  Real const &velocityX,
+                                                  Real const &velocityY,
+                                                  Real const &velocityZ,
+                                                  Real const &magneticX,
+                                                  Real const &magneticY,
+                                                  Real const &magneticZ,
+                                                  Real const &gamma)
+    {
+        // Compute and return energy
+        return (fmax(pressure,TINY_NUMBER)/(gamma - 1.))
+                + 0.5 * density * (velocityX*velocityX + ((velocityY*velocityY) + (velocityZ*velocityZ)))
+                + 0.5 * (magneticX*magneticX + ((magneticY*magneticY) + (magneticZ*magneticZ)));
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Compute the MHD gas pressure in a cell
+     *
+     * \param[in] energy The energy
+     * \param[in] density The density
+     * \param[in] momentumX Momentum in the x-direction
+     * \param[in] momentumY Momentum in the y-direction
+     * \param[in] momentumZ Momentum in the z-direction
+     * \param[in] magneticX Magnetic field in the x-direction
+     * \param[in] magneticY Magnetic field in the y-direction
+     * \param[in] magneticZ Magnetic field in the z-direction
+     * \param[in] gamma The adiabatic index
+     * \return Real The gas pressure in a cell
+     */
+    inline __host__ __device__ Real computeGasPressure(Real const &energy,
+                                                       Real const &density,
+                                                       Real const &momentumX,
+                                                       Real const &momentumY,
+                                                       Real const &momentumZ,
+                                                       Real const &magneticX,
+                                                       Real const &magneticY,
+                                                       Real const &magneticZ,
+                                                       Real const &gamma)
+    {
+        Real pressure = (gamma - 1.)
+                            * (energy
+                                - 0.5 * (momentumX*momentumX + ((momentumY*momentumY) + (momentumZ*momentumZ))) / density
+                                - 0.5 * (magneticX*magneticX + ((magneticY*magneticY) + (magneticZ*magneticZ))));
+
+        return fmax(pressure, TINY_NUMBER);
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Compute the MHD thermal energy in a cell
+     *
+     * \param[in] energyTot The total energy
+     * \param[in] density The density
+     * \param[in] momentumX Momentum in the x-direction
+     * \param[in] momentumY Momentum in the y-direction
+     * \param[in] momentumZ Momentum in the z-direction
+     * \param[in] magneticX Magnetic field in the x-direction
+     * \param[in] magneticY Magnetic field in the y-direction
+     * \param[in] magneticZ Magnetic field in the z-direction
+     * \param[in] gamma The adiabatic index
+     * \return Real The thermal energy in a cell
+     */
+    inline __host__ __device__ Real computeThermalEnergy(Real const &energyTot,
+                                                         Real const &density,
+                                                         Real const &momentumX,
+                                                         Real const &momentumY,
+                                                         Real const &momentumZ,
+                                                         Real const &magneticX,
+                                                         Real const &magneticY,
+                                                         Real const &magneticZ,
+                                                         Real const &gamma)
+    {
+        return energyTot - 0.5 * (momentumX*momentumX + ((momentumY*momentumY) + (momentumZ*momentumZ))) / fmax(density,TINY_NUMBER)
+                         - 0.5 * (magneticX*magneticX + ((magneticY*magneticY) + (magneticZ*magneticZ)));
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Compute the total MHD pressure. I.e. magnetic pressure + gas
+     * pressure
+     *
+     * \param[in] gasPressure The gas pressure
+     * \param[in] magneticX Magnetic field in the x-direction
+     * \param[in] magneticY Magnetic field in the y-direction
+     * \param[in] magneticZ Magnetic field in the z-direction
+     * \return Real The total MHD pressure
+     */
+    inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure,
+                                                         Real const &magneticX,
+                                                         Real const &magneticY,
+                                                         Real const &magneticZ)
+    {
+        Real pTot =  gasPressure + 0.5 * (magneticX*magneticX + ((magneticY*magneticY) + (magneticZ*magneticZ)));
+
+        return fmax(pTot, TINY_NUMBER);
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Compute the speed of the fast magnetosonic wave
+     *
+     * \param density The gas pressure
+     * \param pressure The density
+     * \param magneticX Magnetic field in the x-direction
+     * \param magneticY Magnetic field in the y-direction
+     * \param magneticZ Magnetic field in the z-direction
+     * \param gamma The adiabatic index
+     * \return Real The speed of the fast magnetosonic wave
+     */
+    inline __host__ __device__ Real fastMagnetosonicSpeed(Real const &density,
+                                                          Real const &pressure,
+                                                          Real const &magneticX,
+                                                          Real const &magneticY,
+                                                          Real const &magneticZ,
+                                                          Real const &gamma)
+    {
+        // Compute the sound speed
+        return _magnetosonicSpeed(density,
+                                  pressure,
+                                  magneticX,
+                                  magneticY,
+                                  magneticZ,
+                                  gamma,
+                                  1.0);
+    }
+    // =========================================================================
+
+    // =========================================================================
+    /*!
+     * \brief Compute the speed of the slow magnetosonic wave
+     *
+     * \param density The gas pressure
+     * \param pressure The density
+     * \param magneticX Magnetic field in the x-direction
+     * \param magneticY Magnetic field in the y-direction
+     * \param magneticZ Magnetic field in the z-direction
+     * \param gamma The adiabatic index
+     * \return Real The speed of the slow magnetosonic wave
+     */
+    inline __host__ __device__ Real slowMagnetosonicSpeed(Real const &density,
+                                                          Real const &pressure,
+                                                          Real const &magneticX,
+                                                          Real const &magneticY,
+                                                          Real const &magneticZ,
+                                                          Real const &gamma)
+    {
+        // Compute the sound speed
+        return _magnetosonicSpeed(density,
+                                  pressure,
+                                  magneticX,
+                                  magneticY,
+                                  magneticZ,
+                                  gamma,
+                                  -1.0);
+    }
+    // =========================================================================
+
+    // =========================================================================
+        /*!
+     * \brief Compute the speed of the Alfven wave in a cell
+     *
+     * \param[in] magneticX The magnetic field in the x direction, ie the direction
+     * along with the Riemann solver is acting
+     * \param[in] density The density in the cell
+     * \return Real The Alfven wave speed
+     */
+    inline __host__ __device__ Real alfvenSpeed(Real const &magneticX,
+                                                Real const &density)
+    {
+        // Compute the Alfven wave speed
+        return fabs(magneticX) / sqrt(fmax(density,TINY_NUMBER));
+    }
+    // =========================================================================
+
+} // end  namespace mhdUtils

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -256,4 +256,39 @@ namespace mhdUtils
     }
     // =========================================================================
 
+    // =========================================================================
+    /*!
+     * \brief Compute the cell centered average of the magnetic fields in a
+     * given cell
+     *
+     * \param[in] dev_conserved A pointer to the device array of conserved variables
+     * \param[in] id The 1D index into each grid subarray.
+     * \param[in] xid The x index
+     * \param[in] yid The y index
+     * \param[in] zid The z index
+     * \param[in] n_cells The total number of cells
+     * \param[in] nx The number of cells in the x-direction
+     * \param[in] ny The number of cells in the y-direction
+     * \param[out] avgBx The cell centered average magnetic field in the x-direction
+     * \param[out] avgBy The cell centered average magnetic field in the y-direction
+     * \param[out] avgBz The cell centered average magnetic field in the z-direction
+     */
+    inline __host__ __device__ void cellCenteredMagneticFields(Real const *dev_conserved,
+                                                               size_t const &id,
+                                                               size_t const &xid,
+                                                               size_t const &yid,
+                                                               size_t const &zid,
+                                                               size_t const &n_cells,
+                                                               size_t const &nx,
+                                                               size_t const &ny,
+                                                               Real &avgBx,
+                                                               Real &avgBy,
+                                                               Real &avgBz)
+    {
+        avgBx = 0.5 * (dev_conserved[(5+NSCALARS)*n_cells + id] + dev_conserved[(5+NSCALARS)*n_cells + ((xid+1) + yid*nx     + zid*nx*ny)]); // id+1 in x
+        avgBy = 0.5 * (dev_conserved[(6+NSCALARS)*n_cells + id] + dev_conserved[(6+NSCALARS)*n_cells + (xid     + (yid+1)*nx + zid*nx*ny)]); // id+1 in y
+        avgBz = 0.5 * (dev_conserved[(7+NSCALARS)*n_cells + id] + dev_conserved[(7+NSCALARS)*n_cells + (xid     + yid*nx     + (zid+1)*nx*ny)]); // id+1 in z
+    }
+    // =========================================================================
+
 } // end  namespace mhdUtils

--- a/src/utils/mhd_utilities_tests.cpp
+++ b/src/utils/mhd_utilities_tests.cpp
@@ -9,6 +9,8 @@
 #include <vector>
 #include <string>
 #include <iostream>
+#include <numeric>
+#include <cmath>
 
 // External Includes
 #include <gtest/gtest.h>    // Include GoogleTest and related libraries/headers
@@ -462,4 +464,42 @@ TEST(tMHDAlfvenSpeed,
 }
 // =============================================================================
 // End of tests for the mhdUtils::alfvenSpeed function
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::cellCenteredMagneticFields function
+// =============================================================================
+TEST(tMHDCellCenteredMagneticFields,
+     CorrectInputExpectCorrectOutput)
+{
+    // Initialize the test grid and other state variables
+    size_t const nx = 3, ny = nx;
+    size_t const xid = std::floor(nx/2), yid = xid, zid = xid;
+    size_t const id = xid + yid*nx + zid*nx*ny;
+
+    size_t const n_cells = std::pow(5,3);
+    // Make sure the vector is large enough that the locations where the
+    // magnetic field would be in the real grid are filled
+    std::vector<double> testGrid(n_cells * (8+NSCALARS));
+    // Populate the grid with values where testGrid.at(i) = double(i). The
+    // values chosen aren't that important, just that every cell has a unique
+    // value
+    std::iota(std::begin(testGrid), std::end(testGrid), 0.);
+
+    // Fiducial and test variables
+    double const fiducialAvgBx = 638.5,
+                 fiducialAvgBy = 764.5,
+                 fiducialAvgBz = 892.5;
+    double testAvgBx, testAvgBy, testAvgBz;
+
+    // Call the function to test
+    mhdUtils::cellCenteredMagneticFields(testGrid.data(), id, xid, yid, zid, n_cells, nx, ny, testAvgBx, testAvgBy, testAvgBz);
+
+    // Check the results
+    testingUtilities::checkResults(fiducialAvgBx, testAvgBx, "cell centered Bx value");
+    testingUtilities::checkResults(fiducialAvgBy, testAvgBy, "cell centered By value");
+    testingUtilities::checkResults(fiducialAvgBz, testAvgBz, "cell centered Bz value");
+}
+// =============================================================================
+// End of tests for the mhdUtils::cellCenteredMagneticFields function
 // =============================================================================

--- a/src/utils/mhd_utilities_tests.cpp
+++ b/src/utils/mhd_utilities_tests.cpp
@@ -1,0 +1,465 @@
+/*!
+ * \file mhd_utilities_tests.cpp
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Tests for the contents of mhd_utilities.h and mhd_utilities.cpp
+ *
+ */
+
+// STL Includes
+#include <vector>
+#include <string>
+#include <iostream>
+
+// External Includes
+#include <gtest/gtest.h>    // Include GoogleTest and related libraries/headers
+
+// Local Includes
+#include "../utils/testing_utilities.h"
+#include "../utils/mhd_utilities.h"
+#include "../global/global.h"
+
+// =============================================================================
+// Local helper functions
+namespace
+{
+    struct testParams
+    {
+        double gamma = 5./3.;
+        std::vector<double> density      {8.4087201154e-100, 1.6756968986e2, 5.4882403847e100};
+        std::vector<double> velocityX    {7.0378624601e-100, 7.0829278656e2, 1.8800514112e100};
+        std::vector<double> velocityY    {7.3583469014e-100, 5.9283073464e2, 5.2725717864e100};
+        std::vector<double> velocityZ    {1.7182972216e-100, 8.8417748226e2, 1.5855352639e100};
+        std::vector<double> momentumX    {8.2340416681e-100, 8.1019429453e2, 5.5062596954e100};
+        std::vector<double> momentumY    {4.9924582299e-100, 7.1254780684e2, 6.5939640992e100};
+        std::vector<double> momentumZ    {3.6703192739e-100, 7.5676716066e2, 7.2115881803e100};
+        std::vector<double> energy       {3.0342082433e-100, 7.6976906577e2, 1.9487120853e100};
+        std::vector<double> pressureGas  {2.2244082909e-100, 8.6772951021e2, 6.7261085663e100};
+        std::vector<double> pressureTotal{8.1704748693e-100, 2.6084125198e2, 1.8242151369e100};
+        std::vector<double> magneticX    {2.8568843801e-100, 9.2400807786e2, 2.1621115264e100};
+        std::vector<double> magneticY    {9.2900880344e-100, 8.0382409757e2, 6.6499532343e100};
+        std::vector<double> magneticZ    {9.5795678229e-100, 3.3284839263e2, 9.2337456649e100};
+        std::vector<std::string> names{"Small number case", "Medium number case", "Large number case"};
+    };
+}
+// =============================================================================
+
+
+// =============================================================================
+// Tests for the mhdUtils::computeEnergy function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::computeEnergy function with the standard set of
+ * parameters
+ *
+ */
+TEST(tMHDComputeEnergy,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> fiducialEnergies{3.3366124363499995e-100,
+                                         137786230.15630624,
+                                         9.2884430880010847e+301};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testEnergy = mhdUtils::computeEnergy(parameters.pressureGas.at(i),
+                                                  parameters.density.at(i),
+                                                  parameters.velocityX.at(i),
+                                                  parameters.velocityY.at(i),
+                                                  parameters.velocityZ.at(i),
+                                                  parameters.magneticX.at(i),
+                                                  parameters.magneticY.at(i),
+                                                  parameters.magneticZ.at(i),
+                                                  parameters.gamma);
+
+        testingUtilities::checkResults(fiducialEnergies.at(i),
+                                       testEnergy,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::computeEnergy function with a the standard set of
+ * parameters except pressure is now negative
+ *
+ */
+TEST(tMHDComputeEnergy,
+     NegativePressureExpectAutomaticFix)
+{
+    testParams parameters;
+    std::vector<double> fiducialEnergies{3.3366124363499995e-100,
+                                         137784928.56204093,
+                                         9.2884430880010847e+301};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testEnergy = mhdUtils::computeEnergy(-parameters.pressureGas.at(i),
+                                                  parameters.density.at(i),
+                                                  parameters.velocityX.at(i),
+                                                  parameters.velocityY.at(i),
+                                                  parameters.velocityZ.at(i),
+                                                  parameters.magneticX.at(i),
+                                                  parameters.magneticY.at(i),
+                                                  parameters.magneticZ.at(i),
+                                                  parameters.gamma);
+
+        testingUtilities::checkResults(fiducialEnergies.at(i),
+                                       testEnergy,
+                                       parameters.names.at(i));
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::computeEnergy function
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::computeGasPressure function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::computeGasPressure function with the standard set of
+ * parameters. Energy has been increased to avoid negative pressures
+ *
+ */
+TEST(tMHDComputeGasPressure,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> energyMultiplier{3, 1.0E4, 1.0E105};
+    std::vector<double> fiducialGasPressures{1.8586864490415075e-100,
+                                             4591434.7663756227,
+                                             1.29869419465575e+205};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testGasPressure = mhdUtils::computeGasPressure(energyMultiplier.at(i) * parameters.energy.at(i),
+                                                            parameters.density.at(i),
+                                                            parameters.momentumX.at(i),
+                                                            parameters.momentumY.at(i),
+                                                            parameters.momentumZ.at(i),
+                                                            parameters.magneticX.at(i),
+                                                            parameters.magneticY.at(i),
+                                                            parameters.magneticZ.at(i),
+                                                            parameters.gamma);
+
+        testingUtilities::checkResults(fiducialGasPressures.at(i),
+                                       testGasPressure,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::computeGasPressure function with a the standard set
+ * of parameters which produce negative pressures
+ *
+ */
+TEST(tMHDComputeGasPressure,
+     NegativePressureExpectAutomaticFix)
+{
+    testParams parameters;
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testGasPressure = mhdUtils::computeGasPressure(parameters.energy.at(i),
+                                                            parameters.density.at(i),
+                                                            parameters.momentumX.at(i),
+                                                            parameters.momentumY.at(i),
+                                                            parameters.momentumZ.at(i),
+                                                            parameters.magneticX.at(i),
+                                                            parameters.magneticY.at(i),
+                                                            parameters.magneticZ.at(i),
+                                                            parameters.gamma);
+
+        // I'm using the binary equality assertion here since in the case of
+        // negative pressure the function should return exactly TINY_NUMBER
+        EXPECT_EQ(TINY_NUMBER, testGasPressure)
+            << "Difference in " << parameters.names.at(i) << std::endl;
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::computeGasPressure function
+// =============================================================================
+
+
+// =============================================================================
+// Tests for the mhdUtils::computeThermalEnergy function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::computeThermalEnergy function with the standard set
+ * of parameters.
+ *
+ */
+TEST(tMHDComputeThermalEnergy,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> energyMultiplier{1.0E85, 1.0E4, 1.0E105};
+    std::vector<double> fiducialGasPressures{3.0342082433e-15,
+                                             6887152.1495634327,
+                                             1.9480412919836246e+205};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testGasPressure = mhdUtils::computeThermalEnergy(energyMultiplier.at(i) * parameters.energy.at(i),
+                                                              parameters.density.at(i),
+                                                              parameters.momentumX.at(i),
+                                                              parameters.momentumY.at(i),
+                                                              parameters.momentumZ.at(i),
+                                                              parameters.magneticX.at(i),
+                                                              parameters.magneticY.at(i),
+                                                              parameters.magneticZ.at(i),
+                                                              parameters.gamma);
+
+        testingUtilities::checkResults(fiducialGasPressures.at(i),
+                                       testGasPressure,
+                                       parameters.names.at(i));
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::computeThermalEnergyfunction
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::computeTotalPressure function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::computeTotalPressure function with the standard set
+ * of parameters.
+ *
+ */
+TEST(tMHDComputeTotalPressure,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> fiducialTotalPressures{9.9999999999999995e-21,
+                                               806223.80964077567,
+                                               6.7079331637514151e+201};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testTotalPressure = mhdUtils::computeTotalPressure(parameters.pressureGas.at(i),
+                                                                parameters.magneticX.at(i),
+                                                                parameters.magneticY.at(i),
+                                                                parameters.magneticZ.at(i));
+
+        testingUtilities::checkResults(fiducialTotalPressures.at(i),
+                                       testTotalPressure,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::computeTotalPressure function with a the standard
+ * set of parameters. Gas pressure has been multiplied and made negative to
+ * generate negative total pressures
+ *
+ */
+TEST(tMHDComputeTotalPressure,
+     NegativePressureExpectAutomaticFix)
+{
+    testParams parameters;
+    std::vector<double> pressureMultiplier{1.0, -1.0e4, -1.0e105};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testTotalPressure = mhdUtils::computeTotalPressure(pressureMultiplier.at(i) * parameters.pressureGas.at(i),
+                                                                parameters.magneticX.at(i),
+                                                                parameters.magneticY.at(i),
+                                                                parameters.magneticZ.at(i));
+
+        // I'm using the binary equality assertion here since in the case of
+        // negative pressure the function should return exactly TINY_NUMBER
+        EXPECT_EQ(TINY_NUMBER, testTotalPressure)
+            << "Difference in " << parameters.names.at(i) << std::endl;
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::computeTotalPressure function
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::fastMagnetosonicSpeed function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::fastMagnetosonicSpeed function with the standard
+ * set of parameters. All values are reduced by 1e-25 in the large number case
+ * to avoid overflow
+ *
+ */
+TEST(tMHDFastMagnetosonicSpeed,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> fiducialFastMagnetosonicSpeed{1.9254472601190615e-40,
+                                                      98.062482309387562,
+                                                      1.5634816865472293e+38};
+    std::vector<double> coef{1.0, 1.0, 1.0e-25};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testFastMagnetosonicSpeed = mhdUtils::fastMagnetosonicSpeed(
+                                                coef.at(i)*parameters.density.at(i),
+                                                coef.at(i)*parameters.pressureGas.at(i),
+                                                coef.at(i)*parameters.magneticX.at(i),
+                                                coef.at(i)*parameters.magneticY.at(i),
+                                                coef.at(i)*parameters.magneticZ.at(i),
+                                                parameters.gamma);
+
+        testingUtilities::checkResults(fiducialFastMagnetosonicSpeed.at(i),
+                                       testFastMagnetosonicSpeed,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::fastMagnetosonicSpeed function with the standard
+ * set of parameters, density is negative. All values are reduced by 1e-25 in
+ * the large number case to avoid overflow.
+ *
+ */
+TEST(tMHDFastMagnetosonicSpeed,
+     NegativeDensityExpectAutomaticFix)
+{
+    testParams parameters;
+    std::vector<double> fiducialFastMagnetosonicSpeed{1.9254472601190615e-40,
+                                                      12694062010603.15,
+                                                      1.1582688085027081e+86};
+    std::vector<double> coef{1.0, 1.0, 1.0e-25};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testFastMagnetosonicSpeed = mhdUtils::fastMagnetosonicSpeed(
+                                                -coef.at(i)*parameters.density.at(i),
+                                                coef.at(i)*parameters.pressureGas.at(i),
+                                                coef.at(i)*parameters.magneticX.at(i),
+                                                coef.at(i)*parameters.magneticY.at(i),
+                                                coef.at(i)*parameters.magneticZ.at(i),
+                                                parameters.gamma);
+
+        testingUtilities::checkResults(fiducialFastMagnetosonicSpeed.at(i),
+                                       testFastMagnetosonicSpeed,
+                                       parameters.names.at(i));
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::fastMagnetosonicSpeed function
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::slowMagnetosonicSpeed function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::slowMagnetosonicSpeed function with the standard
+ * set of parameters. All values are reduced by 1e-25 in the large number case
+ * to avoid overflow
+ *
+ */
+TEST(tMHDSlowMagnetosonicSpeed,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> fiducialSlowMagnetosonicSpeed{0.0,
+                                                      2.138424778167535,
+                                                      0.0};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testSlowMagnetosonicSpeed = mhdUtils::slowMagnetosonicSpeed(
+                                                parameters.density.at(i),
+                                                parameters.pressureGas.at(i),
+                                                parameters.magneticX.at(i),
+                                                parameters.magneticY.at(i),
+                                                parameters.magneticZ.at(i),
+                                                parameters.gamma);
+
+        testingUtilities::checkResults(fiducialSlowMagnetosonicSpeed.at(i),
+                                       testSlowMagnetosonicSpeed,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::slowMagnetosonicSpeed function with the standard
+ * set of parameters, density is negative. All values are reduced by 1e-25 in
+ * the large number case to avoid overflow.
+ *
+ */
+TEST(tMHDSlowMagnetosonicSpeed,
+     NegativeDensityExpectAutomaticFix)
+{
+    testParams parameters;
+    std::vector<double> fiducialSlowMagnetosonicSpeed{0.0,
+                                                      276816332809.37604,
+                                                      0.0};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testSlowMagnetosonicSpeed = mhdUtils::slowMagnetosonicSpeed(
+                                                -parameters.density.at(i),
+                                                parameters.pressureGas.at(i),
+                                                parameters.magneticX.at(i),
+                                                parameters.magneticY.at(i),
+                                                parameters.magneticZ.at(i),
+                                                parameters.gamma);
+
+        testingUtilities::checkResults(fiducialSlowMagnetosonicSpeed.at(i),
+                                       testSlowMagnetosonicSpeed,
+                                       parameters.names.at(i));
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::slowMagnetosonicSpeed function
+// =============================================================================
+
+// =============================================================================
+// Tests for the mhdUtils::alfvenSpeed function
+// =============================================================================
+/*!
+ * \brief Test the mhdUtils::alfvenSpeed function with the standard set of
+ * parameters.
+ *
+ */
+TEST(tMHDAlfvenSpeed,
+     CorrectInputExpectCorrectOutput)
+{
+    testParams parameters;
+    std::vector<double> fiducialAlfvenSpeed{2.8568843800999998e-90,
+                                            71.380245120271113,
+                                            9.2291462785524423e+49};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testAlfvenSpeed = mhdUtils::alfvenSpeed(parameters.magneticX.at(i),
+                                                     parameters.density.at(i));
+
+        testingUtilities::checkResults(fiducialAlfvenSpeed.at(i),
+                                       testAlfvenSpeed,
+                                       parameters.names.at(i));
+    }
+}
+
+/*!
+ * \brief Test the mhdUtils::alfvenSpeed function with the standard set of
+ * parameters except density is negative
+ *
+ */
+TEST(tMHDAlfvenSpeed,
+     NegativeDensityExpectAutomaticFix)
+{
+    testParams parameters;
+    std::vector<double> fiducialAlfvenSpeed{2.8568843800999998e-90,
+                                            9240080778600,
+                                            2.1621115263999998e+110};
+
+    for (size_t i = 0; i < parameters.names.size(); i++)
+    {
+        Real testAlfvenSpeed = mhdUtils::alfvenSpeed(parameters.magneticX.at(i),
+                                                     -parameters.density.at(i));
+
+        testingUtilities::checkResults(fiducialAlfvenSpeed.at(i),
+                                       testAlfvenSpeed,
+                                       parameters.names.at(i));
+    }
+}
+// =============================================================================
+// End of tests for the mhdUtils::alfvenSpeed function
+// =============================================================================

--- a/src/utils/testing_utilities.cpp
+++ b/src/utils/testing_utilities.cpp
@@ -115,7 +115,7 @@ namespace testingUtilities
     }
     // =========================================================================
 
-  void wrapperEqual(int i, int j, int k, std::string dataSetName, 
+  void wrapperEqual(int i, int j, int k, std::string dataSetName,
 		    double test_value, double fid_value, double fixedEpsilon=5.0E-12) {
 
     std::string outString;

--- a/src/utils/testing_utilities.h
+++ b/src/utils/testing_utilities.h
@@ -124,27 +124,6 @@ namespace testingUtilities
 
     // =========================================================================
     /*!
-     * \brief A simple function to compare two doubles with the nearlyEqualDbl
-     * function, perform a GTest assert on the result, and print out the values
-     *
-     * \param[in] fiducialNumber The fiducial number to test against
-     * \param[in] testNumber The unverified number to test
-     * \param[in] outString A string to be printed in the first line of the output
-     * message. Format will be "Difference in outString"
-     * \param[in] fixedEpsilon The fixed epsilon to use in the comparison.
-     * Negative values are ignored and default behaviour is used
-     * \param[in] ulpsEpsilon The ULP epsilon to use in the comparison. Negative
-     * values are ignored and default behaviour is used
-     */
-    void checkResults(double fiducialNumber,
-                      double testNumber,
-                      std::string outString,
-                      double fixedEpsilon = -999,
-                      int ulpsEpsilon = -999);
-    // =========================================================================
-
-    // =========================================================================
-    /*!
      * \brief Holds a single std::string that's intended to be read only and
      * global. Use for storing the path of the root directory of Cholla
      *

--- a/src/utils/testing_utilities.h
+++ b/src/utils/testing_utilities.h
@@ -124,6 +124,21 @@ namespace testingUtilities
 
     // =========================================================================
     /*!
+     * \brief A simple function to compare two doubles with the nearlyEqualDbl
+     * function, perform a GTest assert on the result, and print out the values
+     *
+     * \param fiducialNumber The fiducial number to test against
+     * \param testNumber The unverified number to test
+     * \param outString A string to be printed in the first line of the output
+     * message. Format will be "Difference in outString"
+     */
+    void checkResults(double fiducialNumber,
+                      double testNumber,
+                      std::string outString);
+    // =========================================================================
+
+    // =========================================================================
+    /*!
      * \brief Holds a single std::string that's intended to be read only and
      * global. Use for storing the path of the root directory of Cholla
      *

--- a/src/utils/testing_utilities.h
+++ b/src/utils/testing_utilities.h
@@ -127,14 +127,20 @@ namespace testingUtilities
      * \brief A simple function to compare two doubles with the nearlyEqualDbl
      * function, perform a GTest assert on the result, and print out the values
      *
-     * \param fiducialNumber The fiducial number to test against
-     * \param testNumber The unverified number to test
-     * \param outString A string to be printed in the first line of the output
+     * \param[in] fiducialNumber The fiducial number to test against
+     * \param[in] testNumber The unverified number to test
+     * \param[in] outString A string to be printed in the first line of the output
      * message. Format will be "Difference in outString"
+     * \param[in] fixedEpsilon The fixed epsilon to use in the comparison.
+     * Negative values are ignored and default behaviour is used
+     * \param[in] ulpsEpsilon The ULP epsilon to use in the comparison. Negative
+     * values are ignored and default behaviour is used
      */
     void checkResults(double fiducialNumber,
                       double testNumber,
-                      std::string outString);
+                      std::string outString,
+                      double fixedEpsilon = -999,
+                      int ulpsEpsilon = -999);
     // =========================================================================
 
     // =========================================================================


### PR DESCRIPTION
*Passes all tests*

# Overview

This PR adds some basic, but incomplete, MHD support to Cholla including some general groundwork, grid, IO, initial conditions, boundary conditions, and time step support along with an HLLD solver and a set of MHD utility functions. The primary goal is to make basic MHD implementation visible and available while we're working on refactoring Cholla so that MHD can be considered during the refactor.

# MHD Groundwork

- Add `N_MHD_FIELDS` macro variable to facilitate future expanions. It's 0 if MHD is off and 3 if it's on and can be used as an offset
- Add `MAGNETIC_FIELD_UNIT` macro variable
- If MHD is set then increase the number of fields by 3
- Add new 'mhd' make type and add it to the GitHub Actions build matrix

# Grid

- `Grid3D::AllocateMemory`, added MHD pointer assignment
- Add magnetic field pointers for host and device to the `Conserved` struct

# I/O

Note that since the magnetic fields are face centered rather than cell centered
they require one extra cell for the last face.

- `Grid3D::Write_Grid_HDF5`, modified to output magnetic fields as well
- `Grid3D::Write_Header_HDF5`, modified to include the size of the magnetic field grid
- `Grid3D::Write_Grid_Text`, modified to output magnetic fields as well

# Initial Conditions

- `Grid3D::Riemann`, added MHD support and modified to accept Y and Z velocities
- `Grid3D::Constant`, added MHD support
- `Grid3D::Uniform_Grid`, added MHD support
- Added new velocity parameters for Riemann problems: `vy_l`, `vz_l`, `vy_r`, `vz_r`; they all default to zero
- Added magnetic fields to the various types of initial condition parameters
- `Grid3D::Read_Grid`, added MHD support

# Boundary Conditions

Modified `PackGhostCellsKernel` to support MHD. Now
`SetBoundaryMapping` and `FindIndex` generate both a non-MHD index,
just like they did before, and a MHD index used for setting the
values of the magnetic field ghost cells.

# MHD Time Step

Refactor the 3D time step calculations to use two new functions to compute a given cells minimum crossing time. In non-MHD builds the `hydroInverseCrossingTime` function is used and in MHD builds the `mhdInverseCrossingTime` function is used. Both of these functions are declared and implemented in `hydro_cuda.h` so that they can be easily called by tests. The hydro version is the exact same code that was previously in `Calc_dt_3D`, it's just been put in its own function for parity with MHD and to improve readability

- MHD support for `AVERAGE_SLOW_CELLS` builds
- Add `mhdUtils::cellCenteredMagneticFields` functions for computing the cell centered magnetic fields using a straight average
- Fix a bug in `Average_Cell_All_Fields` that assumed the dual energy was the fifth field when the rest of the code assumes it's the last field. This required passing in an `n_fields` argument through a couple layers of functions. All the relevant function declarations, definitions, and calls have been updated
- Add test for `mhdUtils::cellCenteredMagneticFields`
- Add test for `hydroInverseCrossingTime`
- Add test for `mhdInverseCrossingTime`

# HLLD Solver

- HLLD solver based on the existing HLLC solver. Most of the calculations for each state are in separete `__device__` functions in the `_hlldInternal` namespace which is externally accessible but not intended to be used externally
- Supports dual energy and passive scalars
  - These are implemented more similarly to how Athena does it than Cholla's HLLC solver since it's clearer and probably faster
- Tests for HLLD solver based on correct data from Athena's solver and utilizing data from Brio & Wu, Dai & Woodward, Ryu & Jones shock tubes along with Einfeldt Strong Rarefaction and specific edge cases
- Tests also test the dual energy and passive scalar support if those are enabled during the build
- Tests for unphysical states as well to make sure the solver handles them well
- Unit tests for all `__device__` functions used

# MHD Utility Functions

- `computeEnergy`
- `computeGasPressure`
- `computeThermalEnergy` - used for dual energy calculations
- `computeTotalPressure`
- `fastMagnetosonicSpeed`
- `slowMagnetosonicSpeed`
- `alfvenSpeed`
- Tests for all the above functions

# General

- `NSCALARS` now defaults to 0, this facilitates pointing the MHD array pointers to the right locations within the grid arrays
- The `runTests` function in `run_tests.sh` now prints out run command
- Added `MPI_ROOT` to `make.host.c3po`
- Added some comments to indicate which ifdef an endif goes with