### PR TITLE
GPU Resident Reduction Tools

### DIFF
--- a/src/global/global_cuda.cu
+++ b/src/global/global_cuda.cu
@@ -12,6 +12,7 @@ Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
 Real *eta_x, *eta_y, *eta_z, *etah_x, *etah_y, *etah_z;
 Real *host_dti_array;
 Real *dev_dti_array;
+Real *dev_dti;
 int ngrid;
 
 //Arrays for potential in GPU: Will be set to NULL if not using GRAVITY

--- a/src/global/global_cuda.h
+++ b/src/global/global_cuda.h
@@ -26,9 +26,11 @@ extern bool memory_allocated; // Flag becomes true after allocating the memory o
 extern Real *dev_conserved, *dev_conserved_half;
 // input states and associated interface fluxes (Q* and F* from Stone, 2008)
 extern Real *Q_Lx, *Q_Rx, *Q_Ly, *Q_Ry, *Q_Lz, *Q_Rz, *F_x, *F_y, *F_z;
-// array of inverse timesteps for dt calculation
+// array of inverse timesteps for dt calculation, used ONLY for cooling
 extern Real *host_dti_array;
 extern Real *dev_dti_array;
+// Scalar for storing device side hydro/MHD time steps
+extern Real *dev_dti;
 
 //Arrays for potential in GPU: Will be set to NULL if not using GRAVITY
 extern Real *dev_grav_potential;

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -85,14 +85,14 @@ void Grid3D::Get_Position(long i, long j, long k, Real *x_pos, Real *y_pos, Real
 #else   /*MPI_CHOLLA*/
 
   /* position relative to local xyz bounds */
-  /* This approach was replaced because it is less consistent for multiple cores. 
-  Since distributive property does not perfectly hold for floating point operations     
+  /* This approach was replaced because it is less consistent for multiple cores.
+  Since distributive property does not perfectly hold for floating point operations
 
-  > Global_bound + global_i * dx 
+  > Global_bound + global_i * dx
 
-  is more consistent than 
+  is more consistent than
 
-  >local_bound + local_i*dx = (global_bound + (global_i-local_i)*dx) + local_i*dx. 
+  >local_bound + local_i*dx = (global_bound + (global_i-local_i)*dx) + local_i*dx.
 
   *x_pos = H.xblocal + H.dx*(i-H.n_ghost) + 0.5*H.dx;
   *y_pos = H.yblocal + H.dy*(j-H.n_ghost) + 0.5*H.dy;
@@ -101,7 +101,7 @@ void Grid3D::Get_Position(long i, long j, long k, Real *x_pos, Real *y_pos, Real
 
   *x_pos = H.xbound + (nx_local_start+i-H.n_ghost)*H.dx + 0.5*H.dx;
   *y_pos = H.ybound + (ny_local_start+j-H.n_ghost)*H.dy + 0.5*H.dy;
-  *z_pos = H.zbound + (nz_local_start+k-H.n_ghost)*H.dz + 0.5*H.dz;  
+  *z_pos = H.zbound + (nz_local_start+k-H.n_ghost)*H.dz + 0.5*H.dz;
 
 #endif  /*MPI_CHOLLA*/
 
@@ -312,6 +312,7 @@ void Grid3D::AllocateMemory(void)
   // arrays that hold the max_dti calculation for hydro for each thread block (pre reduction)
   CudaSafeCall( cudaHostAlloc(&host_dti_array, ngrid*sizeof(Real), cudaHostAllocDefault) );
   CudaSafeCall( cudaMalloc((void**)&dev_dti_array, ngrid*sizeof(Real)) );
+  CudaSafeCall( cudaMalloc((void**)&dev_dti, sizeof(Real)) );
 
 
   #if defined( GRAVITY )
@@ -632,6 +633,7 @@ void Grid3D::FreeMemory(void)
   // free the timestep arrays
   CudaSafeCall( cudaFreeHost(host_dti_array) );
   cudaFree(dev_dti_array);
+  cudaFree(dev_dti);
 
   #ifdef GRAVITY
   CudaSafeCall( cudaFreeHost(C.Grav_potential) );

--- a/src/hydro/hydro_cuda.cu
+++ b/src/hydro/hydro_cuda.cu
@@ -489,7 +489,7 @@ __global__ void Calc_dt_1D(Real *dev_conserved, int n_cells, int n_ghost, Real d
     }
   }
 
-  // do the grid wide reduction (find the max inverse timestep in the block)
+  // do the grid wide reduction (find the max inverse timestep in the grid)
   reduction_utilities::gridReduceMax(max_dti, dev_dti);
 }
 
@@ -531,7 +531,7 @@ __global__ void Calc_dt_2D(Real *dev_conserved, int nx, int ny, int n_ghost, Rea
     }
   }
 
-  // do the grid wide reduction (find the max inverse timestep in the block)
+  // do the grid wide reduction (find the max inverse timestep in the grid)
   reduction_utilities::gridReduceMax(max_dti, dev_dti);
 }
 
