### PR TITLE
Add util functions for computing 1D & 3D indices

### DIFF
--- a/src/utils/cuda_utilities.h
+++ b/src/utils/cuda_utilities.h
@@ -14,16 +14,47 @@
 
 
 namespace cuda_utilities {
-    /*
-    inline __device__ void Get_GTID(int &id, int &xid, int &yid, int &zid, int &tid, int const &nx, int const &ny, int const &nz) {
-        int blockId = blockIdx.x + blockIdx.y * gridDim.x;
-        int id = threadIdx.x + blockId * blockDim.x;
-        int zid = id / (nx * ny);
-        int yid = (id - zid * nx * ny) / nx;
-        int xid = id - zid * nx * ny - yid * nx;
-        // add a thread id within the block
-        int tid = threadIdx.x;
-    } */
+
+    /*!
+     * \brief Compute the x, y, and z indices based off of the 1D index
+     *
+     * \param[in] id The 1D index
+     * \param[in] nx The total number of cells in the x direction
+     * \param[in] ny The total number of cells in the y direction
+     * \param[out] xid The x index
+     * \param[out] yid The y index
+     * \param[out] zid The z index
+     */
+    inline __host__ __device__ void compute3DIndices(int const &id,
+                                                     int const &nx,
+                                                     int const &ny,
+                                                     int &xid,
+                                                     int &yid,
+                                                     int &zid)
+    {
+        zid = id / (nx * ny);
+        yid = (id - zid * nx * ny) / nx;
+        xid = id - zid * nx * ny - yid * nx;
+    }
+
+    /*!
+     * \brief Compute the 1D index based off of the 3D indices
+     *
+     * \param xid The x index
+     * \param yid The y index
+     * \param zid The z index
+     * \param nx The total number of cells in the x direction
+     * \param ny The total number of cells in the y direction
+     * \return int The 1D index
+     */
+    inline __host__ __device__ int compute1DIndex(int const &xid,
+                                                  int const &yid,
+                                                  int const &zid,
+                                                  int const &nx,
+                                                  int const &ny)
+    {
+        return xid + yid*nx + zid*nx*ny;
+    }
 
     inline __host__ __device__ void Get_Real_Indices(int const &n_ghost, int const &nx, int const &ny, int const &nz, int &is, int &ie, int &js, int &je, int &ks, int &ke) {
         is = n_ghost;
@@ -42,5 +73,5 @@ namespace cuda_utilities {
             ks = n_ghost;
             ke = nz - n_ghost;
         }
-    }   
+    }
 }

--- a/src/utils/cuda_utilities_tests.cpp
+++ b/src/utils/cuda_utilities_tests.cpp
@@ -44,10 +44,10 @@ namespace
 
 TEST(tHYDROSYSTEMCudaUtilsGetRealIndices, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
-    std::vector<std::vector<int>> fiducial_indices {{2, 98, 0, 1, 0, 1}, 
-                                               {2, 2046, 2, 2046, 2, 4094}, 
+    std::vector<std::vector<int>> fiducial_indices {{2, 98, 0, 1, 0, 1},
+                                               {2, 2046, 2, 2046, 2, 4094},
                                                {3, 2045, 3, 2045, 3, 4093},
-                                               {4, 2044, 4, 2044, 4, 4092}}; 
+                                               {4, 2044, 4, 2044, 4, 4092}};
 
     for (size_t i = 0; i < parameters.names.size(); i++)
     {
@@ -68,3 +68,55 @@ TEST(tHYDROSYSTEMCudaUtilsGetRealIndices, CorrectInputExpectCorrectOutput) {
         }
     }
 }
+
+// =============================================================================
+TEST(tALLCompute3DIndices,
+     CorrectInputExpectCorrectOutput)
+{
+    // Parameters
+    int const id = 723;
+    int const nx = 34;
+    int const ny = 14;
+
+    // Fiducial Data
+    int const fiducialXid = 9;
+    int const fiducialYid = 7;
+    int const fiducialZid = 1;
+
+    // Test Variables
+    int testXid;
+    int testYid;
+    int testZid;
+
+    // Get test data
+    cuda_utilities::compute3DIndices(id, nx, ny, testXid, testYid, testZid);
+
+    EXPECT_EQ(fiducialXid, testXid);
+    EXPECT_EQ(fiducialYid, testYid);
+    EXPECT_EQ(fiducialZid, testZid);
+}
+// =============================================================================
+
+// =============================================================================
+TEST(tALLCompute1DIndex,
+     CorrectInputExpectCorrectOutput)
+{
+    // Parameters
+    int const xid = 72;
+    int const yid = 53;
+    int const zid = 14;
+    int const nx  = 128;
+    int const ny  = 64;
+
+    // Fiducial Data
+    int const fiducialId = 121544;
+
+    // Test Variable
+    int testId;
+
+    // Get test data
+    testId = cuda_utilities::compute1DIndex(xid, yid, zid, nx, ny);
+
+    EXPECT_EQ(fiducialId, testId);
+}
+// =============================================================================


### PR DESCRIPTION
- `cuda_utilities::compute3DIndices` computes the 3D indices from the
  1D index
- `cuda_utilities::compute1DIndex` computes the 1D index from the 3D
  indices