### PR TITLE
Add Advecting Field Loop test & initial conditions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 # for those checks, etc. It uses as many of the default values as possible and
 # runs all checks with some exclusions by default.
 #
-# The full list of clang-format 15 checks and documentation can be found
+# The full list of clang-tidy 15 checks and documentation can be found
 # [here](https://releases.llvm.org/15.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
 #
 # The "Checks" command should have 5 sections seperated by a newline:

--- a/builds/run_tests.sh
+++ b/builds/run_tests.sh
@@ -248,12 +248,18 @@ buildAndRunTests ()
     esac
   done
 
+  # Run setup and check if it worked
+  setupTests $MAKE_TYPE_ARG $COMPILER_ARG
+  if [ $? -ne 0 ]; then
+    echo "setup failed"
+    exit 1
+  fi
+
   # Clean the cholla directory
   builtin cd $CHOLLA_ROOT
   make clobber
 
   # Now we get to setting up and building
-  setupTests $MAKE_TYPE_ARG $COMPILER_ARG && \
   if [[ -n $BUILD_GTEST ]]; then
     buildGoogleTest
   fi

--- a/examples/3D/advecting_field_loop.txt
+++ b/examples/3D/advecting_field_loop.txt
@@ -1,0 +1,55 @@
+#
+# Parameter File for an MHD Advecting Field Loop as defined in
+# [Gardiner & Stone 2008](https://ui.adsabs.harvard.edu/abs/2008JCoPh.227.4123G/abstract)
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=128
+# number of grid cells in the y dimension
+ny=128
+# number of grid cells in the z dimension
+nz=256
+# final output time
+tout=2.0
+# time interval for output
+outstep=2.0
+# name of initial conditions
+init=Advecting_Field_Loop
+# domain properties
+xmin=-0.5
+ymin=-0.5
+zmin=-1.0
+xlen=1.0
+ylen=1.0
+zlen=2.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for advecting field loop problem
+# initial density
+rho=1.0
+# velocity in the x direction
+vx=1.0
+# velocity in the y direction
+vy=1.0
+# velocity in the z direction
+vz=2.0
+# initial pressure
+P=1.0
+# amplitude of the loop/magnetic field background value
+A=0.001
+# Radius of the Loop
+R=0.3
+
+# value of gamma
+gamma=1.666666666666667
+

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -359,6 +359,8 @@ void parse_param(char *name, char *value, struct parameters *parms)
     parms->yaw = atof(value);
   } else if (strcmp(name, "polarization") == 0) {
     parms->polarization = atof(value);
+  } else if (strcmp(name, "R") == 0) {
+    parms->R = atof(value);
 #ifdef PARTICLES
   } else if (strcmp(name, "prng_seed") == 0) {
     parms->prng_seed = atoi(value);

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -263,6 +263,7 @@ struct parameters {
   Real pitch               = 0;
   Real yaw                 = 0;
   Real polarization        = 0;
+  Real R                   = 0;
 #ifdef PARTICLES
   // The random seed for particle simulations. With the default of 0 then a
   // machine dependent seed will be generated.

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -290,11 +290,11 @@ void Grid3D::AllocateMemory(void)
   CudaSafeCall(cudaHostAlloc((void **)&C.host, H.n_fields * H.n_cells * sizeof(Real), cudaHostAllocDefault));
 
   // point conserved variables to the appropriate locations
-  C.density    = C.host;
-  C.momentum_x = &(C.host[H.n_cells]);
-  C.momentum_y = &(C.host[2 * H.n_cells]);
-  C.momentum_z = &(C.host[3 * H.n_cells]);
-  C.Energy     = &(C.host[4 * H.n_cells]);
+  C.density    = &(C.host[grid_enum::density * H.n_cells]);
+  C.momentum_x = &(C.host[grid_enum::momentum_x * H.n_cells]);
+  C.momentum_y = &(C.host[grid_enum::momentum_y * H.n_cells]);
+  C.momentum_z = &(C.host[grid_enum::momentum_z * H.n_cells]);
+  C.Energy     = &(C.host[grid_enum::Energy * H.n_cells]);
 #ifdef SCALAR
   C.scalar = &(C.host[H.n_cells * grid_enum::scalar]);
   #ifdef BASIC_SCALAR
@@ -302,9 +302,9 @@ void Grid3D::AllocateMemory(void)
   #endif
 #endif  // SCALAR
 #ifdef MHD
-  C.magnetic_x = &(C.host[(grid_enum::magnetic_x)*H.n_cells]);
-  C.magnetic_y = &(C.host[(grid_enum::magnetic_y)*H.n_cells]);
-  C.magnetic_z = &(C.host[(grid_enum::magnetic_z)*H.n_cells]);
+  C.magnetic_x = &(C.host[grid_enum::magnetic_x * H.n_cells]);
+  C.magnetic_y = &(C.host[grid_enum::magnetic_y * H.n_cells]);
+  C.magnetic_z = &(C.host[grid_enum::magnetic_z * H.n_cells]);
 #endif  // MHD
 #ifdef DE
   C.GasEnergy = &(C.host[(H.n_fields - 1) * H.n_cells]);

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -689,6 +689,14 @@ class Grid3D
    * \param P The parameters. Only uses Vx, pitch, and yaw
    */
   void Circularly_Polarized_Alfven_Wave(struct parameters const P);
+
+  /*!
+   * \brief Initialize the grid with a advecting field loop. See [Gardiner &
+   * Stone 2008](https://arxiv.org/abs/0712.2634).
+   *
+   * \param P The parameters object
+   */
+  void Advecting_Field_Loop(struct parameters const P);
 #endif  // MHD
 #ifdef MPI_CHOLLA
   void Set_Boundaries_MPI(struct parameters P);

--- a/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_AdvectingFieldLoopCorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_AdvectingFieldLoopCorrectInputExpectCorrectOutput.txt
@@ -1,0 +1,55 @@
+#
+# Parameter File for an MHD Advecting Field Loop as defined in
+# [Gardiner & Stone 2008](https://ui.adsabs.harvard.edu/abs/2008JCoPh.227.4123G/abstract)
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=32
+# number of grid cells in the y dimension
+ny=32
+# number of grid cells in the z dimension
+nz=64
+# final output time
+tout=2.0
+# time interval for output
+outstep=2.0
+# name of initial conditions
+init=Advecting_Field_Loop
+# domain properties
+xmin=-0.5
+ymin=-0.5
+zmin=-1.0
+xlen=1.0
+ylen=1.0
+zlen=2.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for linear wave problems
+# initial density
+rho=1.0
+# velocity in the x direction
+vx=1.0
+# velocity in the y direction
+vy=1.0
+# velocity in the z direction
+vz=2.0
+# initial pressure
+P=1.0
+# amplitude of the loop/magnetic field background value
+A=0.001
+# Radius of the Loop
+R=0.3
+
+# value of gamma
+gamma=1.666666666666667
+

--- a/src/system_tests/mhd_system_tests.cpp
+++ b/src/system_tests/mhd_system_tests.cpp
@@ -594,6 +594,13 @@ TEST_P(tMHDSYSTEMParameterizedMpi, RyuAndJones4dShockTubeCorrectInputExpectCorre
   test_runner.numMpiRanks = GetParam();
   test_runner.runTest();
 }
+
+/// Test the Advecting Field Loop
+TEST_P(tMHDSYSTEMParameterizedMpi, AdvectingFieldLoopCorrectInputExpectCorrectOutput)
+{
+  test_runner.numMpiRanks = GetParam();
+  test_runner.runTest();
+}
 /// @}
 // =============================================================================
 

--- a/src/system_tests/system_tester.cpp
+++ b/src/system_tests/system_tester.cpp
@@ -426,7 +426,7 @@ systemTest::SystemTestRunner::SystemTestRunner(bool const &particleData, bool co
   if (useFiducialFile) {
     _fiducialFilePath = ::globalChollaRoot.getString() + "/cholla-tests-data/system_tests/" + _fullTestFileName + ".h5";
     if (not std::filesystem::exists(_fiducialFilePath)) {
-      throw std::invalid_argument("Error: Cholla settings file not found at :" + _fiducialFilePath);
+      throw std::invalid_argument("Error: Cholla fiducial data file not found at :" + _fiducialFilePath);
     }
     _fiducialFile.openFile(_fiducialFilePath, H5F_ACC_RDONLY);
     _fiducialDataSetNames = _findDataSetNames(_fiducialFile);

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -8,12 +8,14 @@
 #pragma once
 
 // STL Includes
+#include <vector>
 
 // External Includes
 
 // Local Includes
 #include "../global/global.h"
 #include "../global/global_cuda.h"
+#include "../grid/grid3D.h"
 #include "../riemann_solvers/hlld_cuda.h"
 #include "../utils/cuda_utilities.h"
 #include "../utils/gpu.hpp"
@@ -284,7 +286,7 @@ inline __host__ __device__ auto cellCenteredMagneticFields(Real const *dev_conse
   // Ternary operator to check that no values outside of the magnetic field
   // arrays are loaded. If the cell is on the edge that doesn't have magnetic
   // fields on both sides then instead set the centered magnetic field to be
-  // equal to the magnetic field of the closest edge. T
+  // equal to the magnetic field of the closest edge.
   Real avgBx = (xid > 0) ?
                          /*if true*/ 0.5 * (dev_conserved[(grid_enum::magnetic_x)*n_cells + id] +
                                             dev_conserved[(grid_enum::magnetic_x)*n_cells +
@@ -309,6 +311,18 @@ inline __host__ __device__ auto cellCenteredMagneticFields(Real const *dev_conse
   };
   return returnStruct{avgBx, avgBy, avgBz};
 }
-#endif  // MHD
 // =========================================================================
+
+// =========================================================================
+/*!
+ * \brief Initialize the magnitice field from the vector potential
+ *
+ * \param H The Header struct
+ * \param C The Conserved struct
+ * \param vectorPotential The vector potential in the same format as the other arrays in Cholla
+ */
+void Init_Magnetic_Field_With_Vector_Potential(Header const &H, Grid3D::Conserved const &C,
+                                               std::vector<Real> const &vectorPotential);
+// =========================================================================
+#endif  // MHD
 }  // end namespace mhd::utils


### PR DESCRIPTION
## Summary

- Example parameter file in `examples/3D/advecting_field_loop.txt`
- New parameter "R" for the radius of the field loop
- New initial conditions type `Advecting_Field_Loop` and an initializing function of the same name
- New MHD system test for the advecting field loop
- New function for initializing the magnetic field from the vector potential and a test to go with it
- Update `Grid3D::AllocateMemory` to use `grid_enums`
- Fix a typo in the `.clang-tidy` file

Fixes #280 