### PR TITLE
Add MHD blast wave test & initial conditions

### DIFF
--- a/examples/3D/advecting_field_loop.txt
+++ b/examples/3D/advecting_field_loop.txt
@@ -48,7 +48,7 @@ P=1.0
 # amplitude of the loop/magnetic field background value
 A=0.001
 # Radius of the Loop
-R=0.3
+radius=0.3
 
 # value of gamma
 gamma=1.666666666666667

--- a/examples/3D/mhd_blast.txt
+++ b/examples/3D/mhd_blast.txt
@@ -1,0 +1,61 @@
+#
+# Parameter File for the MHD Blast wavelength
+# See [Gardiner & Stone 2008](https://arxiv.org/abs/0712.2634) for details.
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=128
+# number of grid cells in the y dimension
+ny=128
+# number of grid cells in the z dimension
+nz=128
+# final output time
+tout=0.02
+# time interval for output
+outstep=0.02
+# name of initial conditions
+init=MHD_Spherical_Blast
+# domain properties
+xmin=-0.5
+ymin=-0.5
+zmin=-0.5
+xlen=1.0
+ylen=1.0
+zlen=1.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for MHD Blast Wave problem
+
+# initial density
+rho=1.0
+# velocity in the x direction
+vx=0.0
+# velocity in the y direction
+vy=0.0
+# velocity in the z direction
+vz=0.0
+# initial pressure outside the blast zone
+P=1.0
+# initial pressure inside the blast zone
+P_blast=100.0
+# The radius of the blast zone
+R=0.125
+# magnetic field in the x direction. Equal to 10/sqrt(2)
+Bx=7.0710678118654746
+# magnetic field in the y direction
+By=0.0
+# magnetic field in the z direction. Equal to 10/sqrt(2)
+Bz=7.0710678118654746
+
+# value of gamma
+gamma=1.666666666666667

--- a/examples/3D/mhd_blast.txt
+++ b/examples/3D/mhd_blast.txt
@@ -49,7 +49,7 @@ P=1.0
 # initial pressure inside the blast zone
 P_blast=100.0
 # The radius of the blast zone
