### PR TITLE
Fix crashes when there are zero local particles

### DIFF
--- a/src/particles/density_CIC_gpu.cu
+++ b/src/particles/density_CIC_gpu.cu
@@ -144,7 +144,7 @@ void Particles_3D::Get_Density_CIC_GPU_function(part_int_t n_local, Real particl
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Get_Density_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, particle_mass, density_dev, pos_x_dev, pos_y_dev, pos_z_dev, mass_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
     CudaCheckError();
     cudaDeviceSynchronize();

--- a/src/particles/density_CIC_gpu.cu
+++ b/src/particles/density_CIC_gpu.cu
@@ -1,4 +1,4 @@
-#ifdef PARTICLES 
+#ifdef PARTICLES
 
 #include <unistd.h>
 #include <stdio.h>
@@ -143,9 +143,12 @@ void Particles_3D::Get_Density_CIC_GPU_function(part_int_t n_local, Real particl
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Get_Density_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, particle_mass, density_dev, pos_x_dev, pos_y_dev, pos_z_dev, mass_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
-  CudaCheckError();
-  cudaDeviceSynchronize();
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Get_Density_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, particle_mass, density_dev, pos_x_dev, pos_y_dev, pos_z_dev, mass_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
+    CudaCheckError();
+    cudaDeviceSynchronize();
+  }
 
   #if !defined(GRAVITY_GPU)
   //Copy the density from device to host

--- a/src/particles/gravity_CIC_gpu.cu
+++ b/src/particles/gravity_CIC_gpu.cu
@@ -1,4 +1,4 @@
-#ifdef PARTICLES 
+#ifdef PARTICLES
 
 #include <unistd.h>
 #include <stdio.h>
@@ -255,8 +255,11 @@ void Particles_3D::Get_Gravity_CIC_GPU_function( part_int_t n_local, int nx_loca
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Get_Gravity_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, gravity_x_dev, gravity_y_dev, gravity_z_dev, pos_x_dev, pos_y_dev, pos_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
-  CudaCheckError();
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Get_Gravity_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, gravity_x_dev, gravity_y_dev, gravity_z_dev, pos_x_dev, pos_y_dev, pos_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
+    CudaCheckError();
+  }
 
 }
 

--- a/src/particles/gravity_CIC_gpu.cu
+++ b/src/particles/gravity_CIC_gpu.cu
@@ -256,7 +256,7 @@ void Particles_3D::Get_Gravity_CIC_GPU_function( part_int_t n_local, int nx_loca
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Get_Gravity_CIC_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, gravity_x_dev, gravity_y_dev, gravity_z_dev, pos_x_dev, pos_y_dev, pos_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, xMin, yMin, zMin, xMax, yMax, zMax, dx, dy, dz, nx_local, ny_local, nz_local, n_ghost_particles_grid );
     CudaCheckError();
   }

--- a/src/particles/particles_boundaries_gpu.cu
+++ b/src/particles/particles_boundaries_gpu.cu
@@ -305,6 +305,11 @@ part_int_t Select_Particles_to_Transfer_GPU_function( part_int_t n_local, int si
   // Initialize the number of tranfer particles
   n_transfer_h[0] = 0;
 
+  // Only launch kernels if there are local particles
+  if (n_local == 0) {
+    return 0;
+  }
+
   hipLaunchKernelGGL( Get_Transfer_Flags_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, side, domainMin, domainMax, pos_d, transfer_flags_d);
   CudaCheckError();
 

--- a/src/particles/particles_boundaries_gpu.cu
+++ b/src/particles/particles_boundaries_gpu.cu
@@ -68,7 +68,6 @@ void Grid3D::Set_Particles_Boundary_GPU( int dir, int side ){
 
   hipLaunchKernelGGL(Set_Particles_Boundary_Kernel, dim1dGrid, dim1dBlock, 0, 0,  side, Particles.n_local, pos_dev, d_min, d_max, L  );
   CudaCheckError();
-
 }
 
 

--- a/src/particles/particles_dynamics_gpu.cu
+++ b/src/particles/particles_dynamics_gpu.cu
@@ -90,6 +90,11 @@ Real Particles_3D::Calc_Particles_dt_GPU_function( int ngrid, part_int_t n_parti
 
   // printf("%f %f %f \n", dx, dy, dz);
 
+  // Only runs if there are local particles
+  if (ngrid == 0) {
+    return 0;
+  }
+
   hipLaunchKernelGGL(Calc_Particles_dti_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_particles_local, dx, dy, dz, vel_x, vel_y, vel_z, dti_array_dev );
   CudaCheckError();
 
@@ -150,9 +155,11 @@ void Particles_3D::Advance_Particles_KDK_Step1_GPU_function( part_int_t n_local,
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
-  CudaCheckError();
-
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
+    CudaCheckError();
+  }
 }
 
 
@@ -165,10 +172,11 @@ void Particles_3D::Advance_Particles_KDK_Step2_GPU_function( part_int_t n_local,
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
-  CudaCheckError();
-
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
+    CudaCheckError();
+  }
 }
 
 
