### PR TITLE
Remove outflow boundary condition diode for MHD

### DIFF
--- a/examples/3D/Dai_and_Woodward.txt
+++ b/examples/3D/Dai_and_Woodward.txt
@@ -7,11 +7,11 @@
 
 ################################################
 # number of grid cells in the x dimension
-nx=32
+nx=64
 # number of grid cells in the y dimension
-ny=32
+ny=64
 # number of grid cells in the z dimension
-nz=32
+nz=64
 # final output time
 tout=0.2
 # time interval for output
@@ -43,28 +43,28 @@ outdir=./
 # density of left state
 rho_l=1.08
 # velocity of left state
-vx_l=0.0
-vy_l=0.0
-vz_l=0.0
+vx_l=1.2
+vy_l=0.01
+vz_l=0.5
 # pressure of left state
-P_l=1.0
+P_l=0.95
 # Magnetic field of the left state
-Bx_l=14.17963081
-By_l=12.76166773
-Bz_l=7.0898154
+Bx_l=1.1283791670955126
+By_l=1.0155412503859613
+Bz_l=0.5641895835477563
 
 # density of right state
 rho_r=1.0
 # velocity of right state
 vx_r=0.0
 vy_r=0.0
-vz_r=1.0
+vz_r=0.0
 # pressure of right state
-P_r=0.2
+P_r=1.0
 # Magnetic field of the right state
-Bx_r=14.17963081
-By_r=14.17963081
-Bz_r=7.0898154
+Bx_r=1.1283791670955126
+By_r=1.1283791670955126
+Bz_r=0.5641895835477563
 
 # location of initial discontinuity
 diaph=0.5

--- a/examples/3D/Ryu_and_Jones_2a.txt
+++ b/examples/3D/Ryu_and_Jones_2a.txt
@@ -9,11 +9,11 @@
 
 ################################################
 # number of grid cells in the x dimension
-nx=32
+nx=64
 # number of grid cells in the y dimension
-ny=32
+ny=64
 # number of grid cells in the z dimension
-nz=32
+nz=64
 # final output time
 tout=0.2
 # time interval for output

--- a/examples/3D/Ryu_and_Jones_4d.txt
+++ b/examples/3D/Ryu_and_Jones_4d.txt
@@ -9,11 +9,11 @@
 
 ################################################
 # number of grid cells in the x dimension
-nx=32
+nx=64
 # number of grid cells in the y dimension
-ny=32
+ny=64
 # number of grid cells in the z dimension
-nz=32
+nz=64
 # final output time
 tout=0.16
 # time interval for output

--- a/src/grid/cuda_boundaries.cu
+++ b/src/grid/cuda_boundaries.cu
@@ -116,6 +116,8 @@ __global__ void SetGhostCellsKernel(Real *c_head, int nx, int ny, int nz, int n_
     if (flags[4] == 2 || flags[5] == 2) {
       c_head[gidx + 3 * n_cells] *= a[2];
     }
+
+#ifndef MHD
     // energy and momentum correction for transmission
     // Diode: only allow outflow
     if (flags[dir] == 3) {
@@ -140,8 +142,9 @@ __global__ void SetGhostCellsKernel(Real *c_head, int nx, int ny, int nz, int n_
           c_head[momdex] = 0.0;
         }
       }
-    }  // end energy correction for transmissive boundaries
-  }    // end idx>=0
+    }   // end energy correction for transmissive boundaries
+#endif  // not MHD
+  }     // end idx>=0
 }  // end function
 
 void SetGhostCells(Real *c_head, int nx, int ny, int nz, int n_fields, int n_cells, int n_ghost, int flags[], int isize,

--- a/src/grid/grid_enum.h
+++ b/src/grid/grid_enum.h
@@ -86,6 +86,10 @@ enum : int {
   magnetic_start = magnetic_x,
   magnetic_end   = magnetic_z,
 
+  ct_elec_x = 0,
+  ct_elec_y = 1,
+  ct_elec_z = 2,
+
   // Note that the direction of the flux, the suffix _? indicates the direction
   // of the electric field, not the magnetic flux
   fluxX_magnetic_z = magnetic_start,

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -117,7 +117,6 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
   #ifdef MHD
     CudaSafeCall(cudaMalloc((void **)&ctElectricFields, ctArraySize));
-    cuda_utilities::initGpuMemory(ctElectricFields, ctArraySize);
   #endif  // MHD
 
   #if defined(GRAVITY)

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -176,12 +176,18 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      2, n_fields);
   #endif  // HLL
   #ifdef HLLD
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx,
-                     &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz, n_ghost, gama, 0, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry,
-                     &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz, n_ghost, gama, 1, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz,
-                     &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz, n_ghost, gama, 2, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Lx, Q_Rx,
+                     &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x,
+                     n_cells, gama, 0, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Ly, Q_Ry,
+                     &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y,
+                     n_cells, gama, 1, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Lz, Q_Rz,
+                     &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z,
+                     n_cells, gama, 2, n_fields);
   #endif  // HLLD
   CudaCheckError();
 
@@ -277,15 +283,18 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      2, n_fields);
   #endif  // HLLC
   #ifdef HLLD
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx,
-                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry,
-                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz, n_ghost, gama, 1,
-                     n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz,
-                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz, n_ghost, gama, 2,
-                     n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Lx, Q_Rx,
+                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]),
+                     F_x, n_cells, gama, 0, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Ly, Q_Ry,
+                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]),
+                     F_y, n_cells, gama, 1, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
+                     0, Q_Lz, Q_Rz,
+                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]),
+                     F_z, n_cells, gama, 2, n_fields);
   #endif  // HLLD
   CudaCheckError();
 

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -176,18 +176,12 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      2, n_fields);
   #endif  // HLL
   #ifdef HLLD
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Lx, Q_Rx,
-                     &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x,
-                     n_cells, gama, 0, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Ly, Q_Ry,
-                     &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y,
-                     n_cells, gama, 1, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Lz, Q_Rz,
-                     &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z,
-                     n_cells, gama, 2, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx,
+                     &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, n_cells, gama, 0, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry,
+                     &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, n_cells, gama, 1, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz,
+                     &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, n_cells, gama, 2, n_fields);
   #endif  // HLLD
   CudaCheckError();
 
