### PR TITLE
Fix MHD I/O & Add Restart Test

### DIFF
--- a/python_scripts/cat_dset_3D.py
+++ b/python_scripts/cat_dset_3D.py
@@ -51,10 +51,9 @@ for n in range(ns, ne+1):
       except KeyError:
         print('No Dual energy data present');
       try:
-        [nx_mag, ny_mag, nz_mag] = head['magnetic_field_dims']
-        bx = fileout.create_dataset("magnetic_x", (nx_mag, ny_mag, nz_mag), chunks=True, dtype=filein['magnetic_x'].dtype)
-        by = fileout.create_dataset("magnetic_y", (nx_mag, ny_mag, nz_mag), chunks=True, dtype=filein['magnetic_y'].dtype)
-        bz = fileout.create_dataset("magnetic_z", (nx_mag, ny_mag, nz_mag), chunks=True, dtype=filein['magnetic_z'].dtype)
+        bx = fileout.create_dataset("magnetic_x", (nx+1, ny, nz), chunks=True, dtype=filein['magnetic_x'].dtype)
+        by = fileout.create_dataset("magnetic_y", (nx, ny+1, nz), chunks=True, dtype=filein['magnetic_y'].dtype)
+        bz = fileout.create_dataset("magnetic_z", (nx, ny, nz+1), chunks=True, dtype=filein['magnetic_z'].dtype)
       except KeyError:
         print('No magnetic field data present');
 
@@ -76,12 +75,9 @@ for n in range(ns, ne+1):
     except KeyError:
         print('No Dual energy data present');
     try:
-      xShift = 1 if xs>0 else 0
-      yShift = 1 if ys>0 else 0
-      zShift = 1 if zs>0 else 0
-      fileout['magnetic_x'][xs-xShift:xs+nxl, ys:ys+nyl,   zs:zs+nzl]   = filein['magnetic_x']
-      fileout['magnetic_y'][xs:xs+nxl,   ys-yShift:ys+nyl, zs:zs+nzl]   = filein['magnetic_y']
-      fileout['magnetic_z'][xs:xs+nxl,   ys:ys+nyl,   zs-zShift:zs+nzl] = filein['magnetic_z']
+      fileout['magnetic_x'][xs:xs+nxl+1, ys:ys+nyl,   zs:zs+nzl]   = filein['magnetic_x']
+      fileout['magnetic_y'][xs:xs+nxl,   ys:ys+nyl+1, zs:zs+nzl]   = filein['magnetic_y']
+      fileout['magnetic_z'][xs:xs+nxl,   ys:ys+nyl,   zs:zs+nzl+1] = filein['magnetic_z']
     except KeyError:
         print('No magnetic field data present');
 

--- a/python_scripts/cat_dset_3D.py
+++ b/python_scripts/cat_dset_3D.py
@@ -76,10 +76,12 @@ for n in range(ns, ne+1):
     except KeyError:
         print('No Dual energy data present');
     try:
-      [nxl_mag, nyl_mag, nzl_mag] = head['magnetic_field_dims_local']
-      fileout['magnetic_x'][xs:xs+nxl_mag,ys:ys+nyl_mag,zs:zs+nzl_mag] = filein['magnetic_x']
-      fileout['magnetic_y'][xs:xs+nxl_mag,ys:ys+nyl_mag,zs:zs+nzl_mag] = filein['magnetic_y']
-      fileout['magnetic_z'][xs:xs+nxl_mag,ys:ys+nyl_mag,zs:zs+nzl_mag] = filein['magnetic_z']
+      xShift = 1 if xs>0 else 0
+      yShift = 1 if ys>0 else 0
+      zShift = 1 if zs>0 else 0
+      fileout['magnetic_x'][xs-xShift:xs+nxl, ys:ys+nyl,   zs:zs+nzl]   = filein['magnetic_x']
+      fileout['magnetic_y'][xs:xs+nxl,   ys-yShift:ys+nyl, zs:zs+nzl]   = filein['magnetic_y']
+      fileout['magnetic_z'][xs:xs+nxl,   ys:ys+nyl,   zs-zShift:zs+nzl] = filein['magnetic_z']
     except KeyError:
         print('No magnetic field data present');
 

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -28,7 +28,6 @@ typedef double Real;
 
 #define MAXLEN      2048
 #define TINY_NUMBER 1.0e-20
