### PR TITLE
Improve timers and read_grid_cat restart

### DIFF
--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -426,6 +426,11 @@ Real Grid3D::Update_Grid(void)
   U_floor /= Cosmo.v_0_gas * Cosmo.v_0_gas / Cosmo.current_a / Cosmo.current_a;
 #endif
 
+
+#ifdef CPU_TIME
+  Timer.Hydro_Integrator.Start();
+#endif //CPU_TIME
+
   // Run the hydro integrator on the grid
   if (H.nx > 1 && H.ny == 1 && H.nz == 1)  // 1D
   {
@@ -468,11 +473,24 @@ Real Grid3D::Update_Grid(void)
     chexit(-1);
   }
 
+
+#ifdef CPU_TIME
+  Timer.Hydro_Integrator.End();
+#endif //CPU_TIME
+
+
 #ifdef CUDA
 
   #ifdef COOLING_GPU
+#ifdef CPU_TIME
+  Timer.Cooling_GPU.Start();
+#endif
   // ==Apply Cooling from cooling/cooling_cuda.h==
   Cooling_Update(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_fields, H.dt, gama);
+#ifdef CPU_TIME
+  Timer.Cooling_GPU.End();
+#endif
+
   #endif  // COOLING_GPU
 
   #ifdef DUST
@@ -558,11 +576,11 @@ Real Grid3D::Update_Hydro_Grid()
 
 #ifdef COOLING_GRACKLE
   #ifdef CPU_TIME
-  Timer.Cooling.Start();
+  Timer.Cooling_Grackle.Start();
   #endif  // CPU_TIME
   Do_Cooling_Step_Grackle();
   #ifdef CPU_TIME
-  Timer.Cooling.End();
+  Timer.Cooling_Grackle.End();
   #endif  // CPU_TIME
 #endif    // COOLING_GRACKLE
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -190,7 +190,7 @@ void OutputData(Grid3D &G, struct parameters P, int nfile)
 #elif defined HDF5
   filename += ".h5";
 #else
-  strcat(filename, ".txt");
+  filename += ".txt";
   if (G.H.nx * G.H.ny * G.H.nz > 1000) printf("Ascii outputs only recommended for small problems!\n");
 #endif
 #ifdef MPI_CHOLLA
@@ -240,7 +240,7 @@ void OutputData(Grid3D &G, struct parameters P, int nfile)
 #else
   // open the file for txt writes
   FILE *out;
-  out = fopen(filename, "w");
+  out = fopen(filename.data(), "w");
   if (out == NULL) {
     printf("Error opening output file.\n");
     exit(-1);
@@ -259,6 +259,7 @@ void OutputData(Grid3D &G, struct parameters P, int nfile)
 
 void OutputFloat32(Grid3D &G, struct parameters P, int nfile)
 {
+#ifdef HDF5
   Header H = G.H;
   // Do nothing in 1-D and 2-D case
   if (H.ny_real == 1) {
@@ -278,7 +279,7 @@ void OutputFloat32(Grid3D &G, struct parameters P, int nfile)
   filename += ".float32.h5";
 #ifdef MPI_CHOLLA
   filename += "." + std::to_string(procID);
-#endif
+#endif // MPI_CHOLLA
 
   // create hdf5 file
   hid_t file_id; /* file identifier */
@@ -305,7 +306,7 @@ void OutputFloat32(Grid3D &G, struct parameters P, int nfile)
     buffer_size = (nx_dset + 1) * (ny_dset + 1) * (nz_dset + 1);
 #else
     buffer_size = nx_dset * ny_dset * nz_dset;
-#endif
+#endif // MHD
 
     // Using static DeviceVector here automatically allocates the buffer the
     // first time it is needed It persists until program exit, and then calls
@@ -359,7 +360,7 @@ void OutputFloat32(Grid3D &G, struct parameters P, int nfile)
                        device_dataset_buffer, G.C.d_magnetic_z, "/magnetic_z");
     }
 
-#endif
+#endif // MHD
 
     free(dataset_buffer);
 
@@ -371,6 +372,7 @@ void OutputFloat32(Grid3D &G, struct parameters P, int nfile)
 
   // close the file
   status = H5Fclose(file_id);
+#endif // HDF5
 }
 
 /* Output a projection of the grid data to file. */

--- a/src/io/io_parallel.cpp
+++ b/src/io/io_parallel.cpp
@@ -71,12 +71,18 @@ void Grid3D::Read_Grid_Cat(struct parameters P)
     exit(0);
   }
 