@@ -283,18 +277,12 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      2, n_fields);
   #endif  // HLLC
   #ifdef HLLD
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Lx, Q_Rx,
-                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]),
-                     F_x, n_cells, gama, 0, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Ly, Q_Ry,
-                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]),
-                     F_y, n_cells, gama, 1, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0,
-                     0, Q_Lz, Q_Rz,
-                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]),
-                     F_z, n_cells, gama, 2, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx,
+                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, n_cells, gama, 0, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry,
+                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, n_cells, gama, 1, n_fields);
+  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz,
+                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, n_cells, gama, 2, n_fields);
   #endif  // HLLD
   CudaCheckError();
 

--- a/src/mhd/ct_electric_fields.cu
+++ b/src/mhd/ct_electric_fields.cu
@@ -70,9 +70,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // ================
 
     // Y-direction slope on the positive Y side. S&G 2009 equation 23
-    signUpwind =
-        fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_pos = mhd::_internal::_ctSlope(fluxY, dev_conserved, -1, 0, 2, -1, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -85,9 +83,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Y-direction slope on the negative Y side. S&G 2009 equation 23
-    signUpwind =
-        fluxZ[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_neg = mhd::_internal::_ctSlope(fluxY, dev_conserved, -1, 0, 1, 2, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -99,9 +95,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the positive Z side. S&G 2009 equation 23
-    signUpwind =
-        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_pos = mhd::_internal::_ctSlope(fluxZ, dev_conserved, 1, 0, 1, -1, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -113,9 +107,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the negative Z side. S&G 2009 equation 23
-    signUpwind =
-        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_neg = mhd::_internal::_ctSlope(fluxZ, dev_conserved, 1, 0, 1, 2, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -142,17 +134,15 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // edge averaged electric field.
     // S&G 2009 equation 22
     ctElectricFields[threadId + grid_enum::ct_elec_x * n_cells] =
-        0.25 * (+face_y_pos + face_y_neg + face_z_pos + face_z_neg +
-                slope_y_pos + slope_y_neg + slope_z_pos + slope_z_neg);
+        0.25 *
+        (+face_y_pos + face_y_neg + face_z_pos + face_z_neg + slope_y_pos + slope_y_neg + slope_z_pos + slope_z_neg);
 
     // ================
     // Y electric field
     // ================
 
     // X-direction slope on the positive X side. S&G 2009 equation 23
-    signUpwind =
-        fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_pos = mhd::_internal::_ctSlope(fluxX, dev_conserved, 1, 1, 2, -1, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -164,9 +154,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the negative X side. S&G 2009 equation 23
-    signUpwind =
-        fluxZ[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_neg = mhd::_internal::_ctSlope(fluxX, dev_conserved, 1, 1, 0, 2, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -178,9 +166,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the positive Z side. S&G 2009 equation 23
-    signUpwind =
-        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_pos = mhd::_internal::_ctSlope(fluxZ, dev_conserved, -1, 1, 0, -1, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -193,9 +179,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the negative Z side. S&G 2009 equation 23
-    signUpwind =
-        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_neg = mhd::_internal::_ctSlope(fluxZ, dev_conserved, -1, 1, 0, 2, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -221,17 +205,15 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // edge averaged electric field.
     // S&G 2009 equation 22
     ctElectricFields[threadId + grid_enum::ct_elec_y * n_cells] =
-        0.25 * (+face_x_pos + face_x_neg + face_z_pos + face_z_neg +
-                slope_x_pos + slope_x_neg + slope_z_pos + slope_z_neg);
+        0.25 *
+        (+face_x_pos + face_x_neg + face_z_pos + face_z_neg + slope_x_pos + slope_x_neg + slope_z_pos + slope_z_neg);
 
     // ================
     // Z electric field
     // ================
 
     // Y-direction slope on the positive Y side. S&G 2009 equation 23
-    signUpwind =
-        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_pos = mhd::_internal::_ctSlope(fluxY, dev_conserved, 1, 2, 0, -1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -243,9 +225,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Y-direction slope on the negative Y side. S&G 2009 equation 23
-    signUpwind =
-        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_neg = mhd::_internal::_ctSlope(fluxY, dev_conserved, 1, 2, 0, 1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -257,9 +237,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the positive X side. S&G 2009 equation 23
-    signUpwind =
-        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_pos = mhd::_internal::_ctSlope(fluxX, dev_conserved, -1, 2, 1, -1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -272,9 +250,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the negative X side. S&G 2009 equation 23
-    signUpwind =
-        fluxY[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) +
-              grid_enum::density * n_cells];
+    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) + grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_neg = mhd::_internal::_ctSlope(fluxX, dev_conserved, -1, 2, 0, 1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -300,8 +276,8 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // edge averaged electric field.
     // S&G 2009 equation 22
     ctElectricFields[threadId + grid_enum::ct_elec_z * n_cells] =
-        0.25 * (+face_x_pos + face_x_neg + face_y_pos + face_y_neg +
-                slope_x_pos + slope_x_neg + slope_y_pos + slope_y_neg);
+        0.25 *
+        (+face_x_pos + face_x_neg + face_y_pos + face_y_neg + slope_x_pos + slope_x_neg + slope_y_pos + slope_y_neg);
   }
 }
 // =========================================================================

--- a/src/mhd/ct_electric_fields.cu
+++ b/src/mhd/ct_electric_fields.cu
@@ -70,7 +70,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // ================
 
     // Y-direction slope on the positive Y side. S&G 2009 equation 23
-    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny)];
+    signUpwind =
+        fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_pos = mhd::_internal::_ctSlope(fluxY, dev_conserved, -1, 0, 2, -1, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -83,7 +85,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Y-direction slope on the negative Y side. S&G 2009 equation 23
-    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny)];
+    signUpwind =
+        fluxZ[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_neg = mhd::_internal::_ctSlope(fluxY, dev_conserved, -1, 0, 1, 2, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -95,7 +99,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the positive Z side. S&G 2009 equation 23
-    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny)];
+    signUpwind =
+        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_pos = mhd::_internal::_ctSlope(fluxZ, dev_conserved, 1, 0, 1, -1, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -107,7 +113,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the negative Z side. S&G 2009 equation 23
-    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny)];
+    signUpwind =
+        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_neg = mhd::_internal::_ctSlope(fluxZ, dev_conserved, 1, 0, 1, 2, 1, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -133,15 +141,18 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // sum and average face centered electric fields and slopes to get the
     // edge averaged electric field.
     // S&G 2009 equation 22
-    ctElectricFields[threadId + 0 * n_cells] = 0.25 * (+face_y_pos + face_y_neg + face_z_pos + face_z_neg +
-                                                       slope_y_pos + slope_y_neg + slope_z_pos + slope_z_neg);
+    ctElectricFields[threadId + grid_enum::ct_elec_x * n_cells] =
+        0.25 * (+face_y_pos + face_y_neg + face_z_pos + face_z_neg +
+                slope_y_pos + slope_y_neg + slope_z_pos + slope_z_neg);
 
     // ================
     // Y electric field
     // ================
 
     // X-direction slope on the positive X side. S&G 2009 equation 23
-    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny)];
+    signUpwind =
+        fluxZ[cuda_utilities::compute1DIndex(xid, yid, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_pos = mhd::_internal::_ctSlope(fluxX, dev_conserved, 1, 1, 2, -1, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -153,7 +164,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the negative X side. S&G 2009 equation 23
-    signUpwind = fluxZ[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny)];
+    signUpwind =
+        fluxZ[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_neg = mhd::_internal::_ctSlope(fluxX, dev_conserved, 1, 1, 0, 2, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -165,7 +178,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the positive Z side. S&G 2009 equation 23
-    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny)];
+    signUpwind =
+        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_pos = mhd::_internal::_ctSlope(fluxZ, dev_conserved, -1, 1, 0, -1, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -178,7 +193,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Z-direction slope on the negative Z side. S&G 2009 equation 23
-    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny)];
+    signUpwind =
+        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid - 1, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_z_neg = mhd::_internal::_ctSlope(fluxZ, dev_conserved, -1, 1, 0, 2, 0, 2, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -203,15 +220,18 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // sum and average face centered electric fields and slopes to get the
     // edge averaged electric field.
     // S&G 2009 equation 22
-    ctElectricFields[threadId + 1 * n_cells] = 0.25 * (+face_x_pos + face_x_neg + face_z_pos + face_z_neg +
-                                                       slope_x_pos + slope_x_neg + slope_z_pos + slope_z_neg);
+    ctElectricFields[threadId + grid_enum::ct_elec_y * n_cells] =
+        0.25 * (+face_x_pos + face_x_neg + face_z_pos + face_z_neg +
+                slope_x_pos + slope_x_neg + slope_z_pos + slope_z_neg);
 
     // ================
     // Z electric field
     // ================
 
     // Y-direction slope on the positive Y side. S&G 2009 equation 23
-    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny)];
+    signUpwind =
+        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_pos = mhd::_internal::_ctSlope(fluxY, dev_conserved, 1, 2, 0, -1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -223,7 +243,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // Y-direction slope on the negative Y side. S&G 2009 equation 23
-    signUpwind = fluxX[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny)];
+    signUpwind =
+        fluxX[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_y_neg = mhd::_internal::_ctSlope(fluxY, dev_conserved, 1, 2, 0, 1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -235,7 +257,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the positive X side. S&G 2009 equation 23
-    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny)];
+    signUpwind =
+        fluxY[cuda_utilities::compute1DIndex(xid, yid - 1, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_pos = mhd::_internal::_ctSlope(fluxX, dev_conserved, -1, 2, 1, -1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -248,7 +272,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     }
 
     // X-direction slope on the negative X side. S&G 2009 equation 23
-    signUpwind = fluxY[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny)];
+    signUpwind =
+        fluxY[cuda_utilities::compute1DIndex(xid - 1, yid - 1, zid, nx, ny) +
+              grid_enum::density * n_cells];
     if (signUpwind > 0.0) {
       slope_x_neg = mhd::_internal::_ctSlope(fluxX, dev_conserved, -1, 2, 0, 1, 0, 1, xid, yid, zid, nx, ny, n_cells);
     } else if (signUpwind < 0.0) {
@@ -273,8 +299,9 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
     // sum and average face centered electric fields and slopes to get the
     // edge averaged electric field.
     // S&G 2009 equation 22
-    ctElectricFields[threadId + 2 * n_cells] = 0.25 * (+face_x_pos + face_x_neg + face_y_pos + face_y_neg +
-                                                       slope_x_pos + slope_x_neg + slope_y_pos + slope_y_neg);
+    ctElectricFields[threadId + grid_enum::ct_elec_z * n_cells] =
+        0.25 * (+face_x_pos + face_x_neg + face_y_pos + face_y_neg +
+                slope_x_pos + slope_x_neg + slope_y_pos + slope_y_neg);
   }
 }
 // =========================================================================

--- a/src/mhd/ct_electric_fields.cu
+++ b/src/mhd/ct_electric_fields.cu
@@ -28,7 +28,7 @@ __global__ void Calculate_CT_Electric_Fields(Real const *fluxX, Real const *flux
 
   // Thread guard to avoid overrun and to skip the first two cells since
   // those ghost cells can't be reconstructed
-  if (xid > 1 and yid > 1 and zid > 1 and xid < nx and yid < ny and zid < nz) {
+  if (xid > 0 and yid > 0 and zid > 0 and xid < nx and yid < ny and zid < nz) {
     // According to Stone et al. 2008 section 5.3 and the source code of
     // Athena, the following equation relate the magnetic flux to the
     // face centered electric fields/EMF. -cross(V,B)x is the negative

--- a/src/mhd/ct_electric_fields.h
+++ b/src/mhd/ct_electric_fields.h
@@ -97,13 +97,22 @@ inline __host__ __device__ Real _ctSlope(Real const *flux, Real const *dev_conse
   // variable, B2 and B3 are the next two fields cyclically. i.e. if
   // B1=Bx then B2=By and B3=Bz, if B1=By then B2=Bz and B3=Bx. The
   // same rules apply for the momentum
-  Real const density    = dev_conserved[idxCentered];
-  Real const Momentum2  = dev_conserved[idxCentered + (modPlus1 + 1) * n_cells];
-  Real const Momentum3  = dev_conserved[idxCentered + (modPlus2 + 1) * n_cells];
-  Real const B2Centered = 0.5 * (dev_conserved[idxCentered + (modPlus1 + grid_enum::magnetic_start) * n_cells] +
-                                 dev_conserved[idxB2Shift + (modPlus1 + grid_enum::magnetic_start) * n_cells]);
-  Real const B3Centered = 0.5 * (dev_conserved[idxCentered + (modPlus2 + grid_enum::magnetic_start) * n_cells] +
-                                 dev_conserved[idxB3Shift + (modPlus2 + grid_enum::magnetic_start) * n_cells]);
+  Real const density =
+      dev_conserved[idxCentered + grid_enum::density * n_cells];
+  Real const Momentum2 =
+      dev_conserved[idxCentered + (modPlus1 + grid_enum::momentum_x) * n_cells];
+  Real const Momentum3 =
+      dev_conserved[idxCentered + (modPlus2 + grid_enum::momentum_x) * n_cells];
+  Real const B2Centered =
+      0.5 * (dev_conserved[idxCentered +
+                           (modPlus1 + grid_enum::magnetic_start) * n_cells] +
+             dev_conserved[idxB2Shift +
+                           (modPlus1 + grid_enum::magnetic_start) * n_cells]);
+  Real const B3Centered =
+      0.5 * (dev_conserved[idxCentered +
+                           (modPlus2 + grid_enum::magnetic_start) * n_cells] +
+             dev_conserved[idxB3Shift +
+                           (modPlus2 + grid_enum::magnetic_start) * n_cells]);
 
   // Compute the electric field in the center with a cross product
   Real const electric_centered = (Momentum3 * B2Centered - Momentum2 * B3Centered) / density;

--- a/src/mhd/ct_electric_fields.h
+++ b/src/mhd/ct_electric_fields.h
@@ -97,22 +97,13 @@ inline __host__ __device__ Real _ctSlope(Real const *flux, Real const *dev_conse
   // variable, B2 and B3 are the next two fields cyclically. i.e. if
   // B1=Bx then B2=By and B3=Bz, if B1=By then B2=Bz and B3=Bx. The
   // same rules apply for the momentum
-  Real const density =
-      dev_conserved[idxCentered + grid_enum::density * n_cells];
-  Real const Momentum2 =
-      dev_conserved[idxCentered + (modPlus1 + grid_enum::momentum_x) * n_cells];
-  Real const Momentum3 =
-      dev_conserved[idxCentered + (modPlus2 + grid_enum::momentum_x) * n_cells];
-  Real const B2Centered =
-      0.5 * (dev_conserved[idxCentered +
-                           (modPlus1 + grid_enum::magnetic_start) * n_cells] +
-             dev_conserved[idxB2Shift +
-                           (modPlus1 + grid_enum::magnetic_start) * n_cells]);
-  Real const B3Centered =
-      0.5 * (dev_conserved[idxCentered +
-                           (modPlus2 + grid_enum::magnetic_start) * n_cells] +
-             dev_conserved[idxB3Shift +
-                           (modPlus2 + grid_enum::magnetic_start) * n_cells]);
+  Real const density    = dev_conserved[idxCentered + grid_enum::density * n_cells];
+  Real const Momentum2  = dev_conserved[idxCentered + (modPlus1 + grid_enum::momentum_x) * n_cells];
+  Real const Momentum3  = dev_conserved[idxCentered + (modPlus2 + grid_enum::momentum_x) * n_cells];
+  Real const B2Centered = 0.5 * (dev_conserved[idxCentered + (modPlus1 + grid_enum::magnetic_start) * n_cells] +
+                                 dev_conserved[idxB2Shift + (modPlus1 + grid_enum::magnetic_start) * n_cells]);
+  Real const B3Centered = 0.5 * (dev_conserved[idxCentered + (modPlus2 + grid_enum::magnetic_start) * n_cells] +
+                                 dev_conserved[idxB3Shift + (modPlus2 + grid_enum::magnetic_start) * n_cells]);
 
   // Compute the electric field in the center with a cross product
   Real const electric_centered = (Momentum3 * B2Centered - Momentum2 * B3Centered) / density;

--- a/src/mhd/ct_electric_fields_tests.cu
+++ b/src/mhd/ct_electric_fields_tests.cu
@@ -39,7 +39,7 @@ class tMHDCalculateCTElectricFields : public ::testing::Test
    *
    */
   tMHDCalculateCTElectricFields()
-      : nx(3),
+      : nx(2),
         ny(nx),
         nz(nx),
         n_cells(nx * ny * nz),
@@ -130,9 +130,9 @@ class tMHDCalculateCTElectricFields : public ::testing::Test
 TEST_F(tMHDCalculateCTElectricFields, PositiveVelocityExpectCorrectOutput)
 {
   // Fiducial values
-  fiducialData.at(26) = 206.29859653255295;
-  fiducialData.at(53) = -334.90052254763339;
-  fiducialData.at(80) = 209.53472440298236;
+  fiducialData.at(7)  = 60.951467108788492;
+  fiducialData.at(15) = -98.736587665919359;
+  fiducialData.at(23) = 61.768055665002557;
 
   // Launch kernel and check results
   runTest();
@@ -143,9 +143,9 @@ TEST_F(tMHDCalculateCTElectricFields, PositiveVelocityExpectCorrectOutput)
 TEST_F(tMHDCalculateCTElectricFields, NegativeVelocityExpectCorrectOutput)
 {
   // Fiducial values
-  fiducialData.at(26) = 203.35149422304994;
-  fiducialData.at(53) = -330.9860399765279;
-  fiducialData.at(80) = 208.55149905461991;
+  fiducialData.at(7)  = 59.978246483260179;
+  fiducialData.at(15) = -97.279949010457187;
+  fiducialData.at(23) = 61.280813140085613;
 
   // Set the density fluxes to be negative to indicate a negative velocity
   // across the face
@@ -164,9 +164,9 @@ TEST_F(tMHDCalculateCTElectricFields, NegativeVelocityExpectCorrectOutput)
 TEST_F(tMHDCalculateCTElectricFields, ZeroVelocityExpectCorrectOutput)
 {
   // Fiducial values
-  fiducialData.at(26) = 204.82504537780144;
-  fiducialData.at(53) = -332.94328126208063;
-  fiducialData.at(80) = 209.04311172880114;
+  fiducialData.at(7)  = 60.464856796024335;
+  fiducialData.at(15) = -98.008268338188287;
+  fiducialData.at(23) = 61.524434402544081;
 
   // Set the density fluxes to be negative to indicate a negative velocity
   // across the face

--- a/src/mhd/magnetic_update.cu
+++ b/src/mhd/magnetic_update.cu
@@ -30,8 +30,7 @@ __global__ void Update_Magnetic_Field_3D(Real *sourceGrid, Real *destinationGrid
 
   // Thread guard to avoid overrun and to skip ghost cells that cannot be
   // evolved due to missing electric fields that can't be reconstructed
-  if (xid > 0 and yid > 0 and zid > 0 and xid < nx - 1 and yid < ny - 1 and
-      zid < nz - 1) {
+  if (xid > 0 and yid > 0 and zid > 0 and xid < nx - 1 and yid < ny - 1 and zid < nz - 1) {
     // Compute the three dt/dx quantities
     Real const dtodx = dt / dx;
     Real const dtody = dt / dy;
@@ -40,32 +39,23 @@ __global__ void Update_Magnetic_Field_3D(Real *sourceGrid, Real *destinationGrid
     // Load the various edge electric fields required. The '1' and '2'
     // fields are not shared and the '3' fields are shared by two of the
     // updates
-    Real electric_x_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid, yid + 1, zid, nx, ny)) +
+    Real electric_x_1 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid, nx, ny)) + grid_enum::ct_elec_x * n_cells];
+    Real electric_x_2 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid, zid + 1, nx, ny)) + grid_enum::ct_elec_x * n_cells];
+    Real electric_x_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid + 1, nx, ny)) +
                                          grid_enum::ct_elec_x * n_cells];
-    Real electric_x_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid, yid, zid + 1, nx, ny)) +
-                                         grid_enum::ct_elec_x * n_cells];
-    Real electric_x_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid, yid + 1, zid + 1, nx, ny)) +
-                                         grid_enum::ct_elec_x * n_cells];
-    Real electric_y_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid + 1, yid, zid, nx, ny)) +
+    Real electric_y_1 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid, nx, ny)) + grid_enum::ct_elec_y * n_cells];
+    Real electric_y_2 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid, zid + 1, nx, ny)) + grid_enum::ct_elec_y * n_cells];
+    Real electric_y_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid + 1, nx, ny)) +
                                          grid_enum::ct_elec_y * n_cells];
