### PR TITLE
Fix GoogleTest version & update cuda-toolkit action

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ CAAR ]
   schedule:
-    - cron: "37 11 * * 1"
+    - cron: "37 07 * * 1"  # run every Monday at 07:37UTC. Crontab computed with crontab.guru
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -67,7 +67,7 @@ jobs:
         h5cc -showconfig
 
     # Install CUDA and dependencies if this is a CUDA build
-    - uses: Jimver/cuda-toolkit@v0.2.4
+    - uses: Jimver/cuda-toolkit@v0.2.8
       if: matrix.gpu-api == 'CUDA'
       id: cuda-toolkit
       with:

--- a/builds/scripts/run_tests.sh
+++ b/builds/scripts/run_tests.sh
@@ -136,12 +136,13 @@ buildGoogleTest ()
 
   # All the flags to pass to GoogleTest when building and GTEST URL
   GOOGLETEST_URL="https://github.com/google/googletest.git"
+  GOOGLETEST_VERSION="release-1.12.1"  # the tag for the latest version that supports C++11
   CMAKE_FLAGS=(-DGTEST_HAS_PTHREAD=1
               -DCMAKE_C_COMPILER=gcc
               -DCMAKE_CXX_COMPILER=g++)
 
   # Download and build
-  git clone $GOOGLETEST_URL  && \
+  git clone --depth 1 -b $GOOGLETEST_VERSION $GOOGLETEST_URL  && \
   builtin cd googletest      && \
   mkdir build                && \
   builtin cd build           && \


### PR DESCRIPTION
GoogleTest 1.12.1 is the last version to support C++11 so we need to fix the version we use at that until we update to C++14 or newer. The `run_tests.sh` script was updated to only download that version of GoogleTest and to only fetch that single commit since we don't need the whole commit history.

Bumped version of cuda-toolkit action from 0.2.4 to 0.2.8. Most salient change is that this automatically enables caching for faster installs. This improves the time to install the cuda-toolkit by 1-2 minutes.