### PR TITLE
Fix GitHub Actions Builds

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -16,7 +16,6 @@ jobs:
       Cuda-toolkit:v${{ matrix.cuda-toolkit-version }}
       GCC:v${{ matrix.gcc-version }}
       ROCm:v${{ matrix.rocm-version }}
-      Clang:v${{ matrix.clang-version }}
     # if: ${{ false }}  # If uncommented this line will disable this job
 
     # Choose OS/Runner
@@ -37,7 +36,6 @@ jobs:
         cuda-toolkit-version: ['11.2.2']
         gcc-version: [9]
         rocm-version: ['5.1.0']
-        clang-version: [latest]
         mpi: ['openmpi'] #Can use mpich and/or openmpi
         # exclude:
         #   - gpu-api: HIP
@@ -90,20 +88,15 @@ jobs:
         c++ --version
 
     # Install HIP and dependencies if this is a HIP build
-    - name: Setup Clang
-      if: matrix.gpu-api == 'HIP'
-      uses: egor-tensin/setup-clang@v1
-      with:
-        version: ${{ matrix.clang-version }}
-    - name: Install ROCm
+    - name: Setup ROCm
       if: matrix.gpu-api == 'HIP'
       run: |
         # Download and install the installation script
         sudo apt-get update
         wget https://repo.radeon.com/amdgpu-install/22.20.1/ubuntu/focal/amdgpu-install_22.20.50201-1_all.deb
-        sudo apt-get install ./amdgpu-install_22.20.50201-1_all.deb
+        sudo apt-get install -y ./amdgpu-install_22.20.50201-1_all.deb
 
-        # Add the repo for the version of ROCm that we want
+        # Get names correct by stripping out the last ".0" if it exists
         ROCM_VERSION=${{ matrix.rocm-version }}
         if [ "${ROCM_VERSION:0-1}" = "0" ]
         then
@@ -112,33 +105,28 @@ jobs:
         else
             ROCM_REPO_VERSION=$ROCM_VERSION
         fi
+
+        # Add the repo for the version of ROCm that we want
         echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${ROCM_REPO_VERSION} ubuntu main" | sudo tee /etc/apt/sources.list.d/rocm.list
         sudo apt update
-
+    - name: Install ROCm
+      if: matrix.gpu-api == 'HIP'
+      run: |
         # Install ROCm
-        sudo amdgpu-install -y --usecase=rocm --rocmrelease=${ROCM_VERSION}
+        sudo amdgpu-install -y --usecase=rocm --rocmrelease=${{ matrix.rocm-version }}
     - name: Install hipFFT and RocFFT
       if: matrix.gpu-api == 'HIP'
       run: |
-        # Setup RocFFT installation
-        sudo apt install gnupg2
-        wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key | sudo apt-key add -
-        echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' | sudo tee /etc/apt/sources.list.d/rocm.list
-        sudo apt update
-
-        sudo apt install -y hipfft rocfft
-    - name: Verify HIP install and find hipfft.h
+        sudo apt install -y hipfft${{ matrix.rocm-version }} rocfft${{ matrix.rocm-version }}
+    - name: Verify HIP install
       if: matrix.gpu-api == 'HIP'
       run: |
         hipconfig --full
-        echo "Looking for hipfft.h"
-        find /opt -name hipfft.h
     - name: Set Environment Variables and Files
       if: matrix.gpu-api == 'HIP'
       run: |
         echo "HIPCONFIG=$(hipconfig -C)" >> $GITHUB_ENV
         echo "ROCM_PATH=$(hipconfig -R)" >> $GITHUB_ENV
-        echo "HIPFFT_PATH=/opt/rocm-5.2.0" >> $GITHUB_ENV
         echo "gfx90a" | sudo tee --append $(hipconfig -R)/bin/target.lst  # trick ROCm into thinking there's a GPU
     - name: Echo Environment Variables and Files
       if: matrix.gpu-api == 'HIP'

--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,9 @@ GPUFLAGS += $(DFLAGS) -Isrc
 
 ifeq ($(findstring -DPARIS,$(DFLAGS)),-DPARIS)
   ifdef HIPCONFIG
-    ifeq ($(CHOLLA_MACHINE), github)
-      CXXFLAGS += -I$(HIPFFT_PATH)/include/hipfft -I$(HIPFFT_PATH)/hipfft/include
-      GPUFLAGS += -I$(HIPFFT_PATH)/include/hipfft -I$(HIPFFT_PATH)/hipfft/include
-      LIBS += -L$(HIPFFT_PATH)/hipfft/lib -lhipfft
-    else
-      CXXFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
-      GPUFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
-      LIBS += -L$(ROCM_PATH)/hipfft/lib -lhipfft
-    endif
+    CXXFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
+    GPUFLAGS += -I$(ROCM_PATH)/include/hipfft -I$(ROCM_PATH)/hipfft/include
+    LIBS += -L$(ROCM_PATH)/hipfft/lib -lhipfft
   else
     LIBS += -lcufft
   endif


### PR DESCRIPTION
This removes the workaround from PR #175 and replaces it with the correct way to install hipFFT in a generalized manner. This commit should probably make it on to main but it isn't critical.

- Fix hipFFT + rocFFT install to install the version compatible with the version of ROCm being installed
- Removed Clang install since it's no longer required
- Remove hipfft path workaround in Makefile
- Organize ROCm install steps better