-    Real electric_y_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid, yid, zid + 1, nx, ny)) +
-                                         grid_enum::ct_elec_y * n_cells];
-    Real electric_y_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid + 1, yid, zid + 1, nx, ny)) +
-                                         grid_enum::ct_elec_y * n_cells];
-    Real electric_z_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid + 1, yid, zid, nx, ny)) +
-                                         grid_enum::ct_elec_z * n_cells];
-    Real electric_z_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid, yid + 1, zid, nx, ny)) +
-                                         grid_enum::ct_elec_z * n_cells];
-    Real electric_z_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
-                                             xid + 1, yid + 1, zid, nx, ny)) +
+    Real electric_z_1 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid, nx, ny)) + grid_enum::ct_elec_z * n_cells];
+    Real electric_z_2 =
+        ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid, nx, ny)) + grid_enum::ct_elec_z * n_cells];
+    Real electric_z_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid + 1, zid, nx, ny)) +
                                          grid_enum::ct_elec_z * n_cells];
 
     // Perform Updates
@@ -73,22 +63,19 @@ __global__ void Update_Magnetic_Field_3D(Real *sourceGrid, Real *destinationGrid
     // X field update
     // S&G 2009 equation 10
     destinationGrid[threadId + grid_enum::magnetic_x * n_cells] =
-        sourceGrid[threadId + grid_enum::magnetic_x * n_cells] +
-        dtodz * (electric_y_3 - electric_y_1) +
+        sourceGrid[threadId + grid_enum::magnetic_x * n_cells] + dtodz * (electric_y_3 - electric_y_1) +
         dtody * (electric_z_1 - electric_z_3);
 
     // Y field update
     // S&G 2009 equation 11
     destinationGrid[threadId + grid_enum::magnetic_y * n_cells] =
-        sourceGrid[threadId + grid_enum::magnetic_y * n_cells] +
-        dtodx * (electric_z_3 - electric_z_2) +
+        sourceGrid[threadId + grid_enum::magnetic_y * n_cells] + dtodx * (electric_z_3 - electric_z_2) +
         dtodz * (electric_x_1 - electric_x_3);
 
     // Z field update
     // S&G 2009 equation 12
     destinationGrid[threadId + grid_enum::magnetic_z * n_cells] =
-        sourceGrid[threadId + grid_enum::magnetic_z * n_cells] +
-        dtody * (electric_x_3 - electric_x_2) +
+        sourceGrid[threadId + grid_enum::magnetic_z * n_cells] + dtody * (electric_x_3 - electric_x_2) +
         dtodx * (electric_y_2 - electric_y_3);
   }
 }