@@ -612,7 +612,7 @@ __global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_gh
     }
   }
 
-  // do the grid wide reduction (find the max inverse timestep in the block)
+  // do the grid wide reduction (find the max inverse timestep in the grid)
   reduction_utilities::gridReduceMax(max_dti, dev_dti);
 }
 

--- a/src/hydro/hydro_cuda.cu
+++ b/src/hydro/hydro_cuda.cu
@@ -4,12 +4,16 @@
 
 #include <stdio.h>
 #include <math.h>
+#include <float.h>
+
 #include "../utils/gpu.hpp"
 #include "../global/global.h"
 #include "../global/global_cuda.h"
 #include "../hydro/hydro_cuda.h"
 #include "../gravity/gravity_cuda.h"
 #include "../utils/hydro_utilities.h"
+#include "../utils/cuda_utilities.h"
+#include "../utils/reduction_utilities.h"
 
 
 __global__ void Update_Conserved_Variables_1D(Real *dev_conserved, Real *dev_F, int n_cells, int x_off, int n_ghost, Real dx, Real xbound, Real dt, Real gamma, int n_fields)
@@ -454,168 +458,116 @@ __device__ __host__ Real mhdInverseCrossingTime(Real const &E,
 
 
 
-__global__ void Calc_dt_1D(Real *dev_conserved, int n_cells, int n_ghost, Real dx, Real *dti_array, Real gamma)
+__global__ void Calc_dt_1D(Real *dev_conserved, int n_cells, int n_ghost, Real dx, Real *dev_dti, Real gamma)
 {
-  __shared__ Real max_dti[TPB];
+  Real max_dti = -DBL_MAX;
 
   Real d, d_inv, vx, vy, vz, P, cs;
-  int id, tid;
 
-  // get a global thread ID
-  id = threadIdx.x + blockIdx.x * blockDim.x;
-  // and a thread id within the block
-  tid = threadIdx.x;
-
-  // set shared memory to 0
-  max_dti[tid] = 0;
-  __syncthreads();
-
-
-  // threads corresponding to real cells do the calculation
-  if (id > n_ghost - 1 && id < n_cells-n_ghost)
+  // Grid stride loop to perform as much of the reduction as possible. The
+  // fact that `id` has type `size_t` is important. I'm not totally sure why
+  // but setting it to int results in some kind of silent over/underflow issue
+  // even though we're not hitting those kinds of numbers. Setting it to type
+  // uint or size_t fixes them
+  for(size_t id = threadIdx.x + blockIdx.x * blockDim.x; id < n_cells; id += blockDim.x * gridDim.x)
   {
-    // start timestep calculation here
-    // every thread collects the conserved variables it needs from global memory
-    d  =  dev_conserved[            id];
-    d_inv = 1.0 / d;
-    vx =  dev_conserved[1*n_cells + id] * d_inv;
-    vy =  dev_conserved[2*n_cells + id] * d_inv;
-    vz =  dev_conserved[3*n_cells + id] * d_inv;
-    P  = (dev_conserved[4*n_cells + id] - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
-    P  = fmax(P, (Real) TINY_NUMBER);
-    // find the max wavespeed in that cell, use it to calculate the inverse timestep
-    cs = sqrt(d_inv * gamma * P);
-    max_dti[tid] = (fabs(vx)+cs)/dx;
-  }
-  __syncthreads();
-
-  // do the reduction in shared memory (find the max inverse timestep in the block)
-  for (unsigned int s=1; s<blockDim.x; s*=2) {
-    if (tid % (2*s) == 0) {
-      max_dti[tid] = fmax(max_dti[tid], max_dti[tid + s]);
-    }
-    __syncthreads();
-  }
-
-  // write the result for this block to global memory
-  if (tid == 0) dti_array[blockIdx.x] = max_dti[0];
-
-
-}
-
-
-
-__global__ void Calc_dt_2D(Real *dev_conserved, int nx, int ny, int n_ghost, Real dx, Real dy, Real *dti_array, Real gamma)
-{
-  __shared__ Real max_dti[TPB];
-
-  Real d, d_inv, vx, vy, vz, P, cs;
-  int id, tid, xid, yid, n_cells;
-  n_cells = nx*ny;
-
-  // get a global thread ID
-  int blockId = blockIdx.x + blockIdx.y*gridDim.x;
-  id = threadIdx.x + blockId * blockDim.x;
-  yid = id / nx;
-  xid = id - yid*nx;
-  // and a thread id within the block
-  tid = threadIdx.x;
-
-  // set shared memory to 0
-  max_dti[tid] = 0;
-  __syncthreads();
-
-  // threads corresponding to real cells do the calculation
-  if (xid > n_ghost-1 && xid < nx-n_ghost && yid > n_ghost-1 && yid < ny-n_ghost)
-  {
-    // every thread collects the conserved variables it needs from global memory
-    d  =  dev_conserved[            id];
-    d_inv = 1.0 / d;
-    vx =  dev_conserved[1*n_cells + id] * d_inv;
-    vy =  dev_conserved[2*n_cells + id] * d_inv;
-    vz =  dev_conserved[3*n_cells + id] * d_inv;
-    P  = (dev_conserved[4*n_cells + id] - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
-    P  = fmax(P, (Real) 1.0e-20);
-    // find the max wavespeed in that cell, use it to calculate the inverse timestep
-    cs = sqrt(d_inv * gamma * P);
-    max_dti[tid] = fmax((fabs(vx)+cs)/dx, (fabs(vy)+cs)/dy);
-  }
-  __syncthreads();
-
-  // do the reduction in shared memory (find the max inverse timestep in the block)
-  for (unsigned int s=1; s<blockDim.x; s*=2) {
-    if (tid % (2*s) == 0) {
-      max_dti[tid] = fmax(max_dti[tid], max_dti[tid + s]);
-    }
-    __syncthreads();
-  }
-
-  // write the result for this block to global memory
-  if (tid == 0) dti_array[blockId] = max_dti[0];
-
-}
-
-
-__global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy, Real dz, Real *dti_array, Real gamma, Real max_dti_slow)
-{
-  __shared__ Real max_dti[TPB];
-
-  Real d, d_inv, vx, vy, vz, E;
-  int id, xid, yid, zid, n_cells;
-  int tid;
-
-  n_cells = nx*ny*nz;
-
-  // get a global thread ID
-  id = threadIdx.x + blockIdx.x * blockDim.x;
-  zid = id / (nx*ny);
-  yid = (id - zid*nx*ny) / nx;
-  xid = id - zid*nx*ny - yid*nx;
-  // and a thread id within the block
-  tid = threadIdx.x;
-
-  // set shared memory to 0
-  max_dti[tid] = 0;
-  __syncthreads();
-
-  // threads corresponding to real cells do the calculation
-  if (xid > n_ghost-1 && xid < nx-n_ghost && yid > n_ghost-1 && yid < ny-n_ghost && zid > n_ghost-1 && zid < nz-n_ghost)
-  {
-    // every thread collects the conserved variables it needs from global memory
-    d  =  dev_conserved[            id];
-    d_inv = 1.0 / d;
-    vx =  dev_conserved[1*n_cells + id] * d_inv;
-    vy =  dev_conserved[2*n_cells + id] * d_inv;
-    vz =  dev_conserved[3*n_cells + id] * d_inv;
-    E  = dev_conserved[4*n_cells + id];
-    #ifdef  MHD
-      // Compute the cell centered magnetic field using a straight average of
-      // the faces
-      Real avgBx, avgBy, avgBz;
-      mhdUtils::cellCenteredMagneticFields(dev_conserved, id, xid, yid, zid, n_cells, nx, ny, avgBx, avgBy, avgBz);
-    #endif  //MHD
-
-    // Compute the maximum inverse crossing time in the cell
-    #ifdef  MHD
-      max_dti[tid] = mhdInverseCrossingTime(E, d, d_inv, vx, vy, vz, avgBx, avgBy, avgBz, dx, dy, dz, gamma);
-    #else  // not MHD
-      max_dti[tid] = hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma);
-    #endif  //MHD
-
-    #ifdef AVERAGE_SLOW_CELLS
-    // If the cell delta_t is smaller than the min_delta_t, then the cell is averaged over its neighbors
-    if (max_dti[tid] > max_dti_slow){
-      // Average this cell
-      printf(" Average Slow Cell [ %d %d %d ] -> dt_cell=%f    dt_min=%f\n", xid, yid, zid, 1./max_dti[tid],  1./max_dti_slow );
-      Average_Cell_All_Fields( xid, yid, zid, nx, ny, nz, n_cells, n_fields, dev_conserved );
-
-      // Recompute max_dti for this cell
+    // threads corresponding to real cells do the calculation
+    if (id > n_ghost - 1 && id < n_cells-n_ghost)
+    {
+      // start timestep calculation here
+      // every thread collects the conserved variables it needs from global memory
       d  =  dev_conserved[            id];
       d_inv = 1.0 / d;
       vx =  dev_conserved[1*n_cells + id] * d_inv;
       vy =  dev_conserved[2*n_cells + id] * d_inv;
       vz =  dev_conserved[3*n_cells + id] * d_inv;
-      E  = dev_conserved[4*n_cells + id];
+      P  = (dev_conserved[4*n_cells + id] - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
+      P  = fmax(P, (Real) TINY_NUMBER);
+      // find the max wavespeed in that cell, use it to calculate the inverse timestep
+      cs = sqrt(d_inv * gamma * P);
+      max_dti = fmax(max_dti,(fabs(vx)+cs)/dx);
+    }
+  }
+
+  // do the grid wide reduction (find the max inverse timestep in the block)
+  reduction_utilities::gridReduceMax(max_dti, dev_dti);
+}
+
+
+
+__global__ void Calc_dt_2D(Real *dev_conserved, int nx, int ny, int n_ghost, Real dx, Real dy, Real *dev_dti, Real gamma)
+{
+  Real max_dti = -DBL_MAX;
+
+  Real d, d_inv, vx, vy, vz, P, cs;
+  int xid, yid, n_cells;
+  n_cells = nx*ny;
+
+  // Grid stride loop to perform as much of the reduction as possible. The
+  // fact that `id` has type `size_t` is important. I'm not totally sure why
+  // but setting it to int results in some kind of silent over/underflow issue
+  // even though we're not hitting those kinds of numbers. Setting it to type
+  // uint or size_t fixes them
+  for(size_t id = threadIdx.x + blockIdx.x * blockDim.x; id < n_cells; id += blockDim.x * gridDim.x)
+  {
+    // get a global thread ID
+    yid = id / nx;
+    xid = id - yid*nx;
+
+    // threads corresponding to real cells do the calculation
+    if (xid > n_ghost-1 && xid < nx-n_ghost && yid > n_ghost-1 && yid < ny-n_ghost)
+    {
+      // every thread collects the conserved variables it needs from global memory
+      d  =  dev_conserved[            id];
+      d_inv = 1.0 / d;
+      vx =  dev_conserved[1*n_cells + id] * d_inv;
+      vy =  dev_conserved[2*n_cells + id] * d_inv;
+      vz =  dev_conserved[3*n_cells + id] * d_inv;
+      P  = (dev_conserved[4*n_cells + id] - 0.5*d*(vx*vx + vy*vy + vz*vz)) * (gamma - 1.0);
+      P  = fmax(P, (Real) 1.0e-20);
+      // find the max wavespeed in that cell, use it to calculate the inverse timestep
+      cs = sqrt(d_inv * gamma * P);
+      max_dti = fmax(max_dti,fmax((fabs(vx)+cs)/dx, (fabs(vy)+cs)/dy));
+    }
+  }
+
+  // do the grid wide reduction (find the max inverse timestep in the block)
+  reduction_utilities::gridReduceMax(max_dti, dev_dti);
+}
+
+
+__global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy, Real dz, Real *dev_dti, Real gamma, Real max_dti_slow)
+{
+  Real max_dti = -DBL_MAX;
+
+  Real d, d_inv, vx, vy, vz, E;
+  #ifdef  MHD
+    Real avgBx, avgBy, avgBz;
+  #endif  //MHD
+  int xid, yid, zid, n_cells;
+
+  n_cells = nx*ny*nz;
+
+  // Grid stride loop to perform as much of the reduction as possible. The
+  // fact that `id` has type `size_t` is important. I'm not totally sure why
+  // but setting it to int results in some kind of silent over/underflow issue
+  // even though we're not hitting those kinds of numbers. Setting it to type
+  // uint or size_t fixes them
+  for(size_t id = threadIdx.x + blockIdx.x * blockDim.x; id < n_cells; id += blockDim.x * gridDim.x)
+  {
+    // get a global thread ID
+    cuda_utilities::compute3DIndices(id, nx, ny, xid, yid, zid);
+
+    // threads corresponding to real cells do the calculation
+    if (xid > n_ghost-1 && xid < nx-n_ghost && yid > n_ghost-1 && yid < ny-n_ghost && zid > n_ghost-1 && zid < nz-n_ghost)
+    {
+      // every thread collects the conserved variables it needs from global memory
+      d     = dev_conserved[            id];
+      d_inv = 1.0 / d;
+      vx    = dev_conserved[1*n_cells + id] * d_inv;
+      vy    = dev_conserved[2*n_cells + id] * d_inv;
+      vz    = dev_conserved[3*n_cells + id] * d_inv;
+      E     = dev_conserved[4*n_cells + id];
       #ifdef  MHD
         // Compute the cell centered magnetic field using a straight average of
         // the faces
@@ -624,60 +576,72 @@ __global__ void Calc_dt_3D(Real *dev_conserved, int nx, int ny, int nz, int n_gh
 
       // Compute the maximum inverse crossing time in the cell
       #ifdef  MHD
-        max_dti[tid] = mhdInverseCrossingTime(E, d, d_inv, vx, vy, vz, avgBx, avgBy, avgBz, dx, dy, dz, gamma);
+        max_dti = fmax(max_dti,mhdInverseCrossingTime(E, d, d_inv, vx, vy, vz, avgBx, avgBy, avgBz, dx, dy, dz, gamma));
       #else  // not MHD
-        max_dti[tid] = hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma);
+        max_dti = fmax(max_dti,hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma));
       #endif  //MHD
+
+      #ifdef AVERAGE_SLOW_CELLS
+      // If the cell delta_t is smaller than the min_delta_t, then the cell is averaged over its neighbors
+      if (max_dti > max_dti_slow){
+        // Average this cell
+        printf(" Average Slow Cell [ %d %d %d ] -> dt_cell=%f    dt_min=%f\n", xid, yid, zid, 1./max_dti,  1./max_dti_slow );
+        Average_Cell_All_Fields( xid, yid, zid, nx, ny, nz, n_cells, n_fields, dev_conserved );
+
+        // Recompute max_dti for this cell
+        d  =  dev_conserved[            id];
+        d_inv = 1.0 / d;
+        vx =  dev_conserved[1*n_cells + id] * d_inv;
+        vy =  dev_conserved[2*n_cells + id] * d_inv;
+        vz =  dev_conserved[3*n_cells + id] * d_inv;
+        E  = dev_conserved[4*n_cells + id];
+        #ifdef  MHD
+          // Compute the cell centered magnetic field using a straight average of
+          // the faces
+          mhdUtils::cellCenteredMagneticFields(dev_conserved, id, xid, yid, zid, n_cells, nx, ny, avgBx, avgBy, avgBz);
+        #endif  //MHD
+
+        // Compute the maximum inverse crossing time in the cell
+        #ifdef  MHD
+          max_dti = fmax(max_dti,mhdInverseCrossingTime(E, d, d_inv, vx, vy, vz, avgBx, avgBy, avgBz, dx, dy, dz, gamma));
+        #else  // not MHD
+          max_dti = fmax(max_dti,hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma));
+        #endif  //MHD
+      }
+      #endif  //AVERAGE_SLOW_CELLS
     }
-
-    #endif
-  }
-  __syncthreads();
-
-  // do the reduction in shared memory (find the max inverse timestep in the block)
-  for (unsigned int s=1; s<blockDim.x; s*=2) {
-    if (tid % (2*s) == 0) {
-      max_dti[tid] = fmax(max_dti[tid], max_dti[tid + s]);
-    }
-    __syncthreads();
   }
 
-  // write the result for this block to global memory
-  if (tid == 0) dti_array[blockIdx.x] = max_dti[0];
-
+  // do the grid wide reduction (find the max inverse timestep in the block)
+  reduction_utilities::gridReduceMax(max_dti, dev_dti);
 }
 
 Real Calc_dt_GPU(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy, Real dz, Real gamma, Real max_dti_slow)
 {
   // set values for GPU kernels
-  // number of blocks per 1D grid
-  dim3 dim1dGrid(ngrid, 1, 1);
-  //  number of threads per 1D block
-  dim3 dim1dBlock(TPB, 1, 1);
+  uint threadsPerBlock, numBlocks;
+  reduction_utilities::reductionLaunchParams(numBlocks, threadsPerBlock);
 
 
-  // compute dt and store in dev_dti_array
+  // compute dt and store in dev_dti
   if (nx > 1 && ny == 1 && nz == 1) //1D
   {
-    hipLaunchKernelGGL(Calc_dt_1D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, n_ghost, dx, dev_dti_array, gamma);
+    hipLaunchKernelGGL(Calc_dt_1D, numBlocks, threadsPerBlock, 0, 0, dev_conserved, nx, n_ghost, dx, dev_dti, gamma);
   }
   else if (nx > 1 && ny > 1 && nz == 1) //2D
   {
-    hipLaunchKernelGGL(Calc_dt_2D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, n_ghost, dx, dy, dev_dti_array, gamma);
+    hipLaunchKernelGGL(Calc_dt_2D, numBlocks, threadsPerBlock, 0, 0, dev_conserved, nx, ny, n_ghost, dx, dy, dev_dti, gamma);
   }
   else if (nx > 1 && ny > 1 && nz > 1) //3D
   {
-    hipLaunchKernelGGL(Calc_dt_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, dx, dy, dz, dev_dti_array, gamma, max_dti_slow);
+    hipLaunchKernelGGL(Calc_dt_3D, numBlocks, threadsPerBlock, 0, 0, dev_conserved, nx, ny, nz, n_ghost, n_fields, dx, dy, dz, dev_dti, gamma, max_dti_slow);
   }
   CudaCheckError();
 
-  // copy dev_dti_array to host_dti_array
-  CudaSafeCall( cudaMemcpy(host_dti_array, dev_dti_array, ngrid*sizeof(Real), cudaMemcpyDeviceToHost) );
-
-  Real max_dti = 0.0;
-  for (int i=0; i<ngrid; i++) {
-    max_dti = fmax(max_dti, host_dti_array[i]);
-  }
+  // copy device side max_dti to host side max_dti
+  Real max_dti;
+  CudaSafeCall( cudaMemcpy(&max_dti, dev_dti, sizeof(Real), cudaMemcpyDeviceToHost) );
+  cudaDeviceSynchronize();
 
   return max_dti;
 }

