### PR TITLE
Miscellaneous Post MHD Tweaks/Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,11 @@ tidy:
 # Flags we might want
 # - --warnings-as-errors=<string> Upgrade all warnings to error, good for CI
 	clang-tidy --verify-config
+	@echo -e
 	(time clang-tidy $(CLANG_TIDY_ARGS) $(CPPFILES_TIDY) -- $(DFLAGS) $(CXXFLAGS_CLANG_TIDY) $(LIBS_CLANG_TIDY)) > tidy_results_cpp.log 2>&1 & \
 	(time clang-tidy $(CLANG_TIDY_ARGS) $(GPUFILES_TIDY) -- $(DFLAGS) $(GPUFLAGS_CLANG_TIDY) $(LIBS_CLANG_TIDY)) > tidy_results_gpu.log 2>&1 & \
 	for i in 1 2; do wait -n; done
+	@echo -e "\nResults from clang-tidy are available in the 'tidy_results_cpp.log' and 'tidy_results_gpu.log' files."
 
 clean:
 	rm -f $(CLEAN_OBJS)

--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -254,7 +254,10 @@ void Grid3D::Compute_Gas_Temperature(Real *temperature, bool convert_cosmo_units
   #ifdef DE
         GE = C.GasEnergy[id];
   #else
-        GE = (E - 0.5 * d * (vx * vx + vy * vy + vz * vz));  // TODO: this probably needs to be fixed for MHD
+        GE = E - hydro_utilities::Calc_Kinetic_Energy_From_Velocity(d, vx, vy, vz);
+    #ifdef MHD
+        GE -= mhd::utils::computeMagneticEnergy(C.magnetic_x[id], C.magnetic_y[id], C.magnetic_z[id]);
+    #endif  // MHD
   #endif
 
         dens_HI    = C.HI_density[id];

--- a/src/io/io_tests.cpp
+++ b/src/io/io_tests.cpp
@@ -34,7 +34,11 @@ TEST(tHYDROtMHDReadGridHdf5, RestartSlowWaveExpectCorrectOutput)
   loadRun.numMpiRanks = num_ranks;
   loadRun.chollaLaunchParams.append(" init=Read_Grid nfile=0 indir=" + read_directory);
 
+#ifdef MHD
   loadRun.setFiducialNumTimeSteps(854);
+#else   // not MHD
+  loadRun.setFiducialNumTimeSteps(427);
+#endif  // MHD
   loadRun.runL1ErrorTest(4.2E-7, 5.4E-7);
 }
 // =============================================================================

--- a/src/riemann_solvers/hlld_cuda.cu
+++ b/src/riemann_solvers/hlld_cuda.cu
@@ -189,9 +189,7 @@ __device__ __host__ mhd::_internal::State loadState(Real const *interfaceArr, Re
     #endif  // SCALAR
     #ifdef DE
   state.thermalEnergySpecific = interfaceArr[threadId + n_cells * grid_enum::GasEnergy] / state.density;
-    #endif  // DE}
 
-    #ifdef DE  // PRESSURE_DE
   Real energyNonThermal = hydro_utilities::Calc_Kinetic_Energy_From_Velocity(state.density, state.velocityX,
                                                                              state.velocityY, state.velocityZ) +
                           mhd::utils::computeMagneticEnergy(magneticX, state.magneticY, state.magneticZ);
@@ -203,7 +201,7 @@ __device__ __host__ mhd::_internal::State loadState(Real const *interfaceArr, Re
   // Note that this function does the positive pressure check
   // internally
   state.gasPressure = mhd::utils::computeGasPressure(state, magneticX, gamma);
-    #endif  // PRESSURE_DE
+    #endif  // DE
 
   state.totalPressure =
       mhd::utils::computeTotalPressure(state.gasPressure, magneticX, state.magneticY, state.magneticZ);

--- a/src/system_tests/system_tester.h
+++ b/src/system_tests/system_tester.h
@@ -322,24 +322,6 @@ class systemTest::SystemTestRunner
   bool _particleDataExists = false;
 
   /*!
-   * \brief Move a file. Throws an exception if the file does not exist.
-   * or if the move was unsuccessful
-   *
-   * \param[in] sourcePath The path the the file to be moved
-   * \param[in] destinationDirectory The path to the director the file should
-   * be moved to
-   */
-  void _safeMove(std::string const &sourcePath, std::string const &destinationDirectory);
-
-  /*!
-   * \brief Checks if the given file exists. Throws an exception if the
-   * file does not exist.
-   *
-   * \param[in] filePath The path to the file to check for
-   */
-  void _checkFileExists(std::string const &filePath);
-
-  /*!
    * \brief Using GTest assertions to check if the fiducial and test data have
    * the same number of time steps
    *


### PR DESCRIPTION
# Summary

This is a handful of small tweaks and fixes I've been putting off while I worked on debugging MHD. Most are minor but I would like @evaneschneider or @bvillasen to take a look at my change to the grid temperature function. I think there might be other places that should be using MHD energy in computations but I don't know where

## List of Changes

- Have `make tidy` print out where the results are stored. This isn't obvious so now it tells you
- Replace straight sum in `systemTest::SystemTestRunner::runL1ErrorTest` with a Kahan sum to avoid loss of precision.
- Fix a minor bug in hydro restart test
- Replace file manipulation methods in `systemTest::SystemTestRunner` with `std::filesystem` calls