### PR TITLE
Automated Testing

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -152,7 +152,7 @@ Checks: "*,
         -readability-suspicious-call-argument"
 WarningsAsErrors: ''
 # More paths can be ignored by modifying this so that it looks like '^((?!/PATH/ONE/|/PATH/TWO/).)*$'
-HeaderFilterRegex: '^((?!/ihome/crc/install/power9/googletest/1.11.0/include/|/usr/lib/x86_64-linux-gnu/hdf5/serial/include/).)*$'
+HeaderFilterRegex: '^((?!/ihome/crc/install/power9/googletest/1.11.0/include/|/ihome/crc/install/power9/googletest/1.11.0/include/|/usr/lib/x86_64-linux-gnu/hdf5/serial/include/).)*$'
 AnalyzeTemporaryDtors: false
 FormatStyle:     'file'
 UseColor: false

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -1,5 +1,8 @@
 name: Build & Lint
 
+# This runs the HIP Builds. CUDA builds can be reenabled by adding the CUDA
+# container to the matrix and uncommenting the CUDA lines
+
 on:
   pull_request:
   schedule:
@@ -26,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         make-type: [hydro, gravity, disk, particles, cosmology, mhd, dust]
-        container: [{name: "CUDA", link: "docker://chollahydro/cholla:cuda_github"}, {name: "HIP",link: "docker://chollahydro/cholla:rocm_github"},]
+        # The CUDA container can be added with {name: "CUDA", link: "docker://chollahydro/cholla:cuda_github"}
+        container: [{name: "HIP",link: "docker://chollahydro/cholla:rocm_github"}]
 
     # Setup environment variables
     env:
@@ -49,12 +53,12 @@ jobs:
         git --version
         git config --global --add safe.directory /__w/cholla/cholla
         git config --global --add safe.directory '*'
-    - name: Show CUDA and gcc version
-      if: matrix.container.name == 'CUDA'
-      run: |
-        cc --version
-        c++ --version
-        nvcc -V
+    # - name: Show CUDA and gcc version
+    #   if: matrix.container.name == 'CUDA'
+    #   run: |
+    #     cc --version
+    #     c++ --version
+    #     nvcc -V
     - name: Show HIP and hipcc version
       if: matrix.container.name == 'HIP'
       run: |
@@ -64,6 +68,7 @@ jobs:
     # Perform Build
     - name: Cholla setup
       run: |
+        make clobber
         source builds/run_tests.sh
         setupTests -c gcc
         echo "CHOLLA_ROOT           = ${CHOLLA_ROOT}"
@@ -82,12 +87,15 @@ jobs:
         buildChollaTests
 
     # Run Clang-tidy
