### PR TITLE
Fixed Orszag-Tang Vortex Initial Conditions 

### DIFF
--- a/src/grid/initial_conditions.cpp
+++ b/src/grid/initial_conditions.cpp
@@ -1938,7 +1938,7 @@ void Grid3D::Orszag_Tang_Vortex()
 
         // Z vector potential
         vectorPotential.at(id + 2 * H.n_cells) =
-            magnetic_background / (4.0 * M_PI) * (std::cos(4.0 * M_PI * x) - 2.0 * std::cos(2.0 * M_PI * y));
+            magnetic_background / (4.0 * M_PI) * (std::cos(4.0 * M_PI * x) + 2.0 * std::cos(2.0 * M_PI * y));
       }
     }
   }


### PR DESCRIPTION
The Orszag-Tang Vortex had a sign error in the initial conditions. This fixes that error and updates the test data.