### PR TITLE
fix particle id type mismatch and discarded boundary particles problem

### DIFF
--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -675,26 +675,9 @@ void Particles_3D::Initialize_Disk_Stellar_Clusters(struct parameters *P) {
       #endif//PARTICLES_CPU
   }
 
-
-
   #ifdef PARTICLES_CPU
   n_local = pos_x.size();
   #endif
-
-  #if defined(PARTICLE_IDS) && defined(MPI_CHOLLA)
-  // Get global IDs: Offset the local IDs to get unique global IDs across the MPI ranks
-  chprintf( " Computing Global Particles IDs offset \n" );
-  part_int_t global_id_offset;
-  global_id_offset = Get_Particles_IDs_Global_MPI_Offset( n_local );
-  #ifdef PARTICLES_CPU
-  for ( int p_indx=0; p_indx<n_local; p_indx++ ){
-    partIDs[p_indx] += global_id_offset;
-  }
-  #endif//PARTICLES_CPU
-  #ifdef PARTICLES_GPU
-  //Particles IDs not implemented for PARTICLES_GPU yet
-  #endif//PARTICLES_GPU
-  #endif//PARTICLE_IDS and MPI_CHOLLA
 
   if (lost_particles > 0) chprintf("  lost %lu particles\n", lost_particles);
   chprintf( " Stellar Disk Particles Initialized, n_local: %lu\n", n_local);

--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -625,9 +625,6 @@ void Particles_3D::Initialize_Disk_Stellar_Clusters(struct parameters *P) {
   Real x, y, z, R, phi;
   Real vx, vy, vz, vel, ac;
   Real expFactor, vR_rms, vR, vPhi_str, vPhi, v_c2, vPhi_rand_rms, kappa2;
-  #ifdef PARTICLE_IDS
-  part_int_t id;
-  #endif
   particle_mass = 1e4;  //solar masses
   //unsigned long int N = (long int)(6.5e6 * 0.11258580827352116);  //2kpc radius
   unsigned long int N = (long int)(6.5e6 * 0.9272485558395908);   // 15kpc radius
@@ -642,9 +639,9 @@ void Particles_3D::Initialize_Disk_Stellar_Clusters(struct parameters *P) {
       y = R * sin(phi);
       z = 0;
 
-      if (x < G.xMin || x > G.xMax) continue;
-      if (y < G.yMin || y > G.yMax) continue;
-      if (z < G.zMin || z > G.zMax) continue;
+      if (x < G.xMin || x >= G.xMax) continue;
+      if (y < G.yMin || y >= G.yMax) continue;
+      if (z < G.zMin || z >= G.zMax) continue;
 
       ac  = fabs(Galaxies::MW.gr_disk_D3D(R, 0) + Galaxies::MW.gr_halo_D3D(R, 0));
       vPhi = sqrt(R*ac);
@@ -666,14 +663,7 @@ void Particles_3D::Initialize_Disk_Stellar_Clusters(struct parameters *P) {
       grav_z.push_back(0.0);
 
       #ifdef PARTICLE_IDS
-      id =  i;
-      #ifdef PARALLEL_OMP
-        #pragma omp parallel num_threads( N_OMP_THREADS )
-        {
-          id += 1.0*omp_get_thread_num()/omp_get_num_threads();
-        }
-      #endif //PARALLEL_OMP
-      partIDs.push_back(id);
+      partIDs.push_back(i);
       #endif //PARTICLE_IDS
 
       #ifdef PARTICLE_AGE


### PR DESCRIPTION
Fix from Trey to prevent particles on MPI boundaries from being discarded and a second fix to keep particle IDs as int