### PR TITLE
Fix MHD Configuration checks

### DIFF
--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -91,7 +91,7 @@ void Check_Configuration(parameters const &P)
   assert(P.nx > 1 and P.ny > 1 and P.nz > 1 and "MHD runs must be 3D");
 
   // Must use the correct integrator
-  #if !defined(VL) || defined(SIMPLE)
+  #if !defined(VL) || defined(SIMPLE) || defined(CTU)
     #error "MHD only supports the Van Leer integrator"
   #endif  //! VL or SIMPLE
 

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -88,7 +88,7 @@ void Check_Configuration(parameters const &P)
 // MHD Checks
 // ==========
 #ifdef MHD
-  assert(P.nx > 1 or P.ny > 1 or P.nz > 1 and "MHD runs must be 3D");
+  assert(P.nx > 1 and P.ny > 1 and P.nz > 1 and "MHD runs must be 3D");
 
   // Must use the correct integrator
   #if !defined(VL) || defined(SIMPLE)


### PR DESCRIPTION
1. There were `or` statements when it should have been `and` in the `Check_Configuration` function.
2. `Check_Configuration` was only checking that the VL integrator was used and the SIMPLE integrator wasn't in MHD builds. Expanded that check to make sure the CTU integrator isn't being used either.