### PR TITLE
Fix make.host.crc to use c++17 again

### DIFF
--- a/builds/make.host.crc
+++ b/builds/make.host.crc
@@ -4,8 +4,8 @@ CC                = mpicc
 CXX               = mpicxx
 CFLAGS_DEBUG      = -g -O0
 CFLAGS_OPTIMIZE   = -Ofast
-CXXFLAGS_DEBUG    = -g -O0 -std=c++14
-CXXFLAGS_OPTIMIZE = -Ofast -std=c++14
+CXXFLAGS_DEBUG    = -g -O0 -std=c++17
+CXXFLAGS_OPTIMIZE = -Ofast -std=c++17
 CUDA_ARCH       = sm_70
 OMP_NUM_THREADS   = 16
 


### PR DESCRIPTION
This accidentally got changed in dev because of my cloudy table PR. In the future I'll submit separate PRs for main/dev to help avoid weird merging situations. 