### PR TITLE
Allow for chemistry units to work with non-cosmological simulations.

### DIFF
--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -31,30 +31,45 @@ void Grid3D::Initialize_Chemistry( struct parameters *P ){
   Chem.H.Temp_end   = 1000000000.0;
   
   Chem.H.H_fraction = INITIAL_FRACTION_HI + INITIAL_FRACTION_HII;
-  
+ 
+#ifdef COSMOLOGY 
   Chem.H.H0 = P->H0;
   Chem.H.Omega_M = P->Omega_M;
   Chem.H.Omega_L = P->Omega_L;
-  
+#endif //COSMOLOGY
   
   // Set up the units system.
   Real Msun, kpc_cgs, kpc_km, dens_to_CGS;
   Msun = MSUN_CGS;
   kpc_cgs = KPC_CGS;
   kpc_km  = KPC;
-  dens_to_CGS = Cosmo.rho_0_gas * Msun / kpc_cgs / kpc_cgs / kpc_cgs * Cosmo.cosmo_h * Cosmo.cosmo_h;
+  dens_to_CGS = Msun / kpc_cgs / kpc_cgs / kpc_cgs;
+#ifdef COSMOLOGY
+  dens_to_CGS = dens_to_CGS * Cosmo.rho_0_gas * Cosmo.cosmo_h * Cosmo.cosmo_h;
+#endif //COSMOLOGY
   
   // These are conversions from code units to cgs. Following Grackle
+  Chem.H.density_units  = dens_to_CGS;
+  Chem.H.length_units   = kpc_cgs;
+  Chem.H.time_units     = kpc_km;
+  Chem.H.dens_number_conv = Chem.H.density_units / MH;
+#ifdef COSMOLOGY
   Chem.H.a_value = Cosmo.current_a;
-  Chem.H.density_units  = dens_to_CGS / Chem.H.a_value / Chem.H.a_value / Chem.H.a_value ;
-  Chem.H.length_units   = kpc_cgs / Cosmo.cosmo_h * Chem.H.a_value;
-  Chem.H.time_units     = kpc_km / Cosmo.cosmo_h ;
+  Chem.H.density_units  = Chem.H.density_units / Chem.H.a_value / Chem.H.a_value / Chem.H.a_value ;
+  Chem.H.length_units   = Chem.H.length_units / Cosmo.cosmo_h * Chem.H.a_value;
+  Chem.H.time_units     = Chem.H.time_units / Cosmo.cosmo_h ;
+  Chem.H.dens_number_conv = Chem.H.density_number_conv * pow(Chem.H.a_value, 3);
+#endif //COSMOLOGY
   Chem.H.velocity_units = Chem.H.length_units /Chem.H.time_units; 
-  Chem.H.dens_number_conv = Chem.H.density_units * pow(Chem.H.a_value, 3) / MH;
   
   Real dens_base, length_base, time_base;
-  dens_base   = Chem.H.density_units * Chem.H.a_value * Chem.H.a_value * Chem.H.a_value;
-  length_base = Chem.H.length_units / Chem.H.a_value;
+  dens_base   = Chem.H.density_units;
+  length_base = Chem.H.length_units;
+#ifdef COSMOLOGY
+  dens_base   = dens_base * Chem.H.a_value * Chem.H.a_value * Chem.H.a_value;
+  length_base = length_base / Chem.H.a_value;
+#endif //COSMOLOGY
+
   time_base   = Chem.H.time_units;   
   Chem.H.cooling_units   = ( pow(length_base, 2) * pow(MH, 2) ) / ( dens_base * pow(time_base, 3) );
   Chem.H.reaction_units = MH / (dens_base * time_base );
@@ -254,7 +269,7 @@ void Grid3D::Compute_Gas_Temperature(  Real *temperature, bool convert_cosmo_uni
         #ifdef DE
         GE = C.GasEnergy[id];
         #else 
-        GE = (dev_conserved[4*n_cells + id] - 0.5*d*(vx*vx + vy*vy + vz*vz));
+        GE = (E - 0.5*d*(vx*vx + vy*vy + vz*vz));
         #endif
         
         dens_HI    = C.HI_density[id];

--- a/src/chemistry_gpu/chemistry_functions_gpu.cu
+++ b/src/chemistry_gpu/chemistry_functions_gpu.cu
@@ -467,7 +467,12 @@ __global__ void Update_Chemistry_kernel( Real *dev_conserved, int nx, int ny, in
     a3 = a2 * current_a;  
     d  *= density_conv / a3;
     GE *= energy_conv  / a2; 
-    dt_hydro = dt_hydro * current_a * current_a / Chem_H.H0 * 1000 * KPC / Chem_H.time_units;
+    dt_hydro = dt_hydro / Chem_H.time_units;
+
+#ifdef COSMOLOGY
+    dt_hydro *= current_a * current_a / Chem_H.H0 * 1000 * KPC 
+#endif //COSMOLOGY
+    //dt_hydro = dt_hydro * current_a * current_a / Chem_H.H0 * 1000 * KPC / Chem_H.time_units;
     // delta_a = Chem_H.H0 * sqrt( Chem_H.Omega_M/current_a + Chem_H.Omega_L*pow(current_a, 2) ) / ( 1000 * KPC ) * dt_hydro * Chem_H.time_units;
         
     // Initialize the thermal state


### PR DESCRIPTION
Minor adjustments were made to chemistry_functions.cpp and chemistry_functions_gpu.cu to enable non-cosmological calculations.

The cosmological unit conversions have been moved into COSMOLOGY ifdef logic. I believe the unit system is CGS, with density (rho_0), factors of a, and factors of h applied after the CGS units are initially defined.

There was also an adjustment replacing a call to dev_conserved with a call to total energy E that avoids referencing n_cells in chemistry_functions.cpp.

This needs to be tested with an RT test compilation and calculation. So I'm assigning to @evaneschneider but I suspect Nick needs to test since he raised the issue.

Would close #190.