### PR TITLE
Fix bug caused by `-Ofast` in tests, refactor `nearlyEqualDbl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ ifeq ($(TEST), true)
   CFLAGS   = $(TEST_FLAGS)
   CXXFLAGS = $(TEST_FLAGS)
   GPUFLAGS = $(TEST_FLAGS)
+
+  # Set the build flags to debug. This is mostly to avoid the approximations
+  # made by Ofast which break std::isnan and std::isinf which are required for
+  # the testing
+  BUILD = DEBUG
 else
   # This isn't a test build so clear out testing related files
   CFILES   := $(filter-out src/system_tests/% %_tests.c,$(CFILES))

--- a/src/utils/mhd_utilities_tests.cpp
+++ b/src/utils/mhd_utilities_tests.cpp
@@ -361,16 +361,18 @@ TEST(tMHDSlowMagnetosonicSpeed,
     testParams parameters;
     std::vector<double> fiducialSlowMagnetosonicSpeed{0.0,
                                                       2.138424778167535,
-                                                      0.0};
+                                                      0.26678309355540852};
+    // Coefficient to make sure the output is well defined and not nan or inf
+    double const coef = 1E-95;
 
-    for (size_t i = 0; i < parameters.names.size(); i++)
+    for (size_t i = 2; i < parameters.names.size(); i++)
     {
         Real testSlowMagnetosonicSpeed = mhdUtils::slowMagnetosonicSpeed(
-                                                parameters.density.at(i),
-                                                parameters.pressureGas.at(i),
-                                                parameters.magneticX.at(i),
-                                                parameters.magneticY.at(i),
-                                                parameters.magneticZ.at(i),
+                                                parameters.density.at(i) * coef,
+                                                parameters.pressureGas.at(i) * coef,
+                                                parameters.magneticX.at(i) * coef,
+                                                parameters.magneticY.at(i) * coef,
+                                                parameters.magneticZ.at(i) * coef,
                                                 parameters.gamma);
 
         testingUtilities::checkResults(fiducialSlowMagnetosonicSpeed.at(i),
@@ -391,16 +393,18 @@ TEST(tMHDSlowMagnetosonicSpeed,
     testParams parameters;
     std::vector<double> fiducialSlowMagnetosonicSpeed{0.0,
                                                       276816332809.37604,
-                                                      0.0};
+                                                      1976400098318.3574};
+    // Coefficient to make sure the output is well defined and not nan or inf
+    double const coef = 1E-95;
 
-    for (size_t i = 0; i < parameters.names.size(); i++)
+    for (size_t i = 2; i < parameters.names.size(); i++)
     {
         Real testSlowMagnetosonicSpeed = mhdUtils::slowMagnetosonicSpeed(
-                                                -parameters.density.at(i),
-                                                parameters.pressureGas.at(i),
-                                                parameters.magneticX.at(i),
-                                                parameters.magneticY.at(i),
-                                                parameters.magneticZ.at(i),
+                                                -parameters.density.at(i) * coef,
+                                                parameters.pressureGas.at(i) * coef,
+                                                parameters.magneticX.at(i) * coef,
+                                                parameters.magneticY.at(i) * coef,
+                                                parameters.magneticZ.at(i) * coef,
                                                 parameters.gamma);
 
         testingUtilities::checkResults(fiducialSlowMagnetosonicSpeed.at(i),

--- a/src/utils/testing_utilities.cpp
+++ b/src/utils/testing_utilities.cpp
@@ -58,14 +58,25 @@ namespace testingUtilities
                         double  const &fixedEpsilon, // = 1E-14 by default
                         int     const &ulpsEpsilon)  // = 4 by default
     {
-        // Handle the near-zero case and pass back the absolute difference
-        absoluteDiff = std::abs(a - b);
-        if (absoluteDiff <= fixedEpsilon)
-            return true;
-
-        // Handle all other cases and pass back the difference in ULPs
+        // Compute differences
         ulpsDiff = ulpsDistanceDbl(a, b);
-        return ulpsDiff <= ulpsEpsilon;
+        absoluteDiff = std::abs(a - b);
+
+        // Perform the ULP check which is for numbers far from zero
+        if (ulpsDiff <= ulpsEpsilon)
+        {
+            return true;
+        }
+        // Perform the absolute check which is for numbers near zero
+        else if (absoluteDiff <= fixedEpsilon)
+        {
+            return true;
+        }
+        // if none of the checks have passed indicate test failure
+        else
+        {
+            return false;
+        }
     }
     // =========================================================================
 


### PR DESCRIPTION
The presense of the `-Ofast` flag, specifically the `--ffinite-math-only` flag that it calls, caused all calls to `std::isnan` and `std::isinf` to be undefined. In practice they always returned false which effectively broke the handling of Nans and infs in `testingUtilities::ulpsDistanceDbl`which in turn is call by all of our FP64 comparison utilities. This has been fixed by settting `BUILD = DEBUG` when building the tests.

Also, `testingUtilities::nearlyEqualDbl` has been refactored so that it always returns proper values of of `absoluteDiff` and `ulpsDiff`. Before it would only compute some of those values and then exit early if they were found to be passing. This could cause `ulpsDiff` to be undefined when comparing small numbers. Now both `absoluteDiff` and `ulpsDiff` are computed first and then the results are checked. This is somewhat less efficient but will lead to more correct and expected behavior.

This change exposed an issue in the tests for the `mhdUtils::slowMagnetosonicSpeed` function. Those tests have been fixed for this change.