### PR TITLE
Make Cholla output the git SHA at which it was compiled and the macro flags it was compiled with

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,12 @@ endif
 
 EXEC := bin/cholla$(SUFFIX)
 
+# Get the git hash and setup macro to store a string of all the other macros so
+# that they can be written to the save files
+DFLAGS      += -DGIT_HASH='"$(shell git rev-parse --verify HEAD)"'
+MACRO_FLAGS := -DMACRO_FLAGS='"$(DFLAGS)"'
+DFLAGS      += $(MACRO_FLAGS)
+
 $(EXEC): prereq-build $(OBJS)
 	mkdir -p bin/ && $(LD) $(LDFLAGS) $(OBJS) -o $(EXEC) $(LIBS)
 	eval $(EXTRA_COMMANDS)

--- a/builds/make.type.hydro
+++ b/builds/make.type.hydro
@@ -1,13 +1,13 @@
 #-- Default hydro only build
 
-#-- separated output flag so that it can be overriden in target-specific 
+#-- separated output flag so that it can be overriden in target-specific
 #   for make check
 OUTPUT    ?=  -DOUTPUT -DHDF5
 
 MPI_GPU   ?=
 
 DFLAGS    += -DCUDA
-DFLAGS    += -DMPI_CHOLLA 
+DFLAGS    += -DMPI_CHOLLA
 DFLAGS    += -DPRECISION=2
 DFLAGS    += -DPPMP
 DFLAGS    += -DHLLC
@@ -38,9 +38,9 @@ DFLAGS    += $(OUTPUT)
 
 #Select if the Hydro Conserved data will reside in the GPU
 #and the MPI transfers are done from the GPU
-#If not specified, MPI_GPU is off by default 
+#If not specified, MPI_GPU is off by default
 #This is set in the system make.host file
-DFLAGS    += $(MPI_GPU)  
+DFLAGS    += $(MPI_GPU)
 
 DFLAGS    += -DPARALLEL_OMP
 DFLAGS    += -DN_OMP_THREADS=$(OMP_NUM_THREADS)

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -481,6 +481,22 @@ void Grid3D::Write_Header_HDF5(hid_t file_id)
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &gama);
   // Close the attribute
   status = H5Aclose(attribute_id);
