### PR TITLE
Switch the cell side magnetic fields are stored

### DIFF
--- a/builds/make.host.c3po
+++ b/builds/make.host.c3po
@@ -4,7 +4,7 @@ CXX               = mpicxx
 CFLAGS_DEBUG      = -g -O0
 CFLAGS_OPTIMIZE   = -g -O2
 CXXFLAGS_DEBUG    = -g -O0 -std=c++11 ${F_OFFLOAD}
-CXXFLAGS_OPTIMIZE = -Ofast -std=c++11 ${F_OFFLOAD}
+CXXFLAGS_OPTIMIZE = -g -Ofast -std=c++11 ${F_OFFLOAD}
 GPUFLAGS_DEBUG    = -g -O0 -std=c++11 -ccbin=mpicxx
 GPUFLAGS_OPTIMIZE = -g -O3 -std=c++11 -ccbin=mpicxx
 

--- a/src/grid/cuda_boundaries.cu
+++ b/src/grid/cuda_boundaries.cu
@@ -278,57 +278,23 @@ __device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *
       // periodic
       case 1:
         id = ig+nx-2*n_ghost;
-        break;
-      // reflective
-      case 2:
-        id = 2*n_ghost-ig-1;
-        *(a) = -1.0;
-        break;
-      // transmissive
-      case 3:
-        id = n_ghost;
-        break;
-      // custom
-      case 4:
-        id = -1;
-        break;
-      // MPI
-      case 5:
-        id = ig;
-        break;
-      // default is periodic
-      default:
-        id = ig+nx-2*n_ghost;
-    }
-    #ifdef  MHD
-      idMag = id;
-    #endif  //MHD
-  }
-  // upper face
-  else
-  {
-    switch(flag)
-    {
-      // periodic
-      case 1:
-        id = ig-nx+2*n_ghost;
         #ifdef  MHD
           idMag = id;
         #endif  //MHD
         break;
       // reflective
       case 2:
-        id = 2*(nx-n_ghost)-ig-1;
+        id = 2*n_ghost-ig-1;
         *(a) = -1.0;
         #ifdef  MHD
-          idMag = id + 1;
+          idMag = id - 1;
         #endif  //MHD
-      break;
+        break;
       // transmissive
       case 3:
-        id = nx-n_ghost-1;
+        id = n_ghost;
         #ifdef  MHD
-          idMag = id + 1;
+          idMag = id - 1;
         #endif  //MHD
         break;
       // custom
@@ -347,11 +313,45 @@ __device__ int FindIndex(int ig, int nx, int flag, int face, int n_ghost, Real *
         break;
       // default is periodic
       default:
-        id = ig-nx+2*n_ghost;
+        id = ig+nx-2*n_ghost;
         #ifdef  MHD
           idMag = id;
         #endif  //MHD
     }
+  }
+  // upper face
+  else
+  {
+    switch(flag)
+    {
+      // periodic
+      case 1:
+        id = ig-nx+2*n_ghost;
+        break;
+      // reflective
+      case 2:
+        id = 2*(nx-n_ghost)-ig-1;
+        *(a) = -1.0;
+      break;
+      // transmissive
+      case 3:
+        id = nx-n_ghost-1;
+        break;
+      // custom
+      case 4:
+        id = -1;
+        break;
+      // MPI
+      case 5:
+        id = ig;
+        break;
+      // default is periodic
+      default:
+        id = ig-nx+2*n_ghost;
+    }
+    #ifdef  MHD
+      idMag = id;
+    #endif  //MHD
   }
   return id;
 }

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -40,7 +40,7 @@
 
 #ifdef CHEMISTRY_GPU
 #include "chemistry_gpu/chemistry_gpu.h"
-#endif 
+#endif
 
 #ifdef ANALYSIS
 #include "../analysis/analysis.h"
@@ -309,11 +309,11 @@ class Grid3D
     // Object that contains data for Grackle cooling
     Cool_GK Cool;
     #endif
