### PR TITLE
Fix sod tests boundaries

### DIFF
--- a/src/system_tests/input_files/tHYDROSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
@@ -25,10 +25,10 @@ zlen=1.0
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
-yl_bcnd=0
-yu_bcnd=0
-zl_bcnd=0
-zu_bcnd=0
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
 # path to output directory
 outdir=./
 

--- a/src/system_tests/input_files/tMHDSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMSodShockTubeParameterizedMpi_CorrectInputExpectCorrectOutput.txt
@@ -25,10 +25,10 @@ zlen=1.0
 # type of boundary conditions
 xl_bcnd=3
 xu_bcnd=3
-yl_bcnd=0
-yu_bcnd=0
-zl_bcnd=0
-zu_bcnd=0
+yl_bcnd=3
+yu_bcnd=3
+zl_bcnd=3
+zu_bcnd=3
 # path to output directory
 outdir=./
 


### PR DESCRIPTION
The Y and Z boundaries in the sod test were using the default boundaries. This will make them use transmissive boundaries, same as X does.