### PR TITLE
Workaround for HIPFFT issues on GitHub Actions

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -15,6 +15,7 @@ jobs:
       Make-Type:${{ matrix.make-type }}
       Cuda-toolkit:v${{ matrix.cuda-toolkit-version }}
       GCC:v${{ matrix.gcc-version }}
+      ROCm:v${{ matrix.rocm-version }}
       Clang:v${{ matrix.clang-version }}
     # if: ${{ false }}  # If uncommented this line will disable this job
 
@@ -35,6 +36,7 @@ jobs:
         # HIP uses the clang-version
         cuda-toolkit-version: ['11.2.2']
         gcc-version: [9]
+        rocm-version: ['5.1.0']
         clang-version: [latest]
         mpi: ['openmpi'] #Can use mpich and/or openmpi
         # exclude:
@@ -93,40 +95,60 @@ jobs:
       uses: egor-tensin/setup-clang@v1
       with:
         version: ${{ matrix.clang-version }}
-    - name: Install HIP, ROCm, and HIPFFT
+    - name: Install ROCm
       if: matrix.gpu-api == 'HIP'
       run: |
+        # Download and install the installation script
         sudo apt-get update
-        wget https://repo.radeon.com/amdgpu-install/21.50/ubuntu/focal/amdgpu-install_21.50.50000-1_all.deb
-        sudo apt-get -y install ./amdgpu-install_21.50.50000-1_all.deb
-        sudo amdgpu-install -y --usecase=rocm
+        wget https://repo.radeon.com/amdgpu-install/22.20.1/ubuntu/focal/amdgpu-install_22.20.50201-1_all.deb
+        sudo apt-get install ./amdgpu-install_22.20.50201-1_all.deb
 
-        sudo apt install hipfft
+        # Add the repo for the version of ROCm that we want
+        ROCM_VERSION=${{ matrix.rocm-version }}
+        if [ "${ROCM_VERSION:0-1}" = "0" ]
+        then
+            # If the last character is a "0" then trim the last ".0"
+            ROCM_REPO_VERSION="${ROCM_VERSION:0:3}"
+        else
+            ROCM_REPO_VERSION=$ROCM_VERSION
+        fi
+        echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_REPO_VERSION} ubuntu main" | sudo tee /etc/apt/sources.list.d/rocm.list
+        sudo apt update
 
-        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV
-        echo "hello ${ROCM_PATH}"
-    - name: Verify HIP install
+        # Install ROCm
+        sudo amdgpu-install -y --usecase=rocm --rocmrelease=${ROCM_VERSION}
+    - name: Install hipFFT and RocFFT
       if: matrix.gpu-api == 'HIP'
-      run: /opt/rocm/bin/hipconfig --full
-    - name: Set HIPCONFIG
+      run: |
+        # Setup RocFFT installation
+        sudo apt install gnupg2
+        wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
+        echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
+        sudo apt update
+
+        sudo apt install -y hipfft rocfft
+    - name: Verify HIP install and find hipfft.h
+      if: matrix.gpu-api == 'HIP'
+      run: |
+        hipconfig --full
+        echo "Looking for hipfft.h"
+        find /opt -name hipfft.h
+    - name: Set Environment Variables and Files
       if: matrix.gpu-api == 'HIP'
       run: |
         echo "HIPCONFIG=$(hipconfig -C)" >> $GITHUB_ENV
-
-
-    # Generate setup file
-    - name: Create setup file
+        echo "ROCM_PATH=$(hipconfig -R)" >> $GITHUB_ENV
+        echo "HIPFFT_PATH=/opt/rocm-5.2.0" >> $GITHUB_ENV
+        echo "gfx90a" | sudo tee --append $(hipconfig -R)/bin/target.lst  # trick ROCm into thinking there's a GPU
+    - name: Echo Environment Variables and Files
+      if: matrix.gpu-api == 'HIP'
       run: |
-        echo -e '
-        echo "mpicxx --version is: "
-        mpicxx --version
+        echo "HIPCONFIG = ${HIPCONFIG}"
+        echo "ROCM_PATH = ${ROCM_PATH}"
+        echo "HIPFFT_PATH = ${HIPFFT_PATH}"
 
-        # export MPI_GPU="-DMPI_GPU"
-        export F_OFFLOAD="-fopenmp -foffload=disable"
-        export CHOLLA_ENVSET=1
-        ' >> builds/setup.githubActions.gcc.sh
-    - name: Show setup file
-      run: cat builds/setup.githubActions.gcc.sh
+        echo "The contents of $(hipconfig -R)/bin/target.lst are:"
+        sudo cat $(hipconfig -R)/bin/target.lst
 
     # Perform Build
     - name: Cholla setup

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,15 @@ GPUFLAGS += $(DFLAGS) -Isrc
 
 ifeq ($(findstring -DPARIS,$(DFLAGS)),-DPARIS)
   ifdef HIPCONFIG