--- a/src/mhd/magnetic_update.cu
+++ b/src/mhd/magnetic_update.cu
@@ -39,34 +39,55 @@ __global__ void Update_Magnetic_Field_3D(Real *sourceGrid, Real *destinationGrid
     // Load the various edge electric fields required. The '1' and '2'
     // fields are not shared and the '3' fields are shared by two of the
     // updates
-    Real electric_x_1 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid, nx, ny))];
-    Real electric_x_2 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid, zid + 1, nx, ny))];
-    Real electric_x_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid + 1, nx, ny))];
-    Real electric_y_1 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid, nx, ny)) + n_cells];
-    Real electric_y_2 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid, zid + 1, nx, ny)) + n_cells];
-    Real electric_y_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid + 1, nx, ny)) + n_cells];
-    Real electric_z_1 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid, zid, nx, ny)) + 2 * n_cells];
-    Real electric_z_2 = ctElectricFields[(cuda_utilities::compute1DIndex(xid, yid + 1, zid, nx, ny)) + 2 * n_cells];
-    Real electric_z_3 = ctElectricFields[(cuda_utilities::compute1DIndex(xid + 1, yid + 1, zid, nx, ny)) + 2 * n_cells];
+    Real electric_x_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid, yid + 1, zid, nx, ny)) +
+                                         grid_enum::ct_elec_x * n_cells];
+    Real electric_x_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid, yid, zid + 1, nx, ny)) +
+                                         grid_enum::ct_elec_x * n_cells];
+    Real electric_x_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid, yid + 1, zid + 1, nx, ny)) +
+                                         grid_enum::ct_elec_x * n_cells];
+    Real electric_y_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid + 1, yid, zid, nx, ny)) +
+                                         grid_enum::ct_elec_y * n_cells];
+    Real electric_y_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid, yid, zid + 1, nx, ny)) +
+                                         grid_enum::ct_elec_y * n_cells];
+    Real electric_y_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid + 1, yid, zid + 1, nx, ny)) +
+                                         grid_enum::ct_elec_y * n_cells];
+    Real electric_z_1 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid + 1, yid, zid, nx, ny)) +
+                                         grid_enum::ct_elec_z * n_cells];
+    Real electric_z_2 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid, yid + 1, zid, nx, ny)) +
+                                         grid_enum::ct_elec_z * n_cells];
+    Real electric_z_3 = ctElectricFields[(cuda_utilities::compute1DIndex(
+                                             xid + 1, yid + 1, zid, nx, ny)) +
+                                         grid_enum::ct_elec_z * n_cells];
 
     // Perform Updates
 
     // X field update
     // S&G 2009 equation 10