-R=0.125
+radius=0.125
 # magnetic field in the x direction. Equal to 10/sqrt(2)
 Bx=7.0710678118654746
 # magnetic field in the y direction

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -361,6 +361,8 @@ void parse_param(char *name, char *value, struct parameters *parms)
     parms->polarization = atof(value);
   } else if (strcmp(name, "R") == 0) {
     parms->R = atof(value);
+  } else if (strcmp(name, "P_blast") == 0) {
+    parms->P_blast = atof(value);
 #ifdef PARTICLES
   } else if (strcmp(name, "prng_seed") == 0) {
     parms->prng_seed = atoi(value);

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -359,8 +359,8 @@ void parse_param(char *name, char *value, struct parameters *parms)
     parms->yaw = atof(value);
   } else if (strcmp(name, "polarization") == 0) {
     parms->polarization = atof(value);
-  } else if (strcmp(name, "R") == 0) {
-    parms->R = atof(value);
+  } else if (strcmp(name, "radius") == 0) {
+    parms->radius = atof(value);
   } else if (strcmp(name, "P_blast") == 0) {
     parms->P_blast = atof(value);
 #ifdef PARTICLES

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -263,7 +263,7 @@ struct parameters {
   Real pitch               = 0;
   Real yaw                 = 0;
   Real polarization        = 0;
-  Real R                   = 0;
+  Real radius              = 0;
   Real P_blast             = 0;
 #ifdef PARTICLES
   // The random seed for particle simulations. With the default of 0 then a

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -264,6 +264,7 @@ struct parameters {
   Real yaw                 = 0;
   Real polarization        = 0;
   Real R                   = 0;
+  Real P_blast             = 0;
 #ifdef PARTICLES
   // The random seed for particle simulations. With the default of 0 then a
   // machine dependent seed will be generated.

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -697,7 +697,16 @@ class Grid3D
    * \param P The parameters object
    */
   void Advecting_Field_Loop(struct parameters const P);
+
+  /*!
+   * \brief Initialize the grid with a spherical MHD blast wave. See [Gardiner &
+   * Stone 2008](https://arxiv.org/abs/0712.2634) for details.
+   *
+   * \param P The parameters struct
+   */
+  void MHD_Spherical_Blast(struct parameters const P);
 #endif  // MHD
+
 #ifdef MPI_CHOLLA
   void Set_Boundaries_MPI(struct parameters P);
   void Set_Boundaries_MPI_BLOCK(int *flags, struct parameters P);

--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -1711,9 +1711,9 @@ void Grid3D::Advecting_Field_Loop(struct parameters const P)
   assert((P.xmin + P.xlen / 2) == 0 and (P.ymin + P.ylen / 2) == 0 and (P.zmin + P.zlen / 2 == 0) and
          "Domain must be centered at zero");
 
-  // Check that P.R is smaller than the size of the domain
+  // Check that P.radius is smaller than the size of the domain
   Real const domain_size = std::hypot(P.xlen / 2, P.ylen / 2, P.zlen / 2);
-  assert(domain_size > P.R and "The size of the domain must be greater than P.R");
+  assert(domain_size > P.radius and "The size of the domain must be greater than P.radius");
 
   // Compute the vector potential. Since the vector potential std::vector is initialized to zero I will only assign new
   // values when required and ignore the cases where I would be assigning zero
@@ -1730,14 +1730,14 @@ void Grid3D::Advecting_Field_Loop(struct parameters const P)
 
         // Y vector potential
         Real radius = std::hypot(x + H.dx / 2., y, z + H.dz / 2.);
-        if (radius < P.R) {
-          vectorPotential.at(id + 1 * H.n_cells) = P.A * (P.R - radius);
+        if (radius < P.radius) {
+          vectorPotential.at(id + 1 * H.n_cells) = P.A * (P.radius - radius);
         }
 
         // Z vector potential
         radius = std::hypot(x + H.dx / 2., y + H.dy / 2., z);
-        if (radius < P.R) {
-          vectorPotential.at(id + 2 * H.n_cells) = P.A * (P.R - radius);
+        if (radius < P.radius) {
+          vectorPotential.at(id + 2 * H.n_cells) = P.A * (P.radius - radius);
         }
       }
     }
@@ -1777,9 +1777,9 @@ void Grid3D::MHD_Spherical_Blast(struct parameters const P)
   assert((P.xmin + P.xlen / 2) == 0 and (P.ymin + P.ylen / 2) == 0 and (P.zmin + P.zlen / 2 == 0) and
          "Domain must be centered at zero");
 
-  // Check that P.R is smaller than the size of the domain
+  // Check that P.radius is smaller than the size of the domain
   Real const domain_size = std::hypot(P.xlen / 2, P.ylen / 2, P.zlen / 2);
-  assert(domain_size > P.R and "The size of the domain must be greater than P.R");
+  assert(domain_size > P.radius and "The size of the domain must be greater than P.radius");
 
   // Initialize the magnetic field
   for (int k = H.n_ghost - 1; k < H.nz - H.n_ghost; k++) {
@@ -1817,7 +1817,7 @@ void Grid3D::MHD_Spherical_Blast(struct parameters const P)
 
         // Set the field(s) that do depend on pressure. That's just energy
         Real radius = std::hypot(x, y, z);
-        if (radius < P.R) {
+        if (radius < P.radius) {
           C.Energy[id] = mhd::utils::computeEnergy(
               P.P_blast, C.density[id], C.momentum_x[id] / C.density[id], C.momentum_y[id] / C.density[id],
               C.momentum_z[id] / C.density[id], magnetic_centered.x, magnetic_centered.y, magnetic_centered.z, ::gama);

--- a/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_AdvectingFieldLoopCorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_AdvectingFieldLoopCorrectInputExpectCorrectOutput.txt
@@ -48,7 +48,7 @@ P=1.0
 # amplitude of the loop/magnetic field background value
 A=0.001
 # Radius of the Loop
-R=0.3
+radius=0.3
 
 # value of gamma
 gamma=1.666666666666667

--- a/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_MhdBlastWaveCorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_MhdBlastWaveCorrectInputExpectCorrectOutput.txt
@@ -1,0 +1,61 @@
+#
+# Parameter File for the MHD Blast wavelength
+# See [Gardiner & Stone 2008](https://arxiv.org/abs/0712.2634) for details.
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=64
+# number of grid cells in the y dimension
+ny=64
+# number of grid cells in the z dimension
+nz=64
+# final output time
+tout=0.02
+# time interval for output
+outstep=0.02
+# name of initial conditions
+init=MHD_Spherical_Blast
+# domain properties
+xmin=-0.5
+ymin=-0.5
+zmin=-0.5
+xlen=1.0
+ylen=1.0
+zlen=1.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for MHD Blast Wave problem
+
+# initial density
+rho=1.0
+# velocity in the x direction
+vx=0.0
+# velocity in the y direction
+vy=0.0
+# velocity in the z direction
+vz=0.0
+# initial pressure outside the blast zone
+P=1.0
+# initial pressure inside the blast zone
+P_blast=100.0
+# The radius of the blast zone
+R=0.125
+# magnetic field in the x direction. Equal to 10/sqrt(2)
+Bx=7.0710678118654746
+# magnetic field in the y direction
+By=0.0
+# magnetic field in the z direction. Equal to 10/sqrt(2)
+Bz=7.0710678118654746
+
+# value of gamma
+gamma=1.666666666666667

--- a/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_MhdBlastWaveCorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_MhdBlastWaveCorrectInputExpectCorrectOutput.txt
@@ -49,7 +49,7 @@ P=1.0
 # initial pressure inside the blast zone
 P_blast=100.0
 # The radius of the blast zone
-R=0.125
+radius=0.125
 # magnetic field in the x direction. Equal to 10/sqrt(2)
 Bx=7.0710678118654746
 # magnetic field in the y direction

--- a/src/system_tests/mhd_system_tests.cpp
+++ b/src/system_tests/mhd_system_tests.cpp
@@ -601,6 +601,13 @@ TEST_P(tMHDSYSTEMParameterizedMpi, AdvectingFieldLoopCorrectInputExpectCorrectOu
   test_runner.numMpiRanks = GetParam();
   test_runner.runTest();
 }
+
+/// Test the MHD Blast Wave
+TEST_P(tMHDSYSTEMParameterizedMpi, MhdBlastWaveCorrectInputExpectCorrectOutput)
+{
+  test_runner.numMpiRanks = GetParam();
+  test_runner.runTest();
+}
 /// @}
 // =============================================================================
 

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -60,6 +60,9 @@ void Check_Configuration(parameters const &P)
 #endif  //! PRECISION
   static_assert(PRECISION == 2, "PRECISION must be 2. Single precision is not currently supported");
 
+  // Check that gamma, the ratio of specific heats, is greater than 1
+  assert(::gama <= 1.0 and "Gamma must be greater than one.");
+
 // MHD Checks
 // ==========
 #ifdef MHD


### PR DESCRIPTION
## Summary 

- Example parameter file in examples/3D/mhd_blast.txt
- New parameter `P_blast` parameter to indicate the pressure in the over pressure zone of the blast
- New initial conditions type `MHD_Spherical_Blast` and an initializing function of the same name
- New MHD system test for the MHD blast wave
- New check in `Check_Configuration` to check that gamma is greater than one. I accidentally forgot to set gamma when setting up this test originally so I added a check to make sure that doesn't happen again.