+
+  // String attributes
+  hid_t stringType = H5Tcopy(H5T_C_S1);
+  H5Tset_size(stringType, H5T_VARIABLE);
+
+  attribute_id = H5Acreate(file_id, "Git Commit Hash", stringType, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+  const char * gitHash = GIT_HASH;
+  status = H5Awrite(attribute_id, stringType, &gitHash);
+  H5Aclose(attribute_id);
+
+  attribute_id = H5Acreate(file_id, "Macro Flags", stringType, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+  const char * macroFlags = MACRO_FLAGS;
+  status = H5Awrite(attribute_id, stringType, &macroFlags);
+  H5Aclose(attribute_id);
+
+  // Numeric Attributes
   attribute_id = H5Acreate(file_id, "t", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &H.t);
   status = H5Aclose(attribute_id);
@@ -701,6 +717,22 @@ void Grid3D::Write_Header_Rotated_HDF5(hid_t file_id)
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &gama);
   // Close the attribute
   status = H5Aclose(attribute_id);
+
+  // String attributes
+  hid_t stringType = H5Tcopy(H5T_C_S1);
+  H5Tset_size(stringType, H5T_VARIABLE);
+
+  attribute_id = H5Acreate(file_id, "Git Commit Hash", stringType, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+  const char * gitHash = GIT_HASH;
+  status = H5Awrite(attribute_id, stringType, &gitHash);
+  H5Aclose(attribute_id);
+
+  attribute_id = H5Acreate(file_id, "Macro Flags", stringType, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
+  const char * macroFlags = MACRO_FLAGS;
+  status = H5Awrite(attribute_id, stringType, &macroFlags);
+  H5Aclose(attribute_id);
+
+  // Numeric Attributes
   attribute_id = H5Acreate(file_id, "t", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT);
   status = H5Awrite(attribute_id, H5T_NATIVE_DOUBLE, &H.t);
   status = H5Aclose(attribute_id);

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -409,16 +409,16 @@ void OutputSlices(Grid3D &G, struct parameters P, int nfile)
  *  \brief Write some relevant header info to a text output file. */
 void Grid3D::Write_Header_Text(FILE *fp)
 {
-
   // Write the header info to the output file
   fprintf(fp, "Header Information\n");
+  fprintf(fp, "Git Commit Hash = %s\n", GIT_HASH);
+  fprintf(fp, "Macro Flags     = %s\n", MACRO_FLAGS);
   fprintf(fp, "n_step: %d  sim t: %f  sim dt: %f\n", H.n_step, H.t, H.dt);
   fprintf(fp, "mass unit: %e  length unit: %e  time unit: %e\n", MASS_UNIT, LENGTH_UNIT, TIME_UNIT);
   fprintf(fp, "nx: %d  ny: %d  nz: %d\n", H.nx, H.ny, H.nz);
   fprintf(fp, "xmin: %f  ymin: %f  zmin: %f\n", H.xbound, H.ybound, H.zbound);
   fprintf(fp, "xlen: %f  ylen: %f  zlen: %f\n", H.domlen_x, H.domlen_y, H.domlen_z);
   fprintf(fp, "t: %f\n", H.t);
-
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,16 +66,22 @@ int main(int argc, char *argv[])
   if (strcmp(P.init, "Read_Grid") == 0  ) chprintf ("Input directory:  %s\n", P.indir);
   chprintf ("Output directory:  %s\n", P.outdir);
 
-  //Create a Log file to output run-time messages
+  //Create a Log file to output run-time messages and output the git hash and
+  //macro flags used
   Create_Log_File(P);
+  std::string message = "Git Commit Hash = " + std::string(GIT_HASH);
+  Write_Message_To_Log_File( message.c_str() );
+  message = "Macro Flags     = " + std::string(MACRO_FLAGS);
+  Write_Message_To_Log_File( message.c_str() );
+
+
 
   // initialize the grid
   G.Initialize(&P);
   chprintf("Local number of grid cells: %d %d %d %d\n", G.H.nx_real, G.H.ny_real, G.H.nz_real, G.H.n_cells);
 
-  char *message = (char*)malloc(50 * sizeof(char));
-  sprintf(message, "Initializing Simulation" );
-  Write_Message_To_Log_File( message );
+  message = "Initializing Simulation";
+  Write_Message_To_Log_File( message.c_str() );
 
   // Set initial conditions and calculate first dt
   chprintf("Setting initial conditions...\n");
@@ -90,8 +96,8 @@ int main(int argc, char *argv[])
 
   #ifdef DE
   chprintf("\nUsing Dual Energy Formalism:\n eta_1: %0.3f   eta_2: %0.4f\n", DE_ETA_1, DE_ETA_2 );
-  sprintf(message, " eta_1: %0.3f   eta_2: %0.3f  ", DE_ETA_1, DE_ETA_2 );
-  Write_Message_To_Log_File( message );
+  message =  " eta_1: " + std::to_string(DE_ETA_1) + "   eta_2: " + std::to_string(DE_ETA_2);
+  Write_Message_To_Log_File( message.c_str() );
   #endif
 
   #ifdef CPU_TIME
@@ -175,8 +181,8 @@ int main(int argc, char *argv[])
 
   // Evolve the grid, one timestep at a time
   chprintf("Starting calculations.\n");
-  sprintf(message, "Starting calculations." );
-  Write_Message_To_Log_File( message );
+  message = "Starting calculations.";
+  Write_Message_To_Log_File( message.c_str() );
   while (G.H.t < P.tout)
   {
     // get the start time
@@ -301,8 +307,8 @@ int main(int argc, char *argv[])
   G.Timer.Print_Average_Times( P );
   #endif
 
-  sprintf(message, "Simulation completed successfully." );
-  Write_Message_To_Log_File( message );
+  message = "Simulation completed successfully.";
+  Write_Message_To_Log_File( message.c_str() );
 
   // free the grid
   G.Reset();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ int main(int argc, char *argv[])
   // read in the parameters
   parse_params (param_file, &P, argc, argv);
   // and output to screen
+  chprintf("Git Commit Hash = %s\n", GIT_HASH);
+  chprintf("Macro Flags     = %s\n", MACRO_FLAGS);
   chprintf ("Parameter values:  nx = %d, ny = %d, nz = %d, tout = %f, init = %s, boundaries = %d %d %d %d %d %d\n",
     P.nx, P.ny, P.nz, P.tout, P.init, P.xl_bcnd, P.xu_bcnd, P.yl_bcnd, P.yu_bcnd, P.zl_bcnd, P.zu_bcnd);
   if (strcmp(P.init, "Read_Grid") == 0  ) chprintf ("Input directory:  %s\n", P.indir);

--- a/src/utils/timing_functions.cpp
+++ b/src/utils/timing_functions.cpp
@@ -60,7 +60,7 @@ void Time::Initialize(){
   // Add or remove timers by editing this list, keep TOTAL at the end
   // add NAME to timing_functions.h
   // add Timer.NAME.Start() and Timer.NAME.End() where appropriate.
-  
+
   onetimes = {
     #ifdef PARTICLES
     &(Calc_dt = OneTime("Calc_dt")),
@@ -86,7 +86,7 @@ void Time::Initialize(){
     #endif
     &(Total = OneTime("Total")),
   };
-  
+
 
   chprintf( "\nTiming Functions is ON \n");
 
@@ -111,6 +111,9 @@ void Time::Print_Average_Times( struct parameters P ){
   std::string header;
 
   chprintf( "Writing timing values to file: %s  \n", file_name.c_str());
+
+  std::string gitHash    = "Git Commit Hash = " + std::string(GIT_HASH)    + std::string("\n");
+  std::string macroFlags = "Macro Flags     = " + std::string(MACRO_FLAGS) + std::string("\n\n");
 
   header = "#n_proc  nx  ny  nz  n_omp  n_steps  ";
 
@@ -138,7 +141,12 @@ void Time::Print_Average_Times( struct parameters P ){
 
 // Output timing values
   out_file.open(file_name.c_str(), std::ios::app);
-  if ( !file_exists ) out_file << header;
+  if ( !file_exists )
+  {
+    out_file << gitHash;
+    out_file << macroFlags;
+    out_file << header;
+  }
   #ifdef MPI_CHOLLA
   out_file << nproc << " ";
   #else


### PR DESCRIPTION
The Git SHA and the list of compile time preprocessor macro flags (i.e. all the `-D` arguments) are now passed to Cholla in the `GIT_HASH` and `MACRO_FLAGS` macros. The values of them are then written out to: 

- terminal output
- run_output.log
- run_timing.log
- ASCII data output
- HDF5 data output

This should enable us to know exactly how Cholla was compiled to generate a given data set.