### PR TITLE
`make clobber` to only delete in `bin/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ clean:
 	-find bin/ -type f -executable -name "cholla.*.$(MACHINE)*" -exec rm -f '{}' \;
 
 clobber: clean
-	find bin/ -type f -executable -name "cholla*" -exec rm -f '{}' \;
+	-find bin/ -type f -executable -name "cholla*" -exec rm -f '{}' \;
 	-find bin/ -type d -name "t*" -prune -exec rm -rf '{}' \;
 	rm -rf bin/cholla.*tests*.xml
 

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ clean:
 	-find bin/ -type f -executable -name "cholla.*.$(MACHINE)*" -exec rm -f '{}' \;
 
 clobber: clean
-	find . -type f -executable -name "cholla*" -exec rm -f '{}' \;
+	find bin/ -type f -executable -name "cholla*" -exec rm -f '{}' \;
 	-find bin/ -type d -name "t*" -prune -exec rm -rf '{}' \;
 	rm -rf bin/cholla.*tests*.xml
 


### PR DESCRIPTION
Previously `make clobber` deleted any executable that matched the pattern `cholla*` in the entire repo. Now it only deletes executables that follow this pattern and are in `bin`. The reason is that I accidentally deleted an executable script who's name started with `cholla` and that seems like something that others will do as well