--- a/src/utils/gpu.hpp
+++ b/src/utils/gpu.hpp
@@ -20,7 +20,10 @@ static void __attribute__((unused)) check(const hipfftResult err, const char *co
   exit(err);
 }
 
-#endif
+#endif  //CUFFT PARIS PARIC_GALACTIC
+
+#define WARPSIZE 64
+static constexpr int maxWarpsPerBlock = 1024/WARPSIZE;
 
 #define CUFFT_D2Z HIPFFT_D2Z
 #define CUFFT_FORWARD HIPFFT_FORWARD
@@ -57,6 +60,8 @@ static void __attribute__((unused)) check(const hipfftResult err, const char *co
 #define cudaReadModeElementType hipReadModeElementType
 #define cudaSetDevice hipSetDevice
 #define cudaSuccess hipSuccess
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaGetDeviceProperties hipGetDeviceProperties
 
 #define cufftDestroy hipfftDestroy
 #define cufftDoubleComplex hipfftDoubleComplex
@@ -76,7 +81,7 @@ static void __attribute__((unused)) check(const hipError_t err, const char *cons
   exit(err);
 }
 
-#else
+#else  // not O_HIP
 
 #include <cuda_runtime.h>
 
@@ -102,9 +107,12 @@ static void check(const cudaError_t err, const char *const file, const int line)
   exit(err);
 }
 