-    CXXFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
-    GPUFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
-    LIBS += -L$(ROCM_PATH)/hipfft/lib -lhipfft
+    ifeq ($(CHOLLA_MACHINE), github)
+      CXXFLAGS += -I$(HIPFFT_PATH)/include/hipfft -I$(HIPFFT_PATH)/hipfft/include
+      GPUFLAGS += -I$(HIPFFT_PATH)/include/hipfft -I$(HIPFFT_PATH)/hipfft/include
+      LIBS += -L$(HIPFFT_PATH)/hipfft/lib -lhipfft
+    else
+      CXXFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
+      GPUFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
+      LIBS += -L$(ROCM_PATH)/hipfft/lib -lhipfft
+    endif
   else
     LIBS += -lcufft
   endif

--- a/builds/make.host.crc
+++ b/builds/make.host.crc
@@ -9,7 +9,6 @@ CXXFLAGS_OPTIMIZE = -Ofast -std=c++17
 CUDA_ARCH       = sm_70
 OMP_NUM_THREADS   = 16
 
-
 #-- Library
 # GCC_ROOT        = /ihome/crc/install/power9/gcc/10.1.0/build-gcc-8.3.1
 # CUDA_ROOT       = /ihome/crc/install/power9/cuda/11.1.0

--- a/builds/make.host.frontier
+++ b/builds/make.host.frontier
@@ -11,7 +11,7 @@ CFLAGS_OPTIMIZE   = -g -O2
 CXXFLAGS_DEBUG    = -g -O0 -std=c++14
 CXXFLAGS_OPTIMIZE = -g -Ofast -std=c++14 -Wno-unused-result
 
-GPUFLAGS          = --offload-arch=gfx90a -Wno-unused-result 
+GPUFLAGS          = --offload-arch=gfx90a -Wno-unused-result
 HIPCONFIG	  = -I$(ROCM_PATH)/include $(shell hipconfig -C) # workaround for Rocm 5.2 warnings
 #HIPCONFIG	  = $(shell hipconfig -C)
 

--- a/builds/make.host.github
+++ b/builds/make.host.github
@@ -3,15 +3,17 @@ CC                = mpicc
 CXX               = mpicxx
 CFLAGS_DEBUG      = -g -O0
 CFLAGS_OPTIMIZE   = -g -O2
-CXXFLAGS_DEBUG    = -g -O0 -std=c++17 ${F_OFFLOAD}
-CXXFLAGS_OPTIMIZE = -Ofast -std=c++17 ${F_OFFLOAD}
-GPUFLAGS_DEBUG    = -std=c++17
-GPUFLAGS_OPTIMIZE = -std=c++17
+CXXFLAGS_DEBUG    = -g -O0 -std=c++14 ${F_OFFLOAD}
+CXXFLAGS_OPTIMIZE = -Ofast -std=c++14 ${F_OFFLOAD}
+GPUFLAGS_DEBUG    = -std=c++14
+GPUFLAGS_OPTIMIZE = -std=c++14
 
 OMP_NUM_THREADS   = 7
 
 #-- Library
-HIPCONFIG	    := $(HIPCONFIG)
+ifdef HIPCONFIG
+	HIPCONFIG := -I$(shell hipconfig -R)/include $(shell hipconfig -C)
+endif
 CUDA_ROOT       := $(CUDA_ROOT)
 HDF5_ROOT       := $(HDF5_ROOT)
 # FFTW_ROOT       = ${OLCF_FFTW_ROOT}


### PR DESCRIPTION
The latest version of ROCm and hipFFT don't install in the same directory given by the ROCM_PATH environment variable. hipFFT always installs in /opt/rocm-5.2.0 and ROCm installs in the director for its version. If you try to install ROCm v5.2.0 and hipFFT then it errors out. The workaround for this is to use a HIPFFT_PATH variable for linking hipFFT on the GitHub Actions builds.

I've also refactored the Cholla Compile script to more neatly break up portions of the job, remove old code that's no longer used, and enable use to install specific versions of ROCm.

This commit should end up on dev and main to fix the builds for both branches. Adding the ROCm version as a matrix variable also changes the name of the checks required to merge. I'll take care of that change.

Other
- Update makefile for GitHub builds
- Set github builds to use C++14 instead of C++17