-    destinationGrid[threadId + (grid_enum::magnetic_x)*n_cells] =
-        sourceGrid[threadId + (grid_enum::magnetic_x)*n_cells] + dtodz * (electric_y_3 - electric_y_1) +
+    destinationGrid[threadId + grid_enum::magnetic_x * n_cells] =
+        sourceGrid[threadId + grid_enum::magnetic_x * n_cells] +
+        dtodz * (electric_y_3 - electric_y_1) +
         dtody * (electric_z_1 - electric_z_3);
 
     // Y field update
     // S&G 2009 equation 11
-    destinationGrid[threadId + (grid_enum::magnetic_y)*n_cells] =
-        sourceGrid[threadId + (grid_enum::magnetic_y)*n_cells] + dtodx * (electric_z_3 - electric_z_2) +
+    destinationGrid[threadId + grid_enum::magnetic_y * n_cells] =
+        sourceGrid[threadId + grid_enum::magnetic_y * n_cells] +
+        dtodx * (electric_z_3 - electric_z_2) +
         dtodz * (electric_x_1 - electric_x_3);
 
     // Z field update
     // S&G 2009 equation 12
-    destinationGrid[threadId + (grid_enum::magnetic_z)*n_cells] =
-        sourceGrid[threadId + (grid_enum::magnetic_z)*n_cells] + dtody * (electric_x_3 - electric_x_2) +
+    destinationGrid[threadId + grid_enum::magnetic_z * n_cells] =
+        sourceGrid[threadId + grid_enum::magnetic_z * n_cells] +
+        dtody * (electric_x_3 - electric_x_2) +
         dtodx * (electric_y_2 - electric_y_3);
   }
 }

