### PR TITLE
Set googletest to automatically load during setup

### DIFF
--- a/builds/setup.crc.gcc.sh
+++ b/builds/setup.crc.gcc.sh
@@ -3,7 +3,7 @@
 #-- This script needs to be sourced in the terminal, e.g.
 #   source ./setup.crc.gcc.sh
 
-module load python/anaconda3-2020.11 gcc/10.1.0 cuda/11.1.0 openmpi/4.0.5 hdf5/1.12.0
+module load python/anaconda3-2020.11 gcc/10.1.0 cuda/11.1.0 openmpi/4.0.5 hdf5/1.12.0 googletest/1.11.0
 
 echo "mpicxx --version is: "
 mpicxx --version

--- a/builds/setup.frontier.cce.sh
+++ b/builds/setup.frontier.cce.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 #-- This script needs to be source-d in the terminal, e.g.
-#   source ./setup.frontier.cce.sh 
+#   source ./setup.frontier.cce.sh
 
 module load cray-python
 module load rocm
 module load craype-accel-amd-gfx90a
 module load cray-hdf5 cray-fftw
+module load googletest/1.10.0
 
 #-- GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/builds/setup.summit.gcc.sh
+++ b/builds/setup.summit.gcc.sh
@@ -4,7 +4,7 @@
 #   source ./setup.summit.gcc.sh
 
 #module load gcc/10.2.0 cuda/11.4.0 fftw hdf5 python
-module load gcc cuda fftw hdf5 python
+module load gcc cuda fftw hdf5 python googletest/1.11.0
 
 #export F_OFFLOAD="-fopenmp -foffload=nvptx-none='-lm -Ofast'"
 export F_OFFLOAD="-fopenmp -foffload=disable"

--- a/builds/setup.summit.xl.sh
+++ b/builds/setup.summit.xl.sh
@@ -3,7 +3,7 @@
 #-- This script needs to be source-d in the terminal, e.g.
 #   source ./setup.summit.xl.sh
 
-module load xl cuda fftw hdf5 python
+module load xl cuda fftw hdf5 python googletest/1.11.0
 
 export F_OFFLOAD="-qsmp=omp -qoffload"
 export CHOLLA_ENVSET=1


### PR DESCRIPTION
At the request of @alwinm I set GoogleTest to automatically load during setup on CRC, Frontier/Crusher, and Summit. On other systems the GoogleTest module can be loaded manually or GoogleTest can be installed from source using the bash function in `run_tests.sh`