### PR TITLE
Misc. Small Changes for MHD timing

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,7 +37,8 @@ Checks: "*,
 
         google-readability-avoid-underscore-in-googletest-name,
         google-upgrade-googletest-case,
-
+-*,
+readability-braces-around-statements,
         -bugprone-implicit-widening-of-multiplication-result,
         -bugprone-narrowing-conversions,
         -cert-env33-c,
@@ -139,6 +140,7 @@ AnalyzeTemporaryDtors: false
 FormatStyle:     'file'
 UseColor: false
 CheckOptions:
+  readability-braces-around-statements.ShortStatementLines: 1
   # readability-identifier-naming allowed casing types
   # - lower_case
   # - UPPER_CASE

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -106,7 +106,7 @@ void Check_Configuration(parameters const &P)
   #endif  // Reconstruction check
 
   // must have HDF5
-  #ifndef HDF5
+  #if defined(OUTPUT) and (not defined(HDF5))
     #error "MHD only supports HDF5 output"
   #endif  //! HDF5
 

--- a/src/utils/timing_functions.cpp
+++ b/src/utils/timing_functions.cpp
@@ -150,14 +150,15 @@ void Time::Print_Average_Times(struct parameters P)
   }
 
   std::string file_name("run_timing.log");
-  std::string header;
 
   chprintf("Writing timing values to file: %s  \n", file_name.c_str());
 
-  std::string gitHash    = "Git Commit Hash = " + std::string(GIT_HASH) + std::string("\n");
-  std::string macroFlags = "Macro Flags     = " + std::string(MACRO_FLAGS) + std::string("\n\n");
+  std::string header = "Git Commit Hash = " + std::string(GIT_HASH) + std::string("\n");
+  header += "Macro Flags     = " + std::string(MACRO_FLAGS) + std::string("\n");
+  header += "Note that the timers all skip the first time step since it always takes longer." + std::string("\n") +
+            "To find the average time divide the time shown by n_steps-1" + std::string("\n");
 
-  header = "#n_proc  nx  ny  nz  n_omp  n_steps  ";
+  header += std::string("\n") + "#n_proc  nx  ny  nz  n_omp  n_steps  ";
 
   for (OneTime* x : onetimes) {
     header += x->name;
@@ -186,8 +187,6 @@ void Time::Print_Average_Times(struct parameters P)
   // Output timing values
   out_file.open(file_name.c_str(), std::ios::app);
   if (!file_exists) {
-    out_file << gitHash;
-    out_file << macroFlags;
     out_file << header;
   }
   #ifdef MPI_CHOLLA


### PR DESCRIPTION
- Allow MHD to build with the `OUTPUT` and `HDF5` flags absent
- Permit single line if statements without braces in clang-tidy
- Minor refactor of the `Time::Print_Average_Times` to make future changes to the header easier
- Add a note about the reduced range of the timers to `run_timing.log`