+#define WARPSIZE 32
+static constexpr int maxWarpsPerBlock = 1024/WARPSIZE;
 #define hipLaunchKernelGGL(F,G,B,M,S,...) F<<<G,B,M,S>>>(__VA_ARGS__)
+#define __shfl_down(...) __shfl_down_sync(0xFFFFFFFF, __VA_ARGS__)
 
-#endif
+#endif  //O_HIP
 
 #define CHECK(X) check(X,__FILE__,__LINE__)
 

--- a/src/utils/reduction_utilities.cu
+++ b/src/utils/reduction_utilities.cu
@@ -1,0 +1,57 @@
+/*!
+ * \file reduction_utilities.cpp
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the implementation of the GPU resident reduction utilities
+ *
+ */
+
+// STL Includes
+#include <float.h>
+
+// External Includes
+
+// Local Includes
+#include "../utils/reduction_utilities.h"
+
+#ifdef CUDA
+    namespace reduction_utilities
+    {
+        // =====================================================================
+        __global__ void kernelReduceMax(Real *in, Real* out, size_t N)
+        {
+            // Initialize variable to store the max value
+            Real maxVal = -DBL_MAX;
+
+            // Grid stride loop to perform as much of the reduction as possible
+            for(size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x)
+            {
+                // A transformation could go here
+
+                // Grid stride reduction
+                maxVal = max(maxVal,in[i]);
+            }
+
+            // Find the maximum val in the grid and write it to `out`. Note that there
+            // is no execution/memory barrier after this and so the reduced scalar is
+            // not available for use in this kernel. The grid wide barrier can be
+            // accomplished by ending this kernel here and then launching a new one or
+            // by using cooperative groups. If this becomes a need it can be added later
+            gridReduceMax(maxVal, out);
+        }
+        // =====================================================================
+
+        // =====================================================================
+        void reductionLaunchParams(uint &numBlocks, uint &threadsPerBlock, uint const &deviceNum)
+        {
+            cudaDeviceProp prop;
+            cudaGetDeviceProperties(&prop, deviceNum);
+
+            // Divide the total number of allowed threads by the number of
+            // threads per block
+            threadsPerBlock =  prop.maxThreadsPerBlock;
+            numBlocks       = (prop.maxThreadsPerMultiProcessor * prop.multiProcessorCount)
+                              / threadsPerBlock;
+        }
+        // =====================================================================
+    }//reduction_utilities
+#endif  //CUDA