-    
+
     #ifdef CPU_TIME
     Time Timer;
     #endif
-    
+
     #ifdef CHEMISTRY_GPU
     // Object that contains data for the GPU chemistry solver
     Chem_GPU Chem;
@@ -357,19 +357,19 @@ class Grid3D
       #ifdef MHD
       /*! \var magnetic_x \brief Array containing the magnetic field in the x
        *  direction of each cell in the grid. Note that this is the magnetic
-       *  field at the x-1/2 face of the cell since constrained transport
+       *  field at the x+1/2 face of the cell since constrained transport
        *  requires face centered, not cell centered, magnetic fields */
       Real *magnetic_x;
 
       /*! \var magnetic_y \brief Array containing the magnetic field in the y
        *  direction of each cell in the grid. Note that this is the magnetic
-       *  field at the y-1/2 face of the cell since constrained transport
+       *  field at the y+1/2 face of the cell since constrained transport
        *  requires face centered, not cell centered, magnetic fields */
       Real *magnetic_y;
 
       /*! \var magnetic_z \brief Array containing the magnetic field in the z
        *  direction of each cell in the grid. Note that this is the magnetic
-       *  field at the z-1/2 face of the cell since constrained transport
+       *  field at the z+1/2 face of the cell since constrained transport
        *  requires face centered, not cell centered, magnetic fields */
       Real *magnetic_z;
       #endif  // MHD
@@ -384,7 +384,7 @@ class Grid3D
       /*! \var grav_potential
       *  \brief Array containing the gravitational potential of each cell, only tracked separately when using  GRAVITY. */
       Real *Grav_potential;
-      
+
       #ifdef CHEMISTRY_GPU
       Real *HI_density;
       Real *HII_density;
@@ -392,9 +392,9 @@ class Grid3D
       Real *HeII_density;
       Real *HeIII_density;
       Real *e_density;
-      #endif 
+      #endif
 
-      
+
       /*! pointer to conserved variable on device */
       Real *device;
       Real *d_density, *d_momentum_x, *d_momentum_y, *d_momentum_z,
@@ -643,7 +643,7 @@ class Grid3D
     void Uniform_Grid();
 
     void Zeldovich_Pancake( struct parameters P );
-    
+
     void Chemistry_Test( struct parameters P );
 
 
@@ -797,13 +797,13 @@ class Grid3D
   void Update_Internal_Energy();
   void Do_Cooling_Step_Grackle();
   #endif
-  
+
   #ifdef CHEMISTRY_GPU
   void Initialize_Chemistry( struct parameters *P );
   void Compute_Gas_Temperature(  Real *temperature, bool convert_cosmo_units  );
   void Update_Chemistry();
   #endif
-  
+
   #ifdef ANALYSIS
   void Initialize_Analysis_Module( struct parameters *P );
   void Compute_and_Output_Analysis( struct parameters *P );

--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -213,23 +213,23 @@ void Grid3D::Constant(Real rho, Real vx, Real vy, Real vz, Real P, Real Bx, Real
   }
 
   // set initial values of conserved variables