--- a/src/mhd/magnetic_update.cu
+++ b/src/mhd/magnetic_update.cu
@@ -30,7 +30,8 @@ __global__ void Update_Magnetic_Field_3D(Real *sourceGrid, Real *destinationGrid
 
   // Thread guard to avoid overrun and to skip ghost cells that cannot be
   // evolved due to missing electric fields that can't be reconstructed
-  if (xid < nx - 2 and yid < ny - 2 and zid < nz - 2) {
+  if (xid > 0 and yid > 0 and zid > 0 and xid < nx - 1 and yid < ny - 1 and
+      zid < nz - 1) {
     // Compute the three dt/dx quantities
     Real const dtodx = dt / dx;
     Real const dtody = dt / dy;

--- a/src/mhd/magnetic_update_tests.cu
+++ b/src/mhd/magnetic_update_tests.cu
@@ -122,9 +122,9 @@ class tMHDUpdateMagneticField3D : public ::testing::Test
 TEST_F(tMHDUpdateMagneticField3D, CorrectInputExpectCorrectOutput)
 {
   // Fiducial values
-  fiducialData.at(135) = 142.68000000000001;
-  fiducialData.at(162) = 151.75999999999999;
-  fiducialData.at(189) = 191.56;
+  fiducialData.at(148) = 155.68000000000001;
+  fiducialData.at(175) = 164.75999999999999;
+  fiducialData.at(202) = 204.56;
 
   // Launch kernel and check results
   runTest();

--- a/src/riemann_solvers/hlld_cuda.cu
+++ b/src/riemann_solvers/hlld_cuda.cu
@@ -30,10 +30,9 @@
 namespace mhd
 {
 // =========================================================================
-__global__ void Calculate_HLLD_Fluxes_CUDA(
-    Real const *dev_bounds_L, Real const *dev_bounds_R,
-    Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
-    Real const gamma, int const direction, int const n_fields)
+__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_bounds_L, Real const *dev_bounds_R,
+                                           Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
+                                           Real const gamma, int const direction, int const n_fields)
 {
   // get a thread index
   int threadId = threadIdx.x + blockIdx.x * blockDim.x;

--- a/src/riemann_solvers/hlld_cuda.cu
+++ b/src/riemann_solvers/hlld_cuda.cu
@@ -30,21 +30,16 @@
 namespace mhd
 {
 // =========================================================================
-__global__ void Calculate_HLLD_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_magnetic_face,
-                                           Real *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma,
-                                           int direction, int n_fields)
+__global__ void Calculate_HLLD_Fluxes_CUDA(
+    Real const *dev_bounds_L, Real const *dev_bounds_R,
+    Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
+    Real const gamma, int const direction, int const n_fields)
 {
   // get a thread index
-  int blockId  = blockIdx.x + blockIdx.y * gridDim.x;
-  int threadId = threadIdx.x + blockId * blockDim.x;
-  int xid, yid, zid;
-  cuda_utilities::compute3DIndices(threadId, nx, ny, xid, yid, zid);
+  int threadId = threadIdx.x + blockIdx.x * blockDim.x;
 
   // Thread guard to avoid overrun
-  if (xid >= nx or yid >= ny or zid >= nz) return;
-
-  // Number of cells
-  int n_cells = nx * ny * nz;
+  if (threadId >= n_cells) return;
 
   // Offsets & indices
   int o1, o2, o3;
@@ -296,6 +291,9 @@ __device__ __host__ void returnFluxes(int const &threadId, int const &o1, int co
                                       int const &n_cells, Real *dev_flux, mhd::_internal::Flux const &flux,
                                       mhd::_internal::State const &state)
 {
+  // Note that the direction of the grid_enum::fluxX_magnetic_DIR is the
+  // direction of the electric field that the magnetic flux is, not the magnetic
+  // flux
   dev_flux[threadId + n_cells * grid_enum::density]          = flux.density;
   dev_flux[threadId + n_cells * o1]                          = flux.momentumX;
   dev_flux[threadId + n_cells * o2]                          = flux.momentumY;

--- a/src/riemann_solvers/hlld_cuda.h
+++ b/src/riemann_solvers/hlld_cuda.h
@@ -25,22 +25,23 @@ namespace mhd
  * \brief Compute the HLLD fluxes from Miyoshi & Kusano 2005
  *
  * \param[in]  dev_bounds_L The interface states on the left side of the
- * interface \param[in]  dev_bounds_R The interface states on the right side of
- * the interface \param[in]  dev_magnetic_face A pointer to the begining of the
+ * interface
+ * \param[in]  dev_bounds_R The interface states on the right side of
+ * the interface
+ * \param[in]  dev_magnetic_face A pointer to the begining of the
  * conserved magnetic field array that is stored at the interface. I.e. for the
  * X-direction solve this would be the begining of the X-direction fields
  * \param[out] dev_flux The output flux
- * \param[in]  nx Number of cells in the X-direction
- * \param[in]  ny Number of cells in the Y-direction
- * \param[in]  nz Number of cells in the Z-direction
+ * \param[in]  n_cells Total number of cells
  * \param[in]  n_ghost Number of ghost cells on each side
- * \param[in]  gamma The adiabatic index
  * \param[in]  dir The direction that the solve is taking place in. 0=X, 1=Y,
- * 2=Z \param[in]  n_fields The total number of fields
+ * 2=Z
+ * \param[in]  n_fields The total number of fields
  */
-__global__ void Calculate_HLLD_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_magnetic_face,
-                                           Real *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma,
-                                           int direction, int n_fields);
+__global__ void Calculate_HLLD_Fluxes_CUDA(
+    Real const *dev_bounds_L, Real const *dev_bounds_R,
+    Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
+    Real const gamma, int const direction, int const n_fields);
 
 /*!
  * \brief Namespace to hold private functions used within the HLLD

--- a/src/riemann_solvers/hlld_cuda.h
+++ b/src/riemann_solvers/hlld_cuda.h
@@ -38,10 +38,9 @@ namespace mhd
  * 2=Z
  * \param[in]  n_fields The total number of fields
  */
-__global__ void Calculate_HLLD_Fluxes_CUDA(
-    Real const *dev_bounds_L, Real const *dev_bounds_R,
-    Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
-    Real const gamma, int const direction, int const n_fields);
+__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_bounds_L, Real const *dev_bounds_R,
+                                           Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
+                                           Real const gamma, int const direction, int const n_fields);
 
 /*!
  * \brief Namespace to hold private functions used within the HLLD

--- a/src/riemann_solvers/hlld_cuda_tests.cu
+++ b/src/riemann_solvers/hlld_cuda_tests.cu
@@ -71,11 +71,11 @@ class tMHDCalculateHLLDFluxesCUDA : public ::testing::Test
     stateRight.erase(stateRight.begin() + grid_enum::magnetic_x);
 
     // Simulation Paramters
-    int const nx     = 1;  // Number of cells in the x-direction
-    int const ny     = 1;  // Number of cells in the y-direction
-    int const nz     = 1;  // Number of cells in the z-direction
-    int const nGhost = 0;  // Isn't actually used it appears
-    int nFields      = 8;  // Total number of conserved fields
+    int const nx      = 1;  // Number of cells in the x-direction
+    int const ny      = 1;  // Number of cells in the y-direction
+    int const nz      = 1;  // Number of cells in the z-direction
+    int const n_cells = nx * ny * nz;
+    int nFields       = 8;  // Total number of conserved fields
     #ifdef SCALAR
     nFields += NSCALARS;
     #endif  // SCALAR
@@ -109,11 +109,12 @@ class tMHDCalculateHLLDFluxesCUDA : public ::testing::Test
         cudaMemcpy(devConservedMagXFace, magneticX.data(), magneticX.size() * sizeof(Real), cudaMemcpyHostToDevice));
 
     // Run kernel
-    hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dimGrid, dimBlock, 0, 0,
-                       devConservedLeft,      // the "left" interface
-                       devConservedRight,     // the "right" interface
-                       devConservedMagXFace,  // the magnetic field at the interface
-                       devTestFlux, nx, ny, nz, nGhost, gamma, direction, nFields);
+    hipLaunchKernelGGL(
+        mhd::Calculate_HLLD_Fluxes_CUDA, dimGrid, dimBlock, 0, 0,
+        devConservedLeft,      // the "left" interface
+        devConservedRight,     // the "right" interface
+        devConservedMagXFace,  // the magnetic field at the interface
+        devTestFlux, n_cells, gamma, direction, nFields);
 
     CudaCheckError();
     CudaSafeCall(cudaMemcpy(testFlux.data(), devTestFlux, testFlux.size() * sizeof(Real), cudaMemcpyDeviceToHost));

--- a/src/riemann_solvers/hlld_cuda_tests.cu
+++ b/src/riemann_solvers/hlld_cuda_tests.cu
@@ -109,12 +109,11 @@ class tMHDCalculateHLLDFluxesCUDA : public ::testing::Test
         cudaMemcpy(devConservedMagXFace, magneticX.data(), magneticX.size() * sizeof(Real), cudaMemcpyHostToDevice));
 
     // Run kernel
-    hipLaunchKernelGGL(
-        mhd::Calculate_HLLD_Fluxes_CUDA, dimGrid, dimBlock, 0, 0,
-        devConservedLeft,      // the "left" interface
-        devConservedRight,     // the "right" interface
-        devConservedMagXFace,  // the magnetic field at the interface
-        devTestFlux, n_cells, gamma, direction, nFields);
+    hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, dimGrid, dimBlock, 0, 0,
+                       devConservedLeft,      // the "left" interface
+                       devConservedRight,     // the "right" interface
+                       devConservedMagXFace,  // the magnetic field at the interface
+                       devTestFlux, n_cells, gamma, direction, nFields);
 
     CudaCheckError();
     CudaSafeCall(cudaMemcpy(testFlux.data(), devTestFlux, testFlux.size() * sizeof(Real), cudaMemcpyDeviceToHost));

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -38,26 +38,26 @@ class tHYDROSYSTEMSodShockTubeParameterizedMpi : public ::testing::TestWithParam
 
 TEST_P(tHYDROSYSTEMSodShockTubeParameterizedMpi, CorrectInputExpectCorrectOutput)
 {
-#ifdef MHD
-  // Loosen correctness check to account for MHD only having PCM. This is
-  // about the error between PCM and PPMP in hydro
-  sodTest.setFixedEpsilon(1E-3);
+  // #ifdef MHD
+  //   // Loosen correctness check to account for MHD only having PCM. This is
+  //   // about the error between PCM and PPMP in hydro
+  //   sodTest.setFixedEpsilon(1E-3);
 
-  // Don't test the gas energy fields
-  auto datasetNames = sodTest.getDataSetsToTest();
-  datasetNames.erase(std::remove(datasetNames.begin(), datasetNames.end(), "GasEnergy"), datasetNames.end());
+  //   // Don't test the gas energy fields
+  //   auto datasetNames = sodTest.getDataSetsToTest();
+  //   datasetNames.erase(std::remove(datasetNames.begin(), datasetNames.end(), "GasEnergy"), datasetNames.end());
 
-  // Set the magnetic fiducial datasets to zero
-  size_t const size = std::pow(65, 3);
-  std::vector<double> const magVec(0, size);
+  //   // Set the magnetic fiducial datasets to zero
+  //   size_t const size = std::pow(65, 3);
+  //   std::vector<double> const magVec(0, size);
 
-  for (auto field : {"magnetic_x", "magnetic_y", "magnetic_z"}) {
-    sodTest.setFiducialData(field, magVec);
-    datasetNames.push_back(field);
-  }
+  //   for (const auto *field : {"magnetic_x", "magnetic_y", "magnetic_z"}) {
+  //     sodTest.setFiducialData(field, magVec);
+  //     datasetNames.push_back(field);
+  //   }
 
-  sodTest.setDataSetsToTest(datasetNames);
-#endif  // MHD
+  //   sodTest.setDataSetsToTest(datasetNames);
+  // #endif  // MHD
 
   sodTest.numMpiRanks = GetParam();
   sodTest.runTest();

--- a/src/utils/timing_functions.h
+++ b/src/utils/timing_functions.h
@@ -13,13 +13,13 @@ class OneTime
 {
  public:
   const char* name;
-  int n_steps = 0;
-  Real time_start;
-  Real t_min;
-  Real t_max;
-  Real t_avg;
-  Real t_all    = 0;
-  bool inactive = true;
+  int n_steps     = 0;
+  Real time_start = 0;
+  Real t_min      = 0;
+  Real t_max      = 0;
+  Real t_avg      = 0;
+  Real t_all      = 0;
+  bool inactive   = true;
   OneTime(void) {}
   OneTime(const char* input_name)
   {


### PR DESCRIPTION
# Disable diode outflow boundaries for MHD

Since MHD needs a larger stencil the diode in the outflow BC's was causing issues. After discussion with @evaneschneider the diode has been disabled for MHD builds.

# Clang Tidy

Minor tweaks to fix clang-tidy's `readability-qualified-auto` and `clang-analyzer-optin.cplusplus.UninitializedObject` checks.

The readablity check was fixed by commenting out some currently used code, it's not deleted since it will be used again when MHD is finished; at which time the actual error will be fixed.

The clang-analyzer check was fixed by initializing some member variables in the OneTime class. @alwinm, I'd like you to take a look at this and make sure I haven't broken anything.

# Other

- Switched more indexing over to using grid_enums and added enums for the CT electric fields.
- Cleaned up the arguments for the HLLD solver, removed unused ones, etc[
- Fix issues with Dai & Woodward shock tube initial conditions
- Up the size of all MHD shock tubes from 32^3 to 64^3