-#define PI          3.141592653589793
 #define MP          1.672622e-24  // mass of proton, grams
 #define KB          1.380658e-16  // boltzmann constant, cgs
 // #define GN 6.67259e-8 // gravitational constant, cgs

--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -275,11 +275,11 @@ void Grid3D::Sound_Wave(Real rho, Real vx, Real vy, Real vz, Real P, Real A)
         C.momentum_z[id] = rho * vz;
         C.Energy[id]     = P / (gama - 1.0) + 0.5 * rho * (vx * vx + vy * vy + vz * vz);
         // add small-amplitude perturbations
-        C.density[id]    = C.density[id] + A * sin(2.0 * PI * x_pos);
-        C.momentum_x[id] = C.momentum_x[id] + A * sin(2.0 * PI * x_pos);
-        C.momentum_y[id] = C.momentum_y[id] + A * sin(2.0 * PI * x_pos);
-        C.momentum_z[id] = C.momentum_z[id] + A * sin(2.0 * PI * x_pos);
-        C.Energy[id]     = C.Energy[id] + A * (1.5) * sin(2 * PI * x_pos);
+        C.density[id]    = C.density[id] + A * sin(2.0 * M_PI * x_pos);
+        C.momentum_x[id] = C.momentum_x[id] + A * sin(2.0 * M_PI * x_pos);
+        C.momentum_y[id] = C.momentum_y[id] + A * sin(2.0 * M_PI * x_pos);
+        C.momentum_z[id] = C.momentum_z[id] + A * sin(2.0 * M_PI * x_pos);
+        C.Energy[id]     = C.Energy[id] + A * (1.5) * sin(2 * M_PI * x_pos);
 #ifdef DE
         C.GasEnergy[id] = P / (gama - 1.0);
 #endif  // DE
@@ -316,7 +316,7 @@ void Grid3D::Linear_Wave(Real rho, Real vx, Real vy, Real vz, Real P, Real A, Re
 
         // set constant initial states. Note that mhd::utils::computeEnergy
         // computes the hydro energy if MHD is turned off
-        Real sine_wave = std::sin(2.0 * PI * x_pos);
+        Real sine_wave = std::sin(2.0 * M_PI * x_pos);
 
         C.density[id]    = rho;
         C.momentum_x[id] = rho * vx;
@@ -331,7 +331,7 @@ void Grid3D::Linear_Wave(Real rho, Real vx, Real vy, Real vz, Real P, Real A, Re
         C.Energy[id] += A * rEigenVec_E * sine_wave;
 
 #ifdef MHD
-        sine_wave        = std::sin(2.0 * PI * (x_pos + stagger));
+        sine_wave        = std::sin(2.0 * M_PI * (x_pos + stagger));
         C.magnetic_x[id] = Bx + A * rEigenVec_Bx * sine_wave;
         C.magnetic_y[id] = By + A * rEigenVec_By * sine_wave;
         C.magnetic_z[id] = Bz + A * rEigenVec_Bz * sine_wave;
@@ -526,7 +526,7 @@ void Grid3D::Shu_Osher()
       P                = 10.33333;
       C.Energy[id]     = P / (gama - 1.0) + 0.5 * C.density[id] * vx * vx;
     } else {
-      C.density[id]    = 1.0 + 0.2 * sin(5.0 * PI * x_pos);
+      C.density[id]    = 1.0 + 0.2 * sin(5.0 * M_PI * x_pos);
       Real vx          = 0.0;
       C.momentum_x[id] = C.density[id] * vx;
       C.momentum_y[id] = 0.0;
@@ -624,7 +624,7 @@ void Grid3D::KH()
         if (y_pos <= 1.0 * H.ydglobal / 4.0) {
           C.density[id]    = d2;
           C.momentum_x[id] = v2 * C.density[id];
-          C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos);
+          C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos);
           C.momentum_z[id] = 0.0;
 #ifdef SCALAR
   #ifdef BASIC_SCALAR
@@ -634,7 +634,7 @@ void Grid3D::KH()
         } else if (y_pos >= 3.0 * H.ydglobal / 4.0) {
           C.density[id]    = d2;
           C.momentum_x[id] = v2 * C.density[id];
-          C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos);
+          C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos);
           C.momentum_z[id] = 0.0;
 
 #ifdef SCALAR
