### PR TITLE
hydro and cuda utils unit test naming

### DIFF
--- a/src/cooling/cooling_cuda.cu
+++ b/src/cooling/cooling_cuda.cu
@@ -16,7 +16,7 @@ extern texture<float, 2, cudaReadModeElementType> heatTexObj;
 void Cooling_Update(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dt, Real gamma, Real *dt_array){
   dim3 dim1dGrid(ngrid, 1, 1);
   dim3 dim1dBlock(TPB, 1, 1);
-  hipLaunchKernelGGL(cooling_kernel, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, dt, gamma, dt_array);
+  hipLaunchKernelGGL(cooling_kernel, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, dt, gama, dt_array);
   CudaCheckError();  
 }
 

--- a/src/utils/cuda_utilities_tests.cpp
+++ b/src/utils/cuda_utilities_tests.cpp
@@ -42,7 +42,7 @@ namespace
     };
 }
 
-TEST(tHYDROSYSTEMCudaUtilsGetRealIndices, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROCudaUtilsGetRealIndices, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<std::vector<int>> fiducial_indices {{2, 98, 0, 1, 0, 1}, 
                                                {2, 2046, 2, 2046, 2, 4094}, 

--- a/src/utils/hydro_utilities_tests.cpp
+++ b/src/utils/hydro_utilities_tests.cpp
@@ -54,7 +54,7 @@ namespace
     };
 }
 
-TEST(tHYDROSYSTEMHydroUtilsCalcPressurePrimitive, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsCalcPressurePrimitive, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Ps {1e-20, 139983415580.5549, 1.2697896247496674e+301};
 
@@ -66,7 +66,7 @@ TEST(tHYDROSYSTEMHydroUtilsCalcPressurePrimitive, CorrectInputExpectCorrectOutpu
     }
 }
 
-TEST(tHYDROSYSTEMHydroUtilsCalcPressureConserved, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsCalcPressureConserved, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Ps {1e-20, 139984604373.87094, 1.3965808056866668e+301};
 
@@ -78,7 +78,7 @@ TEST(tHYDROSYSTEMHydroUtilsCalcPressureConserved, CorrectInputExpectCorrectOutpu
     }
 }
 
-TEST(tHYDROSYSTEMHydroUtilsCalcTemp, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsCalcTemp, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Ts {3465185.0560059389, 29370603.906644326, 28968949.83344138};
 
@@ -91,7 +91,7 @@ TEST(tHYDROSYSTEMHydroUtilsCalcTemp, CorrectInputExpectCorrectOutput) {
 }
 
 #ifdef DE
-TEST(tHYDROSYSTEMHydroUtilsCalcTempDE, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsCalcTempDE, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Ts {5.123106988008801e-09, 261106139.02514684, 1.2105231166585662e+107};
 
@@ -104,7 +104,7 @@ TEST(tHYDROSYSTEMHydroUtilsCalcTempDE, CorrectInputExpectCorrectOutput) {
 }
 #endif // DE
 
-TEST(tHYDROSYSTEMHydroUtilsCalcEnergyPrimitive, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsCalcEnergyPrimitive, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Es {3.3366124363499997e-10, 1784507.7619407175, 1.9018677140549926e+300};
 
@@ -116,7 +116,7 @@ TEST(tHYDROSYSTEMHydroUtilsCalcEnergyPrimitive, CorrectInputExpectCorrectOutput)
     }
 }
 
-TEST(tHYDROSYSTEMHydroUtilsGetPressureFromDE, CorrectInputExpectCorrectOutput) {
+TEST(tHYDROHydroUtilsGetPressureFromDE, CorrectInputExpectCorrectOutput) {
     TestParams parameters;
     std::vector<double> fiducial_Ps {1.5927160260000002e-10, 71.713126573333341, 7.2549358980000001e+99};
 


### PR DESCRIPTION
Change `HYDROSYSTEM` to just `HYDRO` in the naming of the hydro and cuda utility function unit test naming at Bob's request, as that naming scheme is reserved for system tests. Reran all hydro tests and they passed.