### PR TITLE
Restore & refactor `MPI_Comm_node` function

### DIFF
--- a/src/mpi/mpi_routines.h
+++ b/src/mpi/mpi_routines.h
@@ -4,6 +4,8 @@
     #include <mpi.h>
     #include <stddef.h>
 
+    #include <utility>
+
     #include "../global/global.h"
     #include "../grid/grid3D.h"
 
@@ -198,6 +200,13 @@ void deallocate_three_dimensional_int_array(int ***x, int n, int l, int m);
 
 /* Copy MPI receive buffers on Host to their device locations */
 void copyHostToDeviceReceiveBuffer(int direction);
+
+/*!
+ * \brief Split the communicator for each node and return IDs
+ *
+ * \return std::pair<int, int> The rank id and total number of processes
+ */
+std::pair<int, int> MPI_Comm_node();
 
   #endif /*MPI_ROUTINES_H*/
 #endif   /*MPI_CHOLLA*/


### PR DESCRIPTION
This restores the `MPI_Comm_node` function removed in PR #259 and which caused issue #266. While the return of that function was unused it did play an important roll in arranging MPI ranks for Cholla. This PR restores a refactored version of the function that is a bit simpler with the unused bit cut out.

Shout out to @helenarichie for finding the bug and @evaneschneider for identifying what needed to be fixed.

closes #266 