@@ -647,7 +647,7 @@ void Grid3D::KH()
         else {
           C.density[id]    = d1;
           C.momentum_x[id] = v1 * C.density[id];
-          C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos);
+          C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos);
           C.momentum_z[id] = 0.0;
 
 #ifdef SCALAR
@@ -721,7 +721,7 @@ void Grid3D::KH_res_ind()
             C.momentum_x[id] =
                 v1 * C.density[id] - C.density[id] * (v1 - v2) *
                                          exp(-0.5 * pow(y_pos - 0.75 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-            C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos) *
+            C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos) *
                                exp(-0.5 * pow(y_pos - 0.75 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           } else {
             C.density[id] =
@@ -729,7 +729,7 @@ void Grid3D::KH_res_ind()
             C.momentum_x[id] =
                 v1 * C.density[id] - C.density[id] * (v1 - v2) *
                                          exp(-0.5 * pow(y_pos - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-            C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos) *
+            C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos) *
                                exp(-0.5 * pow(y_pos - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           }
         }
@@ -741,7 +741,7 @@ void Grid3D::KH_res_ind()
             C.momentum_x[id] =
                 v2 * C.density[id] + C.density[id] * (v1 - v2) *
                                          exp(-0.5 * pow(y_pos - 0.75 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-            C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos) *
+            C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos) *
                                exp(-0.5 * pow(y_pos - 0.75 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           } else {
             C.density[id] =
@@ -749,7 +749,7 @@ void Grid3D::KH_res_ind()
             C.momentum_x[id] =
                 v2 * C.density[id] + C.density[id] * (v1 - v2) *
                                          exp(-0.5 * pow(y_pos - 0.25 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-            C.momentum_y[id] = C.density[id] * A * sin(4 * PI * x_pos) *
+            C.momentum_y[id] = C.density[id] * A * sin(4 * M_PI * x_pos) *
                                exp(-0.5 * pow(y_pos - 0.25 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           }
         }
@@ -765,18 +765,18 @@ void Grid3D::KH_res_ind()
           C.density[id] = d1 - (d1 - d2) * exp(-0.5 * pow(r - 0.25 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           C.momentum_x[id] = v1 * C.density[id] -
                              C.density[id] * exp(-0.5 * pow(r - 0.25 - sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-          C.momentum_y[id] = cos(phi) * C.density[id] * A * sin(4 * PI * x_pos) *
+          C.momentum_y[id] = cos(phi) * C.density[id] * A * sin(4 * M_PI * x_pos) *
                              exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-          C.momentum_z[id] = sin(phi) * C.density[id] * A * sin(4 * PI * x_pos) *
+          C.momentum_z[id] = sin(phi) * C.density[id] * A * sin(4 * M_PI * x_pos) *
                              exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
         } else  // outside the cylinder
         {
           C.density[id] = d2 + (d1 - d2) * exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
           C.momentum_x[id] = v2 * C.density[id] +
                              C.density[id] * exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy));
-          C.momentum_y[id] = cos(phi) * C.density[id] * A * sin(4 * PI * x_pos) *
+          C.momentum_y[id] = cos(phi) * C.density[id] * A * sin(4 * M_PI * x_pos) *
                              (1.0 - exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy)));
-          C.momentum_z[id] = sin(phi) * C.density[id] * A * sin(4 * PI * x_pos) *
+          C.momentum_z[id] = sin(phi) * C.density[id] * A * sin(4 * M_PI * x_pos) *
                              (1.0 - exp(-0.5 * pow(r - 0.25 + sqrt(-2.0 * dy * dy * log(0.5)), 2) / (dy * dy)));
         }
 
@@ -815,7 +815,7 @@ void Grid3D::Rayleigh_Taylor()
       Get_Position(i, j, H.n_ghost, &x_pos, &y_pos, &z_pos);
 
       // set the y velocities (small perturbation tapering off from center)
-      vy = 0.01 * cos(6 * PI * x_pos + PI) * exp(-(y_pos - 0.5 * H.ydglobal) * (y_pos - 0.5 * H.ydglobal) / 0.1);
+      vy = 0.01 * cos(6 * M_PI * x_pos + M_PI) * exp(-(y_pos - 0.5 * H.ydglobal) * (y_pos - 0.5 * H.ydglobal) / 0.1);
       // vy = 0.0;
 
       // lower half of slab
@@ -1084,7 +1084,7 @@ void Grid3D::Disk_2D()
       // Disk surface density [M_sun / kpc^2]
       // Assume gas surface density is exponential with scale length 2*R_d and
       // mass 0.25*M_d
-      Sigma = 0.25 * M_d * exp(-r / (2 * R_d)) / (8 * PI * R_d * R_d);
+      Sigma = 0.25 * M_d * exp(-r / (2 * R_d)) / (8 * M_PI * R_d * R_d);
       d     = Sigma;                         // just use sigma for mass density since height is arbitrary
       n     = d * DENSITY_UNIT / MP;         // number density, cgs
       P     = n * KB * T_d / PRESSURE_UNIT;  // disk pressure, code units

--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -631,7 +631,7 @@ void Grid3D::KH()
           C.basic_scalar[id] = 0.0;
   #endif
 #endif
-        // inner half of slab
+          // inner half of slab
         } else {
           C.density[id]    = d1;
           C.momentum_x[id] = v1 * C.density[id];

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -710,28 +710,12 @@ void Grid3D::Write_Header_HDF5(hid_t file_id)
 
   status = Write_HDF5_Attribute(file_id, dataspace_id, int_data, "dims");
 
-  #ifdef MHD
-  for (size_t i = 0; i < 3; i++) {
-    int_data[i]++;
-  }
-
-  status = Write_HDF5_Attribute(file_id, dataspace_id, int_data, "magnetic_field_dims");
-  #endif  // MHD
-
   #ifdef MPI_CHOLLA
   int_data[0] = H.nx_real;
   int_data[1] = H.ny_real;
   int_data[2] = H.nz_real;
 
   status = Write_HDF5_Attribute(file_id, dataspace_id, int_data, "dims_local");
-
-    #ifdef MHD
-  int_data[0] = H.nx_real + 1;
-  int_data[1] = H.ny_real + 1;
-  int_data[2] = H.nz_real + 1;
-
-  status = Write_HDF5_Attribute(file_id, dataspace_id, int_data, "magnetic_field_dims_local");
-    #endif  // MHD
 
   int_data[0] = nx_local_start;
   int_data[1] = ny_local_start;

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -1630,12 +1630,12 @@ void Grid3D::Write_Grid_HDF5(hid_t file_id)
   #ifdef MHD
     if (H.Output_Complete_Data) {
       // Note: for WriteHDF5Field3D, use the left side n_ghost
-      WriteHDF5Field3D(H.nx, H.ny, nx_dset + 1, ny_dset + 1, nz_dset + 1, H.n_ghost - 1, file_id, dataset_buffer,
-                       device_dataset_buffer, C.d_magnetic_x, "/magnetic_x");
-      WriteHDF5Field3D(H.nx, H.ny, nx_dset + 1, ny_dset + 1, nz_dset + 1, H.n_ghost - 1, file_id, dataset_buffer,
-                       device_dataset_buffer, C.d_magnetic_y, "/magnetic_y");
-      WriteHDF5Field3D(H.nx, H.ny, nx_dset + 1, ny_dset + 1, nz_dset + 1, H.n_ghost - 1, file_id, dataset_buffer,
-                       device_dataset_buffer, C.d_magnetic_z, "/magnetic_z");
+      WriteHDF5Field3D(H.nx, H.ny, nx_dset + 1, ny_dset, nz_dset, H.n_ghost, file_id, dataset_buffer,
+                       device_dataset_buffer, C.d_magnetic_x, "/magnetic_x", 0);
+      WriteHDF5Field3D(H.nx, H.ny, nx_dset, ny_dset + 1, nz_dset, H.n_ghost, file_id, dataset_buffer,
+                       device_dataset_buffer, C.d_magnetic_y, "/magnetic_y", 1);
+      WriteHDF5Field3D(H.nx, H.ny, nx_dset, ny_dset, nz_dset + 1, H.n_ghost, file_id, dataset_buffer,
+                       device_dataset_buffer, C.d_magnetic_z, "/magnetic_z", 2);
     }
   #endif  // MHD
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -3183,23 +3183,20 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     min_l  = 1e65;
     max_l  = -1;
     // Copy the x magnetic field array to the grid
-    for (k = 0; k < H.nz_real + 1; k++) {
-      for (j = 0; j < H.ny_real + 1; j++) {
+    for (k = 0; k < H.nz_real; k++) {
+      for (j = 0; j < H.ny_real; j++) {
         for (i = 0; i < H.nx_real + 1; i++) {
-          id               = (i + H.n_ghost - 1) + (j + H.n_ghost - 1) * H.nx + (k + H.n_ghost - 1) * H.nx * H.ny;
-          buf_id           = k + j * (H.nz_real + 1) + i * (H.nz_real + 1) * (H.ny_real + 1);
+          id               = (i + H.n_ghost - 1) + (j + H.n_ghost) * H.nx + (k + H.n_ghost) * H.nx * H.ny;
+          buf_id           = k + j * (H.nz_real) + i * (H.nz_real) * (H.ny_real);
           C.magnetic_x[id] = dataset_buffer[buf_id];
-          mean_l += fabs(C.magnetic_x[id]);
-          if (fabs(C.magnetic_x[id]) > max_l) {
-            max_l = fabs(C.magnetic_x[id]);
-          }
-          if (fabs(C.magnetic_x[id]) < min_l) {
-            min_l = fabs(C.magnetic_x[id]);
-          }
+
+          mean_l += std::abs(C.magnetic_x[id]);
+          max_l = std::max(max_l, std::abs(C.magnetic_x[id]));
+          min_l = std::min(min_l, std::abs(C.magnetic_x[id]));
         }
       }
     }
-    mean_l /= ((H.nz_real + 1) * (H.ny_real + 1) * (H.nx_real + 1));
+    mean_l /= ((H.nz_real + 1) * (H.ny_real) * (H.nx_real));
 
     #if MPI_CHOLLA
     mean_g = ReduceRealAvg(mean_l);
@@ -3229,23 +3226,20 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     min_l  = 1e65;
     max_l  = -1;
     // Copy the y magnetic field array to the grid
-    for (k = 0; k < H.nz_real + 1; k++) {
+    for (k = 0; k < H.nz_real; k++) {
       for (j = 0; j < H.ny_real + 1; j++) {
-        for (i = 0; i < H.nx_real + 1; i++) {
-          id               = (i + H.n_ghost - 1) + (j + H.n_ghost - 1) * H.nx + (k + H.n_ghost - 1) * H.nx * H.ny;
-          buf_id           = k + j * (H.nz_real + 1) + i * (H.nz_real + 1) * (H.ny_real + 1);
+        for (i = 0; i < H.nx_real; i++) {
+          id               = (i + H.n_ghost) + (j + H.n_ghost - 1) * H.nx + (k + H.n_ghost) * H.nx * H.ny;
+          buf_id           = k + j * (H.nz_real) + i * (H.nz_real) * (H.ny_real + 1);
           C.magnetic_y[id] = dataset_buffer[buf_id];
-          mean_l += fabs(C.magnetic_y[id]);
-          if (fabs(C.magnetic_y[id]) > max_l) {
-            max_l = fabs(C.magnetic_y[id]);
-          }
-          if (fabs(C.magnetic_y[id]) < min_l) {
-            min_l = fabs(C.magnetic_y[id]);
-          }
+
+          mean_l += std::abs(C.magnetic_x[id]);
+          max_l = std::max(max_l, std::abs(C.magnetic_x[id]));
+          min_l = std::min(min_l, std::abs(C.magnetic_x[id]));
         }
       }
     }
-    mean_l /= ((H.nz_real + 1) * (H.ny_real + 1) * (H.nx_real + 1));
+    mean_l /= ((H.nz_real) * (H.ny_real + 1) * (H.nx_real));
 
     #if MPI_CHOLLA
     mean_g = ReduceRealAvg(mean_l);
@@ -3276,22 +3270,19 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct parameters P)
     max_l  = -1;
     // Copy the z magnetic field array to the grid
     for (k = 0; k < H.nz_real + 1; k++) {
-      for (j = 0; j < H.ny_real + 1; j++) {
-        for (i = 0; i < H.nx_real + 1; i++) {
-          id               = (i + H.n_ghost - 1) + (j + H.n_ghost - 1) * H.nx + (k + H.n_ghost - 1) * H.nx * H.ny;
-          buf_id           = k + j * (H.nz_real + 1) + i * (H.nz_real + 1) * (H.ny_real + 1);
+      for (j = 0; j < H.ny_real; j++) {
+        for (i = 0; i < H.nx_real; i++) {
+          id               = (i + H.n_ghost) + (j + H.n_ghost) * H.nx + (k + H.n_ghost - 1) * H.nx * H.ny;
+          buf_id           = k + j * (H.nz_real + 1) + i * (H.nz_real + 1) * (H.ny_real);
           C.magnetic_z[id] = dataset_buffer[buf_id];
-          mean_l += fabs(C.magnetic_z[id]);
-          if (fabs(C.magnetic_z[id]) > max_l) {
-            max_l = fabs(C.magnetic_z[id]);
-          }
-          if (fabs(C.magnetic_z[id]) < min_l) {
-            min_l = fabs(C.magnetic_z[id]);
-          }
+
+          mean_l += std::abs(C.magnetic_x[id]);
+          max_l = std::max(max_l, std::abs(C.magnetic_x[id]));
+          min_l = std::min(min_l, std::abs(C.magnetic_x[id]));
         }
       }
     }
-    mean_l /= ((H.nz_real + 1) * (H.ny_real + 1) * (H.nx_real + 1));
+    mean_l /= ((H.nz_real) * (H.ny_real) * (H.nx_real + 1));
 
     #if MPI_CHOLLA
     mean_g = ReduceRealAvg(mean_l);

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -482,7 +482,7 @@ void OutputRotatedProjectedData(Grid3D &G, struct parameters P, int nfile)
   } else if (G.R.flag_delta == 2) {
     // case 2 -- outputting at a rotating delta
     // rotation rate given in the parameter file
-    G.R.delta = fmod(nfile * G.R.ddelta_dt * 2.0 * PI, (2.0 * PI));
+    G.R.delta = fmod(nfile * G.R.ddelta_dt * 2.0 * M_PI, (2.0 * M_PI));
 
     // Create a new file
     file_id = H5Fcreate(filename, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -65,7 +65,7 @@ herr_t Write_HDF5_Dataset(hid_t file_id, hid_t dataspace_id, float* dataset_buff
 // Use GPU to pack source -> device_buffer, then copy device_buffer -> buffer,
 // then write HDF5 field
 void WriteHDF5Field3D(int nx, int ny, int nx_real, int ny_real, int nz_real, int n_ghost, hid_t file_id, float* buffer,
-                      float* device_buffer, Real* source, const char* name);
+                      float* device_buffer, Real* source, const char* name, int mhd_direction = -1);
 void WriteHDF5Field3D(int nx, int ny, int nx_real, int ny_real, int nz_real, int n_ghost, hid_t file_id, double* buffer,
-                      double* device_buffer, Real* source, const char* name);
+                      double* device_buffer, Real* source, const char* name, int mhd_direction = -1);
 #endif

--- a/src/io/io_tests.cpp
+++ b/src/io/io_tests.cpp
@@ -1,0 +1,40 @@
+/*!
+ * \file io_tests.cpp
+ * \author Robert 'Bob' Caddy (rvc@pitt.edu)
+ * \brief Contains all the system tests for code in io.h and io.cpp
+ *
+ */
+
+// External Libraries and Headers
+#include <gtest/gtest.h>
+
+// Local includes
+#include "../io/io.h"
+#include "../system_tests/system_tester.h"
+
+// STL includes
+#include <filesystem>
+#include <string>
+
+// =============================================================================
+TEST(tHYDROtMHDReadGridHdf5, RestartSlowWaveExpectCorrectOutput)
+{
+  // Set parameters
+  int const num_ranks = 4;
+
+  // Generate the data to read from
+  systemTest::SystemTestRunner initializer(false, true, false);
+  initializer.numMpiRanks = num_ranks;
+  initializer.chollaLaunchParams.append(" tout=0.0 outstep=0.0");
+  initializer.launchCholla();
+  std::string const read_directory = initializer.getOutputDirectory() + "/";
+
+  // Reload data and run the test
+  systemTest::SystemTestRunner loadRun(false, true, false);
+  loadRun.numMpiRanks = num_ranks;
+  loadRun.chollaLaunchParams.append(" init=Read_Grid nfile=0 indir=" + read_directory);
+
+  loadRun.setFiducialNumTimeSteps(427);
+  loadRun.runL1ErrorTest(4.2E-7, 5.4E-7);
+}
+// =============================================================================

--- a/src/io/io_tests.cpp
+++ b/src/io/io_tests.cpp
@@ -34,7 +34,7 @@ TEST(tHYDROtMHDReadGridHdf5, RestartSlowWaveExpectCorrectOutput)
   loadRun.numMpiRanks = num_ranks;
   loadRun.chollaLaunchParams.append(" init=Read_Grid nfile=0 indir=" + read_directory);
 
-  loadRun.setFiducialNumTimeSteps(427);
+  loadRun.setFiducialNumTimeSteps(854);
   loadRun.runL1ErrorTest(4.2E-7, 5.4E-7);
 }
 // =============================================================================

--- a/src/system_tests/cooling_system_tests.cpp
+++ b/src/system_tests/cooling_system_tests.cpp
@@ -13,10 +13,6 @@
 #include "../system_tests/system_tester.h"
 #include "../utils/testing_utilities.h"
 
-#ifndef PI
-  #define PI 3.141592653589793
-#endif
-
 #define COOL_RHO 6.9498489284711
 
 TEST(tCOOLINGSYSTEMConstant5, CorrectInputExpectCorrectOutput)

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -15,10 +15,6 @@
 #include "../system_tests/system_tester.h"
 #include "../utils/testing_utilities.h"
 
-#ifndef PI
-  #define PI 3.141592653589793
-#endif
-
 // =============================================================================
 // Test Suite: tHYDROtMHDSYSTEMSodShockTube
 // =============================================================================
@@ -89,7 +85,7 @@ TEST(tHYDROtMHDSYSTEMSoundWave3D, CorrectInputExpectCorrectOutput)
   double amplitude = 1e-5;
   double dx        = 1. / 64.;
 
-  double real_kx = 2 * PI;  // kx of the physical problem
+  double real_kx = 2 * M_PI;  // kx of the physical problem
 
   double kx        = real_kx * dx;
   double speed     = 1;                                  // speed of wave is 1 since P = 0.6 and gamma = 1.666667

--- a/src/system_tests/input_files/tHYDROtMHDReadGridHdf5_RestartSlowWaveExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROtMHDReadGridHdf5_RestartSlowWaveExpectCorrectOutput.txt
@@ -1,0 +1,72 @@
+#
+# Parameter File for MHD slow magnetosonic wave
+# See [this blog post](https://robertcaddy.com/posts/Classes-and-bugfixing-6/)
+# for details on each wave
+# The right eigenvector for this wave is:
+# (1/(6*sqrt(5))) * [12, +/-6, +/-8*sqrt(2), +/-4, 0, -4*sqrt(2), -2, 9]
+# The terms with two sign options: use the left one for right moving waves and
+# the right one for left moving waves
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=64
+# number of grid cells in the y dimension
+ny=32
+# number of grid cells in the z dimension
+nz=32
+# final output time
+tout=2.0
+# time interval for output
+outstep=2.0
+# name of initial conditions
+init=Linear_Wave
+# domain properties
+xmin=0.0
+ymin=0.0
+zmin=0.0
+xlen=1.0
+ylen=0.5
+zlen=0.5
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for linear wave problems
+# initial density
+rho=1.0
+# velocity in the x direction
+vx=0
+# velocity in the y direction
+vy=0
+# velocity in the z direction
+vz=0
+# initial pressure
+P=0.6
+# magnetic field in the x direction
+Bx=1
+# magnetic field in the y direction
+By=1.5
+# magnetic field in the z direction
+Bz=0
+# amplitude of perturbing oscillations
+A=1e-6
+# value of gamma
+gamma=1.666666666666667
+# The right eigenvectors to set the wave properly
+rEigenVec_rho=0.8944271909999159
+rEigenVec_MomentumX=0.4472135954999579
+rEigenVec_MomentumY=0.8944271909999159
+rEigenVec_MomentumZ=0.0
+rEigenVec_Bx=0.0
+rEigenVec_By=-0.4472135954999579
+rEigenVec_Bz=0.0
+rEigenVec_E=0.6708203932499369
+

--- a/src/system_tests/system_tester.cpp
+++ b/src/system_tests/system_tester.cpp
@@ -512,11 +512,18 @@ std::vector<double> systemTest::SystemTestRunner::loadTestFieldData(std::string 
     file = _testHydroFieldsFileVec;
   }
 
-  // Get the size of each dimension. First check if the field is a magnetic
+  // Get the size of each dimension. Check if the field is a magnetic
   // field or not to make sure we're retreiving the right dimensions
-  std::string dimsName     = (dataSetName.find("magnetic") != std::string::npos) ? "magnetic_field_dims" : "dims";
-  H5::Attribute dimensions = file[0].openAttribute(dimsName.c_str());
+  H5::Attribute dimensions = file[0].openAttribute("dims");
   dimensions.read(H5::PredType::NATIVE_ULONG, testDims.data());
+
+  if (dataSetName == "magnetic_x") {
+    testDims.at(0)++;
+  } else if (dataSetName == "magnetic_y") {
+    testDims.at(1)++;
+  } else if (dataSetName == "magnetic_z") {
+    testDims.at(2)++;
+  }
 
   // Allocate the vector
   std::vector<double> testData(testDims[0] * testDims[1] * testDims[2]);
@@ -544,11 +551,17 @@ std::vector<double> systemTest::SystemTestRunner::loadTestFieldData(std::string 
     H5::Attribute offsetAttr = file[rank].openAttribute("offset");
     offsetAttr.read(H5::PredType::NATIVE_INT, offset.data());
 
+    if (dataSetName == "magnetic_x") {
+      offset.at(0)--;
+    } else if (dataSetName == "magnetic_y") {
+      offset.at(1)--;
+    } else if (dataSetName == "magnetic_z") {
+      offset.at(2)--;
+    }
+
     // Get dims_local
     std::vector<int> dimsLocal(3, 1);
-    std::string dimsNameLocal =
-        (dataSetName.find("magnetic") != std::string::npos) ? "magnetic_field_dims_local" : "dims_local";
-    H5::Attribute dimsLocalAttr = file[rank].openAttribute(dimsNameLocal.c_str());
+    H5::Attribute dimsLocalAttr = file[rank].openAttribute("dims_local");
     dimsLocalAttr.read(H5::PredType::NATIVE_INT, dimsLocal.data());
 
     // Now we add the data to the larger vector


### PR DESCRIPTION
## Restart Test

Added a test for MHD and hydro restarts. It doesn't work with gravity, particles, etc but would be pretty easy to extend to those or write new tests for them based off of this test.

## MHD I/O

The MHD I/O was outputting an extra cell in every direction when it should only output an extra cell in the direction of the magnetic field; i.e. the Bx dataset should be (nx+1, ny, nz) not (nx+1, ny+1, nz+1). This should fix that issue and clean up MHD I/O a bit in general.

## Replaced all custom `PI` macros with the built in `M_PI`