-  for(k=kstart; k<kend+1; k++) {
-    for(j=jstart; j<jend+1; j++) {
-      for(i=istart; i<iend+1; i++) {
+  for(k=kstart-1; k<kend; k++) {
+    for(j=jstart-1; j<jend; j++) {
+      for(i=istart-1; i<iend; i++) {
 
         //get cell index
         id = i + j*H.nx + k*H.nx*H.ny;
 
-        // Set the magnetic field including the first "ghost" cell which is
-        // really the right face of the last grid cell
+        // Set the magnetic field including the rightmost ghost cell on the
+        // left side which is really the left face of the first grid cell
         #ifdef  MHD
           C.magnetic_x[id] = Bx;
           C.magnetic_y[id] = By;
           C.magnetic_z[id] = Bz;
         #endif  // MHD
 
-        // Exclude the first ghost cell on the "right" side
-        if ((k < kend) and (j < jend) and (i < iend))
+        // Exclude the rightmost ghost cell on the "left" side
+        if ((k >= kstart) and (j >= jstart) and (i >= istart))
         {
           // set constant initial states
           C.density[id]    = rho;
@@ -418,7 +418,7 @@ void Grid3D::Riemann(Real rho_l, Real vx_l, Real vy_l, Real vz_l, Real P_l, Real
   #ifdef MHD
     auto setMagnetFields = [&] ()
     {
-      Real x_pos_face = x_pos - 0.5 * H.dx;
+      Real x_pos_face = x_pos + 0.5 * H.dx;
 
       if (x_pos_face < diaph)
       {
@@ -436,9 +436,9 @@ void Grid3D::Riemann(Real rho_l, Real vx_l, Real vy_l, Real vz_l, Real P_l, Real
   #endif  // MHD
 
   // set initial values of conserved variables
-  for(k=kstart; k<kend+1; k++) {
-    for(j=jstart; j<jend+1; j++) {
-      for(i=istart; i<iend+1; i++) {
+  for(k=kstart-1; k<kend; k++) {
+    for(j=jstart-1; j<jend; j++) {
+      for(i=istart-1; i<iend; i++) {
 
         //get cell index
         id = i + j*H.nx + k*H.nx*H.ny;
@@ -447,13 +447,13 @@ void Grid3D::Riemann(Real rho_l, Real vx_l, Real vy_l, Real vz_l, Real P_l, Real
         Get_Position(i, j, k, &x_pos, &y_pos, &z_pos);
 
         #ifdef  MHD
-          // Set the magnetic field including the first "ghost" cell on the
-          // right side which is really the right face of the last grid cell
+          // Set the magnetic field including the rightmost ghost cell on the
+          // left side which is really the left face of the first grid cell
           setMagnetFields();
         #endif  //MHD
 
-        // Exclude the first ghost cell on the "right" side
-        if ((k < kend) and (j < jend) and (i < iend))
+        // Exclude the rightmost ghost cell on the "left" side
+        if ((k >= kstart) and (j >= jstart) and (i >= istart))
         {
           if (x_pos < diaph)
           {
@@ -1221,22 +1221,22 @@ void Grid3D::Uniform_Grid()
   size_t const kend   = H.nz-H.n_ghost;
 
   // set the initial values of the conserved variables
-  for (k=kstart; k<kend+1; k++) {
-    for (j=jstart; j<jend+1; j++) {
-      for (i=istart; i<iend+1; i++) {
+  for (k=kstart-1; k<kend; k++) {
+    for (j=jstart-1; j<jend; j++) {
+      for (i=istart-1; i<iend; i++) {
 
         id = i + j*H.nx + k*H.nx*H.ny;
 
         #ifdef  MHD
-          // Set the magnetic field including the first "ghost" cell on the
-          // right side which is really the right face of the last grid cell
+          // Set the magnetic field including the rightmost ghost cell on the
+          // left side which is really the left face of the first grid cell
           C.magnetic_x[id] = 0;
           C.magnetic_y[id] = 0;
           C.magnetic_z[id] = 0;
         #endif  // MHD
 
-        // Exclude the first ghost cell on the right side
-        if ((k < kend) and (j < jend) and (i < iend))
+        // Exclude the rightmost ghost cell on the "left" side
+        if ((k >= kstart) and (j >= jstart) and (i >= istart))
         {
           C.density[id] = 0;
           C.momentum_x[id] = 0;

--- a/src/hydro/hydro_cuda.cu
+++ b/src/hydro/hydro_cuda.cu
@@ -1190,9 +1190,12 @@ __device__ void Average_Cell_All_Fields( int i, int j, int k, int nx, int ny, in
   Average_Cell_Single_Field( 4, i, j, k, nx, ny, nz, ncells, conserved );
   #ifdef  MHD
     // Average MHD
-    Average_Cell_Single_Field( 5+NSCALARS, i, j, k, nx, ny, nz, ncells, conserved );
-    Average_Cell_Single_Field( 6+NSCALARS, i, j, k, nx, ny, nz, ncells, conserved );
-    Average_Cell_Single_Field( 7+NSCALARS, i, j, k, nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 5+NSCALARS, i,   j,   k,   nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 6+NSCALARS, i,   j,   k,   nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 7+NSCALARS, i,   j,   k,   nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 5+NSCALARS, i-1, j,   k,   nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 6+NSCALARS, i,   j-1, k,   nx, ny, nz, ncells, conserved );
+    Average_Cell_Single_Field( 7+NSCALARS, i,   j,   k-1, nx, ny, nz, ncells, conserved );
   #endif  //MHD
   #ifdef DE
   // Average GasEnergy

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -285,9 +285,9 @@ namespace mhdUtils
                                                                Real &avgBy,
                                                                Real &avgBz)
     {
-        avgBx = 0.5 * (dev_conserved[(5+NSCALARS)*n_cells + id] + dev_conserved[(5+NSCALARS)*n_cells + ((xid+1) + yid*nx     + zid*nx*ny)]); // id+1 in x
-        avgBy = 0.5 * (dev_conserved[(6+NSCALARS)*n_cells + id] + dev_conserved[(6+NSCALARS)*n_cells + (xid     + (yid+1)*nx + zid*nx*ny)]); // id+1 in y
-        avgBz = 0.5 * (dev_conserved[(7+NSCALARS)*n_cells + id] + dev_conserved[(7+NSCALARS)*n_cells + (xid     + yid*nx     + (zid+1)*nx*ny)]); // id+1 in z
+        avgBx = 0.5 * (dev_conserved[(5+NSCALARS)*n_cells + id] + dev_conserved[(5+NSCALARS)*n_cells + ((xid-1) + yid*nx     + zid*nx*ny)]);
+        avgBy = 0.5 * (dev_conserved[(6+NSCALARS)*n_cells + id] + dev_conserved[(6+NSCALARS)*n_cells + (xid     + (yid-1)*nx + zid*nx*ny)]);
+        avgBz = 0.5 * (dev_conserved[(7+NSCALARS)*n_cells + id] + dev_conserved[(7+NSCALARS)*n_cells + (xid     + yid*nx     + (zid-1)*nx*ny)]);
     }
     // =========================================================================
 

--- a/src/utils/mhd_utilities_tests.cpp
+++ b/src/utils/mhd_utilities_tests.cpp
@@ -487,9 +487,9 @@ TEST(tMHDCellCenteredMagneticFields,
     std::iota(std::begin(testGrid), std::end(testGrid), 0.);
 
     // Fiducial and test variables
-    double const fiducialAvgBx = 638.5,
-                 fiducialAvgBy = 764.5,
-                 fiducialAvgBz = 892.5;
+    double const fiducialAvgBx = 637.5,
+                 fiducialAvgBy = 761.5,
+                 fiducialAvgBz = 883.5;
     double testAvgBx, testAvgBy, testAvgBz;
 
     // Call the function to test


### PR DESCRIPTION
# Magnetic Field Face Change

Magnetic fields were stored on the "left" (i-1/2) face of the cell that was indexed; i.e. the i,j,k cell stored the magnetic fields at the i-1/2, j-1/2, and k-1/2 faces. This is opposite the way Cholla stores the other face centered quantities (interface states and fluxes) so I switched the magnetic fields to be stored on the "right" faces instead.

# Other Changes:

- Add `-g` compiler flag to `CXXFLAGS_OPTIMIZE` on C-3PO
- Fix bug in `Average_Cell_All_Fields` where it only rebuilt one magnetic field face in a cell instead of both
- Significantly simplified the code for output MHD ASCII files
- Removed code that could output the grid to an HDF5 file when less than 3 dimensions were present. No other part of the code supports non-3D MHD