### PR TITLE
Fix clang-tidy config error that disabled almost all checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,8 +37,7 @@ Checks: "*,
 
         google-readability-avoid-underscore-in-googletest-name,
         google-upgrade-googletest-case,
--*,
-readability-braces-around-statements,
+
         -bugprone-implicit-widening-of-multiplication-result,
         -bugprone-narrowing-conversions,
         -cert-env33-c,


### PR DESCRIPTION
I accidentally committed a test setup that I use that disabled almost all checks. This PR fixes it. Once this is merged then all PRs should be updated and rerun through the CI pipeline to make sure nothing was missed.