-  // TODO (written by Alwin, for anyone to do) : Need to consider how or whether to read attributes.
-  // even without read gamma from file, it is set in initial_conditions.cpp
-  // if I do not set t or n_step it is set to 0 in grid/grid3D.cpp
-  // This should be okay to start with.
-  // Choosing not to read attributes is because
-  // Parallel-reading attributes can be slow without collective calls.
+  // TODO (written by Alwin, for anyone to do) : 
+  // Consider using collective calls if this part is slow at scale
+  hid_t attribute_id;
+  attribute_id = H5Aopen(file_id, "t", H5P_DEFAULT);
+  status       = H5Aread(attribute_id, H5T_NATIVE_DOUBLE, &H.t);
+  status       = H5Aclose(attribute_id);
+  attribute_id = H5Aopen(file_id, "n_step", H5P_DEFAULT);
+  status       = H5Aread(attribute_id, H5T_NATIVE_INT, &H.n_step);
+  status       = H5Aclose(attribute_id);
+
+
+
 
   // Offsets are global variables from mpi_routines.h
   hsize_t offset[3];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,16 @@ int main(int argc, char *argv[])
       "Parameter values:  nx = %d, ny = %d, nz = %d, tout = %f, init = %s, "
       "boundaries = %d %d %d %d %d %d\n",
       P.nx, P.ny, P.nz, P.tout, P.init, P.xl_bcnd, P.xu_bcnd, P.yl_bcnd, P.yu_bcnd, P.zl_bcnd, P.zu_bcnd);
+
+  bool is_restart = false;
   if (strcmp(P.init, "Read_Grid") == 0) {
+    is_restart = true;
+  }
+  if (strcmp(P.init, "Read_Grid_Cat") == 0) {
+    is_restart = true;
+  }
+
+  if (is_restart) {
     chprintf("Input directory:  %s\n", P.indir);
   }
   chprintf("Output directory:  %s\n", P.outdir);
@@ -107,8 +116,8 @@ int main(int argc, char *argv[])
   chprintf("Setting initial conditions...\n");
   G.Set_Initial_Conditions(P);
   chprintf("Initial conditions set.\n");
-  // set main variables for Read_Grid initial conditions
-  if (strcmp(P.init, "Read_Grid") == 0) {
+  // set main variables for Read_Grid and Read_Grid_Cat initial conditions
+  if (is_restart) {
     outtime += G.H.t;
     nfile = P.nfile;
   }
@@ -192,7 +201,7 @@ int main(int argc, char *argv[])
   chprintf("Nstep = %d  Simulation time = %f\n", G.H.n_step, G.H.t);
 
 #ifdef OUTPUT
-  if (strcmp(P.init, "Read_Grid") != 0 || G.H.Output_Now) {
+  if (!is_restart || G.H.Output_Now) {
     // write the initial conditions to file
     chprintf("Writing initial conditions to file...\n");
     WriteData(G, P, nfile);

--- a/src/utils/timing_functions.cpp
+++ b/src/utils/timing_functions.cpp
@@ -14,6 +14,7 @@
 
 void OneTime::Start()
 {
+  cudaDeviceSynchronize();
   if (inactive) {
     return;
   }
@@ -29,6 +30,7 @@ void OneTime::Subtract(Real time_to_subtract)
 
 void OneTime::End()
 {
+  cudaDeviceSynchronize();
   if (inactive) {
     return;
   }
@@ -96,6 +98,7 @@ void Time::Initialize()
   #ifdef PARTICLES
       &(Calc_dt = OneTime("Calc_dt")),
   #endif
+      &(Hydro_Integrator = OneTime("Hydro_Integrator")),
       &(Hydro = OneTime("Hydro")),
       &(Boundaries = OneTime("Boundaries")),
   #ifdef GRAVITY
@@ -109,8 +112,11 @@ void Time::Initialize()
       &(Advance_Part_1 = OneTime("Advance_Part_1")),
       &(Advance_Part_2 = OneTime("Advance_Part_2")),
   #endif
+  #ifdef COOLING_GPU
+      &(Cooling_GPU = OneTime("Cooling_GPU")),
+  #endif
   #ifdef COOLING_GRACKLE
-      &(Cooling = OneTime("Cooling")),
+      &(Cooling_Grackle = OneTime("Cooling_Grackle")),
   #endif
   #ifdef CHEMISTRY_GPU
       &(Chemistry = OneTime("Chemistry")),

--- a/src/utils/timing_functions.h
+++ b/src/utils/timing_functions.h
@@ -45,6 +45,7 @@ class Time
 
   OneTime Total;
   OneTime Calc_dt;
+  OneTime Hydro_Integrator;
   OneTime Hydro;
   OneTime Boundaries;
   OneTime Grav_Potential;
@@ -54,7 +55,8 @@ class Time
   OneTime Part_Dens_Transf;
   OneTime Advance_Part_1;
   OneTime Advance_Part_2;
-  OneTime Cooling;
+  OneTime Cooling_GPU;
+  OneTime Cooling_Grackle;
   OneTime Chemistry;
   OneTime Feedback;
   OneTime FeedbackAnalysis;


### PR DESCRIPTION
- Make minor fixes so that Cholla compiles without -DOUTPUT and -DHDF5
- Add Hydro Integrator-specific timer. Note that double-counting time is not an issue since the Total is not computed from any sum. 
- Add CudaSynchronize to timers (necessary for Hydro Integrator)
- Make slight improvement to Read_Cat_Grid to avoid overwriting input and to start at the correct nfile. 
- Make slight improvement to Read_Cat_Grid to correctly set some variables which are not strictly necessary but may cause confusion. 