### PR TITLE
Fix missing headers in `chemistry_functions.cpp`

### DIFF
--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -2,6 +2,8 @@
 
   #include "../grid/grid3D.h"
   #include "../io/io.h"
+  #include "../utils/hydro_utilities.h"
+  #include "../utils/mhd_utilities.h"
   #include "chemistry_gpu.h"
   #include "rates.cuh"
 


### PR DESCRIPTION
Fixes issue #281 