-    - name: Run clang-tidy
-      if: matrix.container.name == 'CUDA'
-      run: make tidy TYPE=${{ matrix.make-type }} CLANG_TIDY_ARGS="--warnings-as-errors=*"
-    - name: Display tidy_results_cpp.log
-      if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-      run: cat tidy_results_cpp.log
-    - name: Display tidy_results_gpu.log
-      if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-      run: cat tidy_results_gpu.log
+    # - name: Run clang-tidy
+    #   if: matrix.container.name == 'CUDA'
+    #   run: make tidy TYPE=${{ matrix.make-type }} CLANG_TIDY_ARGS="--warnings-as-errors=*"
+    # - name: Display tidy_results_cpp.log
+    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+    #   run: cat tidy_results_cpp.log
+    # - name: Display tidy_results_c.log
+    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+    #   run: cat tidy_results_c.log
+    # - name: Display tidy_results_gpu.log
+    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+    #   run: cat tidy_results_gpu.log

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,121 @@
+pipeline
+{
+    agent none
+
+    environment
+    {
+        CHOLLA_ROOT           = "${env.WORKSPACE}"
+        CHOLLA_MACHINE        = 'crc'
+        CHOLLA_LAUNCH_COMMAND = 'mpirun -np'
+    }
+
+    stages
+    {
+        stage('BuildAndTest')
+        {
+            matrix
+            {
+                agent
+                {
+                    label
+                    {
+                        label 'eschneider-ppc-n4'
+                        customWorkspace "${env.JOB_NAME}/${env.CHOLLA_MAKE_TYPE}"
+                    }
+                }
+
+                axes
+                {
+                    axis
+                    {
+                        name 'CHOLLA_MAKE_TYPE'
+                        values 'hydro', 'gravity', 'disk', 'particles', 'cosmology', 'mhd', 'dust'
+                    }
+                }
+
+                stages
+                {
+                    stage('Clone Repo Cholla')
+                    {
+                        steps
+                        {
+                            sh  '''
+                                git submodule update --init --recursive
+                                make clobber
+                                '''
+                        }
+                    }
+                    stage('Build Cholla')
+                    {
+                        steps
+                        {
+                            sh  '''
+                                source builds/run_tests.sh
+                                setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
+
+                                buildCholla OPTIMIZE
+                                '''
+                        }
+                    }
+                    stage('Build Tests')
+                    {
+                        steps
+                        {
+                            sh  '''
+                                source builds/run_tests.sh
+                                setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
+
+                                buildChollaTests
+                                '''
+                        }
+                    }
+                    stage('Run Tests')
+                    {
+                        steps
+                        {
+                            sh  '''
+                                source builds/run_tests.sh
+                                setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
+
+                                runTests
+                                '''
+                        }
+                    }
+                    stage('Run Clang Tidy')
+                    {
+                        steps
+                        {
+                            catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+                                sh  '''
+                                    source builds/run_tests.sh
+                                    setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
+
+                                    module load clang/15.0.2
+                                    make tidy CLANG_TIDY_ARGS="--warnings-as-errors=*" TYPE=${CHOLLA_MAKE_TYPE}
+                                    '''
+                            }
+                        }
+                    }
+                    stage('Show Tidy Results')
+                    {
+                        steps
+                        {
+                            // Print the clang-tidy results with bars of equal
+                            // signs seperating each file
+                            sh  '''
+                                printf '=%.0s' {1..100}
+                                printf "\n"
+                                cat tidy_results_cpp.log
+                                printf '=%.0s' {1..100}
+                                printf "\n"
+                                cat tidy_results_gpu.log
+                                printf '=%.0s' {1..100}
+                                printf "\n"
+                                '''
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/builds/run_tests.sh
+++ b/builds/run_tests.sh
@@ -54,6 +54,8 @@ setupTests ()
     return 1
   fi
 
+  builtin cd $CHOLLA_ROOT
+
   # Determine the hostname then use that to pick the right machine name and launch
   # command
   if [[ -n ${CHOLLA_MACHINE+x} ]]; then
@@ -93,10 +95,6 @@ setupTests ()
       return 1
       ;;
   esac
-
-  # Clean the cholla directory
-  builtin cd $CHOLLA_ROOT
-  make clobber
 
   # Source the setup file
   source "${CHOLLA_ROOT}/builds/setup.${CHOLLA_MACHINE}${CHOLLA_COMPILER}.sh"
@@ -249,6 +247,10 @@ buildAndRunTests ()
             ;;
     esac
   done
+
+  # Clean the cholla directory
+  builtin cd $CHOLLA_ROOT
+  make clobber
 
   # Now we get to setting up and building
   setupTests $MAKE_TYPE_ARG $COMPILER_ARG && \

--- a/src/system_tests/particles_system_tests.cpp
+++ b/src/system_tests/particles_system_tests.cpp
@@ -20,7 +20,7 @@
  *
  */
 /// @{
-TEST(tPARTICLESSYSTEMSphericalCollapse, CorrectInputExpectCorrectOutput)
+TEST(tPARTICLESSYSTEMSphericalCollapse, DISABLED_CorrectInputExpectCorrectOutput)
 {
   systemTest::SystemTestRunner collapseTest(true);
   collapseTest.runTest();

--- a/src/utils/DeviceVector_tests.cu
+++ b/src/utils/DeviceVector_tests.cu
@@ -310,6 +310,7 @@ TEST(tALLDeviceVectorAt, OutOfBoundsAccessExpectThrowOutOfRange)
   devVector.cpyHostToDevice(stdVec);
 
   // Check that the .at() method throws the correct exception
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_THROW(devVector.at(100), std::out_of_range);
 }
 
@@ -322,6 +323,7 @@ TEST(tALLDeviceVectorStdVectorHostToDeviceCopy, OutOfBoundsCopyExpectThrowOutOfR
   std::iota(stdVec.begin(), stdVec.end(), 0);
 
   // Copy the value to the device memory
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_THROW(devVector.cpyHostToDevice(stdVec), std::out_of_range);
 }
 
@@ -334,5 +336,6 @@ TEST(tALLDeviceVectorStdVectorDeviceToHostCopy, OutOfBoundsCopyExpectThrowOutOfR
   std::iota(stdVec.begin(), stdVec.end(), 0);
 
   // Copy the value to the device memory
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-goto,hicpp-avoid-goto)
   EXPECT_THROW(devVector.cpyDeviceToHost(stdVec), std::out_of_range);
 }


### PR DESCRIPTION
# Summary

This enables automated testing of pull requests using Jenkins running on Pitt CRC hardware. This will not appear to pass all the current required checks since I've disables the CUDA builds on GitHub Actions since those are now done at the CRC. Instead this should be merged when all the other checks pass and once this is merged in we can update the branch protection rules.

## Changes
- Add jenkinsfile
- Disable CUDA builds on Build & Lint GHA
- Move the `make clobber` in run_tests.sh so it can work with automation better
- Disable the tPARTICLESSYSTEMSphericalCollapse_CorrectInputExpectCorrectOutput test
- Add more ignore paths to clang-tidy
- Add some NOLINTs where needed to avoid erroneous errors with clang-tidy on C-3PO