--- a/src/utils/reduction_utilities.cu
+++ b/src/utils/reduction_utilities.cu
@@ -17,10 +17,10 @@
     namespace reduction_utilities
     {
         // =====================================================================
-        __global__ void kernelReduceMax(Real *in, Real* out, size_t N)
+        __global__ void kernelReduceMax(Real *in, Real* out, size_t N, Real lowLimit)
         {
             // Initialize variable to store the max value
-            Real maxVal = -DBL_MAX;
+            Real maxVal = lowLimit;
 
             // Grid stride loop to perform as much of the reduction as possible
             for(size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x)

--- a/src/utils/reduction_utilities.h
+++ b/src/utils/reduction_utilities.h
@@ -1,0 +1,192 @@
+/*!
+ * \file reduction_utilities.h
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains the declaration of the GPU resident reduction utilities
+ *
+ */
+
+#pragma once
+
+// STL Includes
+#include <float.h>
+
+// External Includes
+
+// Local Includes
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+#include "../utils/gpu.hpp"
+
+#ifdef CUDA
+    /*!
+    * \brief Namespace to contain device resident reduction functions. Includes
+    * functions and kernels for array reduction, warp level, block level, and
+    * grid level reductions.
+    *
+    */
+    namespace reduction_utilities
+    {
+        // =====================================================================
+        /*!
+        * \brief Perform a reduction within the warp/wavefront to find the
+        * maximum value of `val`
+        *
+        * \param[in] val The thread local variable to find the maximum of across
+        * the warp
+        * \return Real The maximum value of `val` within the warp
+        */
+        __inline__ __device__ Real warpReduceMax(Real val)
+        {
+            for (int offset = warpSize/2; offset > 0; offset /= 2)
+            {
+                val = max(val, __shfl_down(val, offset));
+            }
+            return val;
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+        * \brief Perform a reduction within the block to find the maximum value
+        * of `val`
+        *
+        * \param[in] val The thread local variable to find the maximum of across
+        * the block
+        * \return Real The maximum value of `val` within the block
+        */
+        __inline__ __device__ Real blockReduceMax(Real val)
+        {
+            // Shared memory for storing the results of each warp-wise partial
+            // reduction
+            __shared__ Real shared[::maxWarpsPerBlock];
+
+            int lane   = threadIdx.x % warpSize;  // thread ID within the warp,
+            int warpId = threadIdx.x / warpSize;  // ID of the warp itself
+
+            val = warpReduceMax(val);     // Each warp performs partial reduction
+
+            if (lane==0) shared[warpId]=val; // Write reduced value to shared memory
+
+            __syncthreads();              // Wait for all partial reductions
+
+            //read from shared memory only if that warp existed
+            val = (threadIdx.x < blockDim.x / warpSize) ? shared[lane] : 0;
+
+            if (warpId==0) val = warpReduceMax(val); //Final reduce within first warp
+
+            return val;
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+        * \brief Perform an atomic reduction to find the maximum value of `val`
+        *
+        * \param[out] address The pointer to where to store the reduced scalar
+        * value in device memory
+        * \param[in] val The thread local variable to find the maximum of across
+        * the grid. Typically this should be a partial reduction that has
+        * already been reduced to the block level
+        */
+        __inline__ __device__ double atomicMax_double(double* address, double val)
+        {
+            unsigned long long int* address_as_ull = (unsigned long long int*) address;
+            unsigned long long int old = *address_as_ull, assumed;
+            // Explanation of loop here:
+            // https://stackoverflow.com/questions/16077464/atomicadd-for-double-on-gpu
+            // The loop is to make sure the value at address doesn't change
+            // between the load at the atomic since the entire operation isn't
+            // atomic
+
+            // While it appears that this could result in many times more atomic
+            // operations than required, in practice it's only a handful of
+            // extra operation even in the worst case. Running with 16,000
+            // blocks gives ~8-37 atomics after brief testing
+            do {
+                assumed = old;
+                old = atomicCAS(address_as_ull,
+                                assumed,
+                                __double_as_longlong(fmax(val, __longlong_as_double(assumed))));
+            } while (assumed != old);
+            return __longlong_as_double(old);
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+        * \brief Perform a reduction within the grid to find the maximum value
+        * of `val`. Note that this will overwrite the value in `out` with
+        * `-DBL_MAX`
+        *
+        * \details This function can perform a reduction to find the maximum of
+        * the thread local variable `val` across the entire grid. It relies on a
+        * warp-wise reduction using registers followed by a block-wise reduction
+        * using shared memory, and finally a grid-wise reduction using atomics.
+        * As a result the performance of this function is substantally improved
+        * by using as many threads per block as possible and as few blocks as
+        * possible since each block has to perform an atomic operation. To
+        * accomplish this it is recommened that you use the
+        * `reductionLaunchParams` functions to get the optimal number of blocks
+        * and threads per block to launch rather than relying on Cholla defaults
+        * and then within the kernel using a grid-stride loop to make sure the
+        * kernel works with any combination of threads and blocks. Note that
+        * after this function call you cannot use the reduced value in global
+        * memory since there is no grid wide sync. You can get around this by
+        * either launching a second kernel to do the next steps or by using
+        * cooperative groups to perform a grid wide sync. During it's execution
+        * it also calls multiple __synchThreads and so cannot be called from
+        * within any kind of thread guard.
+        *
+        * \param[in] val The thread local variable to find the maximum of across
+        * the grid
+        * \param[out] out The pointer to where to store the reduced scalar value
+        * in device memory
+        */
+        __inline__ __device__ void gridReduceMax(Real val, Real* out)
+        {
+            // Set the value in global memory so meaningful comparisons can be
+            // performed
+            if (threadIdx.x + blockIdx.x * blockDim.x == 0) *out = -DBL_MAX;
+
+            // Reduce the entire block in parallel
+            val = blockReduceMax(val);
+
+            // Write block level reduced value to the output scalar atomically
+            if (threadIdx.x == 0) atomicMax_double(out, val);
+        }
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+         * \brief Find the maximum value in the array. Note that this will
+         * overwrite the value in `out` with `-DBL_MAX`. If `in` and `out` are
+         * the same array that's ok, all the loads are completed before the
+         * overwrite occurs
+         *
+         * \param[in] in The pointer to the array to reduce in device memory
+         * \param[out] out The pointer to where to store the reduced scalar
+         * value in device memory
+         * \param[in] N The size of the `in` array
+         */
+        __global__ void kernelReduceMax(Real *in, Real* out, size_t N);
+        // =====================================================================
+
+        // =====================================================================
+        /*!
+        * \brief Determine the optimal number of blocks and threads per block to
+        * use when launching a reduction kernel
+        *
+        * \param[out] numBlocks The maximum number of blocks that are
+        * scheduleable by the device in use when each block has the maximum
+        * number of threads
+        * \param[out] threadsPerBlock The maximum threads per block supported by
+        * the device in use
+        * \param[in] deviceNum optional: which device is being targeted.
+        * Defaults to zero
+        */
+        void reductionLaunchParams(uint &numBlocks,
+                                   uint &threadsPerBlock,
+                                   uint const &deviceNum=0);
+        // =====================================================================
+    }  // namespace reduction_utilities
+#endif  //CUDA

--- a/src/utils/reduction_utilities_tests.cu
+++ b/src/utils/reduction_utilities_tests.cu
@@ -1,0 +1,73 @@
+/*!
+ * \file reduction_utilities_tests.cpp
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Tests for the contents of reduction_utilities.h and reduction_utilities.cpp
+ *
+ */
+
+// STL Includes
+#include <vector>
+#include <string>
+#include <iostream>
+#include <random>
+
+// External Includes
+#include <gtest/gtest.h>    // Include GoogleTest and related libraries/headers
+
+// Local Includes
+#include "../utils/testing_utilities.h"
+#include "../utils/reduction_utilities.h"
+#include "../global/global.h"
+
+// =============================================================================
+// Tests for divergence max reduction
+// =============================================================================
+TEST(tALLKernelReduceMax, CorrectInputExpectCorrectOutput)
+{
+    // Launch parameters
+    // =================
+    uint numBlocks, threadsPerBlock;
+    reduction_utilities::reductionLaunchParams(numBlocks, threadsPerBlock);
+
+    // Grid Parameters & testing parameters
+    // ====================================
+    size_t const gridSize = 128;
+    size_t const size     = std::pow(gridSize, 3);;
+    Real   const maxValue = 4;
+    std::vector<Real> host_grid(size);
+    Real host_max;
+
+    // Fill grid with random values and assign maximum value
+    std::mt19937 prng(1);
+    std::uniform_real_distribution<double> doubleRand(-std::abs(maxValue)-1, std::abs(maxValue) - 1);
+    std::uniform_int_distribution<int> intRand(0, host_grid.size()-1);
+    for (size_t i = 0; i < host_grid.size(); i++)
+    {
+        host_grid.at(i) = doubleRand(prng);
+    }
+    host_grid.at(intRand(prng)) = maxValue;
+
+
+    // Allocating and copying to device
+    // ================================
+    Real *dev_grid, *dev_max;
+    CudaSafeCall(cudaMalloc(&dev_grid, host_grid.size() * sizeof(Real)));
+    CudaSafeCall(cudaMalloc(&dev_max, sizeof(Real)));
+    CudaSafeCall(cudaMemcpy(dev_grid, host_grid.data(), host_grid.size() * sizeof(Real), cudaMemcpyHostToDevice));
+
+    // Do the reduction
+    // ================
+    hipLaunchKernelGGL(reduction_utilities::kernelReduceMax, numBlocks, threadsPerBlock, 0, 0, dev_grid, dev_max, host_grid.size());
+    CudaCheckError();
+
+    // Copy back and sync
+    // ==================
+    CudaSafeCall(cudaMemcpy(&host_max, dev_max, sizeof(Real), cudaMemcpyDeviceToHost));
+    cudaDeviceSynchronize();
+
+    // Perform comparison
+    testingUtilities::checkResults(maxValue, host_max, "maximum value found");
+}
+// =============================================================================
+// Tests for divergence max reduction
+// =============================================================================


### PR DESCRIPTION
# GPU Resident Reduction Tools

Cholla regularly performs reductions and previously they were done with a hybrid GPU/CPU approach that was complicated to implement. This commit introduces a reduction that can be performed with a single device function call at the end of a transform-reduce kernel and also a kernel that can be used to reduce an array. Currently the only reduction that is implemented is for finding the maximum, however, it would be very easy to implement it for any common reduction by replacing every instance of `fmax` with the appropriate operator. Tests for the reductions are included.

Note that any transform-reduce kernels that utilize this reduction should use a grid stride loop to perform as much of the tranform-reduce as possible. It's important to minimize the number of blocks as the performance is significantly impacted by having excess blocks. The new `reduction_utilities::reductionLaunchParams` function returns the optimal threads per block and number of threads to launch a reduction.

Thanks to @alwinm and @twhite-cray for helping troubleshoot.

# Time Step Calculations

The new reduction method has been added to the hydro time step calculations. This partially replaces the need for the `dev_dti_array` variable with a single scalar value. The only place that `dev_dti_array` is still used is in the cooling time step calculations and if those kernels are updated to use the new reduction code we will eliminate the need for that array.

# New HIPifly macros

- `cudaGetDeviceProperties`/`hipGetDeviceProperties`
- `cudaDeviceProp`/`hipDeviceProp_t`
- `__shfl_down_sync`/`__shfl_down` - This one assumes that you want
  all lanes in a warp to participate in the shuffle

# Other

- New `WARPSIZE` macro in `gpu.hpp` to choose the right number of
  threads per warp
- New `maxWarpsPerBlock` global variable to indicate the maximum
  number of warps per block