### PR TITLE
Update `run_tests.sh` to use GoogleTest main

### DIFF
--- a/builds/make.host.github
+++ b/builds/make.host.github
@@ -5,8 +5,8 @@ CFLAGS_DEBUG      = -g -O0
 CFLAGS_OPTIMIZE   = -g -O2
 CXXFLAGS_DEBUG    = -g -O0 -std=c++17 ${F_OFFLOAD}
 CXXFLAGS_OPTIMIZE = -Ofast -std=c++17 ${F_OFFLOAD}
-GPUFLAGS_DEBUG    = -std=c++11
-GPUFLAGS_OPTIMIZE = -std=c++11
+GPUFLAGS_DEBUG    = -std=c++17
+GPUFLAGS_OPTIMIZE = -std=c++17
 
 OMP_NUM_THREADS   = 7
 

--- a/builds/run_tests.sh
+++ b/builds/run_tests.sh
@@ -136,13 +136,17 @@ buildGoogleTest ()
 
   # All the flags to pass to GoogleTest when building and GTEST URL
   GOOGLETEST_URL="https://github.com/google/googletest.git"
-  GOOGLETEST_VERSION="release-1.12.1"  # the tag for the latest version that supports C++11
+
+  # Uncomment this line to run with the last version of GoogleTest that supports
+  # C++11
+  # GOOGLETEST_VERSION="-b release-1.12.1"
+
   CMAKE_FLAGS=(-DGTEST_HAS_PTHREAD=1
               -DCMAKE_C_COMPILER=gcc
               -DCMAKE_CXX_COMPILER=g++)
 
   # Download and build
-  git clone --depth 1 -b $GOOGLETEST_VERSION $GOOGLETEST_URL  && \
+  git clone --depth 1 $GOOGLETEST_VERSION $GOOGLETEST_URL  && \
   builtin cd googletest      && \
   mkdir build                && \
   builtin cd build           && \


### PR DESCRIPTION
If `buildAndRunTests` is passed the `-g` flag it now clones and builds the latest version of GoogleTest instead of the latest version that is compatible with C++11. This is mostly relevant for the automated builds and anyone who wants to build GoogleTest from source since Crusher, Summit, Pitt CRC, and C-3PO all have older version of GoogleTest.

With the recent restructuring of branches I'm not sure where this PR should land. I've chosen main for now since I think we talked about CAAR being deprecated but please redirect it to the appropriate branch.
