### PR TITLE
Fix race condition in GPU reductions

### DIFF
--- a/src/utils/cuda_utilities.h
+++ b/src/utils/cuda_utilities.h
@@ -13,8 +13,8 @@
 #include "../utils/gpu.hpp"
 
 
-namespace cuda_utilities {
-
+namespace cuda_utilities
+{
     /*!
      * \brief Compute the x, y, and z indices based off of the 1D index
      *
@@ -74,4 +74,26 @@ namespace cuda_utilities {
             ke = nz - n_ghost;
         }
     }
+
+    // =========================================================================
+    /*!
+    * \brief Set the value that `pointer` points at in GPU memory to `value`.
+    * This only sets the first value in memory so if `pointer` points to an
+    * array then only `pointer[0]` will be set; i.e. this effectively does
+    * `pointer = &value`
+    *
+    * \tparam T Any scalar type
+    * \param[in] pointer The location in GPU memory
+    * \param[in] value The value to set `*pointer` to
+    */
+    template <typename T>
+    void setScalarDeviceMemory(T *pointer, T const value)
+    {
+        CudaSafeCall(
+            cudaMemcpy(pointer,  // destination
+                       &value,   // source
+                       sizeof(T),
+                       cudaMemcpyHostToDevice));
+    }
+    // =========================================================================
 }

--- a/src/utils/cuda_utilities_tests.cpp
+++ b/src/utils/cuda_utilities_tests.cpp
@@ -120,3 +120,23 @@ TEST(tALLCompute1DIndex,
     EXPECT_EQ(fiducialId, testId);
 }
 // =============================================================================
+
+// =============================================================================
+TEST(tALLSetScalarDeviceMemory,
+     TypeDoubleInputExpectCorrectValueSet)
+{
+    double value = 173.246;
+    double *dev_ptr, host_val;
+    CudaSafeCall(cudaMalloc(&dev_ptr, sizeof(double)));
+
+    cuda_utilities::setScalarDeviceMemory<double>(dev_ptr, value);
+
+    CudaSafeCall(
+        cudaMemcpy(&host_val,  // destination
+                    dev_ptr,    // source
+                    sizeof(double),
+                    cudaMemcpyDeviceToHost));
+
+    EXPECT_EQ(value, host_val);
+}
+// =============================================================================

--- a/src/utils/reduction_utilities.cu
+++ b/src/utils/reduction_utilities.cu
@@ -17,13 +17,15 @@
     namespace reduction_utilities
     {
         // =====================================================================
-        __global__ void kernelReduceMax(Real *in, Real* out, size_t N, Real lowLimit)
+        __global__ void kernelReduceMax(Real *in, Real* out, size_t N)
         {
-            // Initialize variable to store the max value
-            Real maxVal = lowLimit;
+            // Initialize maxVal to the smallest possible number
+            Real maxVal = -DBL_MAX;
 
             // Grid stride loop to perform as much of the reduction as possible
-            for(size_t i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x)
+            for(size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+                i < N;
+                 i += blockDim.x * gridDim.x)
             {
                 // A transformation could go here
 
@@ -31,11 +33,12 @@
                 maxVal = max(maxVal,in[i]);
             }
 
-            // Find the maximum val in the grid and write it to `out`. Note that there
-            // is no execution/memory barrier after this and so the reduced scalar is
-            // not available for use in this kernel. The grid wide barrier can be
-            // accomplished by ending this kernel here and then launching a new one or
-            // by using cooperative groups. If this becomes a need it can be added later
+            // Find the maximum val in the grid and write it to `out`. Note that
+            // there is no execution/memory barrier after this and so the
+            // reduced scalar is not available for use in this kernel. The grid
+            // wide barrier can be accomplished by ending this kernel here and
+            // then launching a new one or by using cooperative groups. If this
+            // becomes a need it can be added later
             gridReduceMax(maxVal, out);
         }
         // =====================================================================

--- a/src/utils/reduction_utilities.h
+++ b/src/utils/reduction_utilities.h
@@ -39,7 +39,7 @@
         {
             for (int offset = warpSize/2; offset > 0; offset /= 2)
             {
-                val = fmax(val, __shfl_down(val, offset));
+                val = max(val, __shfl_down(val, offset));
             }
             return val;
         }
@@ -115,9 +115,10 @@
         // =====================================================================
         /*!
          * \brief Perform a reduction within the grid to find the maximum value
-         * of `val`. Note that this will overwrite the value in `out` with
-         * the value of the optional argument `lowLimit` which defaults to
-         * `-DBL_MAX`
+         * of `val`. Note that the value of `out` should be set appropriately
+         * before the kernel launch that uses this function to avoid any
+         * potential race condition; the `cuda_utilities::setScalarDeviceMemory`
+         * function exists for this purpose.
          *
          * \details This function can perform a reduction to find the maximum of
          * the thread local variable `val` across the entire grid. It relies on a
@@ -126,7 +127,7 @@
          * As a result the performance of this function is substantally improved
          * by using as many threads per block as possible and as few blocks as
          * possible since each block has to perform an atomic operation. To
-         * accomplish this it is recommened that you use the
+         * accomplish this it is reccommened that you use the
          * `reductionLaunchParams` functions to get the optimal number of blocks
          * and threads per block to launch rather than relying on Cholla defaults
          * and then within the kernel using a grid-stride loop to make sure the
@@ -142,46 +143,33 @@
          * the grid
          * \param[out] out The pointer to where to store the reduced scalar value
          * in device memory
-         * \param[in] lowLimit (optional)What value to initilize global memory
-         * with. Defaults to -DBL_MAX. This value will be the lowest possible
-         * value that the reduction can produce since all other values are
-         * compared against it
          */
-        __inline__ __device__ void gridReduceMax(Real val, Real* out, Real lowLimit = -DBL_MAX)
+        __inline__ __device__ void gridReduceMax(Real val, Real* out)
         {
-            __syncthreads();              // Wait for all threads to calculate val;
-	  
-            // Set the value in global memory so meaningful comparisons can be
-            // performed
-            if (threadIdx.x + blockIdx.x * blockDim.x == 0) *out = lowLimit;
+            // __syncthreads();  // Wait for all threads to calculate val;
 
             // Reduce the entire block in parallel
             val = blockReduceMax(val);
 
             // Write block level reduced value to the output scalar atomically
-            // if (threadIdx.x == 0) atomicMax_double(out, val);
-	    if (threadIdx.x == 0) out[blockIdx.x] = val;
+            if (threadIdx.x == 0) atomicMax_double(out, val);
         }
         // =====================================================================
 
         // =====================================================================
         /*!
-         * \brief Find the maximum value in the array. Note that this will
-         * overwrite the value in `out` with the value of the optional argument
-         * `lowLimit` which defaults to `-DBL_MAX`. If `in` and `out` are the
-         * same array that's ok, all the loads are completed before the
-         * overwrite occurs
+         * \brief Find the maximum value in the array. Make sure to initialize
+         * `out` correctly before using this kernel; the
+         * `cuda_utilities::setScalarDeviceMemory` function exists for this
+         * purpose. If `in` and `out` are the same array that's ok, all the
+         * loads are completed before the overwrite occurs.
          *
          * \param[in] in The pointer to the array to reduce in device memory
          * \param[out] out The pointer to where to store the reduced scalar
          * value in device memory
          * \param[in] N The size of the `in` array
-         * \param[in] lowLimit (optional) What value to initilize global memory
-         * with. Defaults to -DBL_MAX. This value will be the lowest possible
-         * value that the reduction can produce since all other values are
-         * compared against it
          */
-        __global__ void kernelReduceMax(Real *in, Real* out, size_t N, Real lowLimit = -DBL_MAX);
+        __global__ void kernelReduceMax(Real *in, Real* out, size_t N);
         // =====================================================================
 
         // =====================================================================


### PR DESCRIPTION
- Refactor reduction utilities to avoid a race condition. Previously the value to compare against was being set at the beginning of the  kernel or device function. This could lead to a race condition where the zeroeth thread was trying to initialize that value while an  already running thread was trying to atomically write to it. Now the  value in globabl memory is not set at all and instead must be set  elsewhere; the `cuda_utilities::setScalarDeviceMemory` templated  function has been added for that purpose.
- Replace calls to `reduction_utilities::gridReduceMax` in time step calculations with calls to `reduction_utilities::blockReduceMax` to  reflect what is actually being done
- Add a new `cuda_utilities::setScalarDeviceMemory` function for  setting device memory. This is basically an easier to use version of  cudaMemSet which takes any scalar variable as the value to set  instead of only hex values