@@ -249,9 +257,12 @@ void Particles_3D::Advance_Particles_KDK_Step1_Cosmo_GPU_function( part_int_t n_
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
-  CHECK(cudaDeviceSynchronize());
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
+    CHECK(cudaDeviceSynchronize());
   // CudaCheckError();
+  }
 
 }
 
@@ -266,10 +277,12 @@ void Particles_3D::Advance_Particles_KDK_Step2_Cosmo_GPU_function( part_int_t n_
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
-  hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
-  CHECK(cudaDeviceSynchronize());
+  // Only runs if there are local particles
+  if (n_local) {
+    hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
+    CHECK(cudaDeviceSynchronize());
   // CudaCheckError();
-
+  }
 }
 
 #endif //COSMOLOGY

--- a/src/particles/particles_dynamics_gpu.cu
+++ b/src/particles/particles_dynamics_gpu.cu
@@ -156,7 +156,7 @@ void Particles_3D::Advance_Particles_KDK_Step1_GPU_function( part_int_t n_local,
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
     CudaCheckError();
   }
@@ -173,7 +173,7 @@ void Particles_3D::Advance_Particles_KDK_Step2_GPU_function( part_int_t n_local,
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, dt, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev );
     CudaCheckError();
   }
@@ -258,7 +258,7 @@ void Particles_3D::Advance_Particles_KDK_Step1_Cosmo_GPU_function( part_int_t n_
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Advance_Particles_KDK_Step1_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, pos_x_dev, pos_y_dev, pos_z_dev, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
     CHECK(cudaDeviceSynchronize());
   // CudaCheckError();
@@ -278,7 +278,7 @@ void Particles_3D::Advance_Particles_KDK_Step2_Cosmo_GPU_function( part_int_t n_
   dim3 dim1dBlock(TPB_PARTICLES, 1, 1);
 
   // Only runs if there are local particles
-  if (n_local) {
+  if (n_local > 0) {
     hipLaunchKernelGGL(Advance_Particles_KDK_Step2_Cosmo_Kernel, dim1dGrid, dim1dBlock, 0, 0,  n_local, delta_a, vel_x_dev, vel_y_dev, vel_z_dev, grav_x_dev, grav_y_dev, grav_z_dev, current_a, H0, cosmo_h, Omega_M, Omega_L, Omega_K );
     CHECK(cudaDeviceSynchronize());
   // CudaCheckError();


### PR DESCRIPTION
When n_local = 0 and ngrid = 0, CUDA crashes as a result of trying to call a kernel with 0 blocks. Usually in the code this is avoided by always adding +1 to the number of blocks, but in my opinion I think it's preferable to avoid adding an extra block, avoid the kernel call altogether, and make the logic a little more explicit for future readers of the code. 

Currently I am proposing the pushed changes, but in the interest of consistency I can re-do these changes in the old way, or re-do the old ways to match these changes. 

I'll ping @ojwg since we've talked about these crashes, and I'll ping @bvillasen to tap his particles expertise.  

One nice feature about this pull request is that pure-hydro examples will now run with zero particles, even if particle flags were included. 