### PR TITLE
Introduce new ``ERROR`` and ``ASSERT`` macros

### DIFF
--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -34,7 +34,7 @@ void Set_Gammas(Real gamma_in)
 {
   // set gamma
   gama = gamma_in;
-  ASSERT(gama > 1.0, "Gamma must be greater than one.");
+  CHOLLA_ASSERT(gama > 1.0, "Gamma must be greater than one.");
 }
 
 /*! \fn double get_time(void)

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -12,7 +12,8 @@
 
 #include <set>
 
-#include "../io/io.h"  //defines chprintf
+#include "../io/io.h"                 //defines chprintf
+#include "../utils/error_handling.h"  // defines ASSERT
 
 /* Global variables */
 Real gama;   // Ratio of specific heats
@@ -33,6 +34,7 @@ void Set_Gammas(Real gamma_in)
 {
   // set gamma
   gama = gamma_in;
+  ASSERT(gama > 1.0, "Set_Gammas", "Gamma must be greater than one.");
 }
 
 /*! \fn double get_time(void)

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -34,7 +34,7 @@ void Set_Gammas(Real gamma_in)
 {
   // set gamma
   gama = gamma_in;
-  ASSERT(gama > 1.0, "Set_Gammas", "Gamma must be greater than one.");
+  ASSERT(gama > 1.0, "Gamma must be greater than one.");
 }
 
 /*! \fn double get_time(void)

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -2788,10 +2788,10 @@ void Ensure_Outdir_Exists(std::string outdir)
       // to a directory (it's unclear from docs whether err-code is set in that
       // case)
       if (err_code or not std::filesystem::is_directory(without_file_prefix)) {
-        ERROR("Ensure_Outdir_Exists",
-              "something went wrong while trying to create the path to the "
-              "output-dir: %s",
-              outdir.c_str());
+        ERROR(
+            "something went wrong while trying to create the path to the "
+            "output-dir: %s",
+            outdir.c_str());
       }
     }
   }

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -2788,7 +2788,7 @@ void Ensure_Outdir_Exists(std::string outdir)
       // to a directory (it's unclear from docs whether err-code is set in that
       // case)
       if (err_code or not std::filesystem::is_directory(without_file_prefix)) {
-        ERROR(
+        CHOLLA_ERROR(
             "something went wrong while trying to create the path to the "
             "output-dir: %s",
             outdir.c_str());

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -2788,11 +2788,10 @@ void Ensure_Outdir_Exists(std::string outdir)
       // to a directory (it's unclear from docs whether err-code is set in that
       // case)
       if (err_code or not std::filesystem::is_directory(without_file_prefix)) {
-        chprintf(
-            "something went wrong while trying to create the path to the "
-            "output-dir: %s\n",
-            outdir.c_str());
-        chexit(1);
+        ERROR("Ensure_Outdir_Exists",
+              "something went wrong while trying to create the path to the "
+              "output-dir: %s",
+              outdir.c_str());
       }
     }
   }

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -61,11 +61,10 @@ void Check_Configuration(parameters const& P)
   // Check the boundary conditions
   auto Check_Boundary = [](int const& boundary, std::string const& direction) {
     bool is_allowed_bc = boundary >= 0 and boundary <= 4;
-    std::string const error_message =
-        "WARNING: Possibly invalid boundary conditions for direction: " + direction +
-        " flag: " + std::to_string(boundary) +
-        ". Must select between 0 (no boundary), 1 (periodic), 2 (reflective), 3 (transmissive), 4 (custom), 5 (mpi).";
-    assert(is_allowed_bc && error_message.c_str());
+    ASSERT(is_allowed_bc, "Check_Configuration",
+           "WARNING: Possibly invalid boundary conditions for direction: %s flag: %d. "
+           "Must select between 0 (no boundary), 1 (periodic), 2 (reflective), 3 (transmissive), 4 (custom), 5 (mpi).",
+           direction.c_str(), boundary);
   };
   Check_Boundary(P.xl_bcnd, "xl_bcnd");
   Check_Boundary(P.xu_bcnd, "xu_bcnd");
@@ -84,9 +83,6 @@ void Check_Configuration(parameters const& P)
   #error "The PRECISION macro is required"
 #endif  //! PRECISION
   static_assert(PRECISION == 2, "PRECISION must be 2. Single precision is not currently supported");
-
-  // Check that gamma, the ratio of specific heats, is greater than 1
-  assert(::gama <= 1.0 and "Gamma must be greater than one.");
 
 // MHD Checks
 // ==========

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -61,7 +61,7 @@ void Check_Configuration(parameters const& P)
   // Check the boundary conditions
   auto Check_Boundary = [](int const& boundary, std::string const& direction) {
     bool is_allowed_bc = boundary >= 0 and boundary <= 4;
-    ASSERT(is_allowed_bc, "Check_Configuration",
+    ASSERT(is_allowed_bc,
            "WARNING: Possibly invalid boundary conditions for direction: %s flag: %d. "
            "Must select between 0 (no boundary), 1 (periodic), 2 (reflective), 3 (transmissive), 4 (custom), 5 (mpi).",
            direction.c_str(), boundary);

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -60,10 +60,11 @@ void Check_Configuration(parameters const& P)
   // Check the boundary conditions
   auto Check_Boundary = [](int const& boundary, std::string const& direction) {
     bool is_allowed_bc = boundary >= 0 and boundary <= 4;
-    ASSERT(is_allowed_bc,
-           "WARNING: Possibly invalid boundary conditions for direction: %s flag: %d. "
-           "Must select between 0 (no boundary), 1 (periodic), 2 (reflective), 3 (transmissive), 4 (custom), 5 (mpi).",
-           direction.c_str(), boundary);
+    CHOLLA_ASSERT(is_allowed_bc,
+                  "WARNING: Possibly invalid boundary conditions for direction: %s flag: %d. Must "
+                  "select between 0 (no boundary), 1 (periodic), 2 (reflective), 3 (transmissive), "
+                  "4 (custom), 5 (mpi).",
+                  direction.c_str(), boundary);
   };
   Check_Boundary(P.xl_bcnd, "xl_bcnd");
   Check_Boundary(P.xu_bcnd, "xu_bcnd");

--- a/src/utils/error_handling.h
+++ b/src/utils/error_handling.h
@@ -3,12 +3,57 @@
 #include <stdlib.h>
 
 #include "../global/global.h"
-void chexit(int code);
+[[noreturn]] void chexit(int code);
 
 /*!
  * \brief Check that the Cholla configuration and parameters don't have any significant errors. Mostly compile time
  * checks.
  *
  */
-void Check_Configuration(parameters const &P);
+void Check_Configuration(parameters const& P);
+
+/*!
+ * \brief helper function that prints an error message & aborts the program (in
+ * an MPI-safe way). Commonly invoked through a macro.
+ *
+ */
+[[noreturn]] void Abort_With_Err_(const char* func_name, const char* file_name, int line_num, const char* msg, ...);
+
+/*!
+ * \brief print an error-message (with printf formatting) & abort the program.
+ *
+ * This macro should be treated as a function with the signature:
+ *   [[noreturn]] void ERROR(const char* func_name, const char* msg, ...);
+ *
+ * - The 1st arg is the name of the function where it's called
+ * - The 2nd arg is printf-style format argument specifying the error message
+ * - The remaining args arguments are used to format error message
+ *
+ * \note
+ * the ``msg`` string is part of the variadic args so that there is always
+ * at least 1 variadic argument (even in cases when ``msg`` doesn't format
+ * any arguments). There is no way around this until C++ 20.
+ */
+#define ERROR(func_name, ...) Abort_With_Err_(func_name, __FILE__, __LINE__, __VA_ARGS__)
+
+/*!
+ * \brief if the condition is false, print an error-message (with printf
+ * formatting) & abort the program.
+ *
+ * This macro should be treated as a function with the signature:
+ *   [[noreturn]] void ASSERT(bool cond, const char* func_name, const char* msg, ...);
+ *
+ * - The 1st arg is a boolean condition. When true, this does noth
+ * - The 2nd arg is the name of the function where it's called
+ * - The 3rd arg is printf-style format argument specifying the error message
+ * - The remaining args arguments are used to format error message
+ *
+ * \note
+ * the behavior is independent of the ``NDEBUG`` macro
+ */
+#define ASSERT(cond, func_name, ...)                             \
+  if (not(cond)) {                                               \
+    Abort_With_Err_(func_name, __FILE__, __LINE__, __VA_ARGS__); \
+  }
+
 #endif /*ERROR_HANDLING_CHOLLA_H*/

--- a/src/utils/error_handling.h
+++ b/src/utils/error_handling.h
@@ -19,14 +19,27 @@ void Check_Configuration(parameters const& P);
  */
 [[noreturn]] void Abort_With_Err_(const char* func_name, const char* file_name, int line_num, const char* msg, ...);
 
+/* __CHOLLA_PRETTY_FUNC__ is a magic constant like __LINE__ or __FILE__ that
+ * provides the name of the current function.
+ * - The C++11 standard requires that __func__ is provided on all platforms, but
+ *   that only provides limited information (just the name of the function).
+ * - Where available, we prefer to use compiler-specific features that provide
+ *   more information about the function (like the scope of the function & the
+ *   the function signature).
+ */
+#ifdef __GNUG__
+  #define __CHOLLA_PRETTY_FUNC__ __PRETTY_FUNCTION__
+#else
+  #define __CHOLLA_PRETTY_FUNC__ __func__
+#endif
+
 /*!
  * \brief print an error-message (with printf formatting) & abort the program.
  *
  * This macro should be treated as a function with the signature:
- *   [[noreturn]] void ERROR(const char* func_name, const char* msg, ...);
+ *   [[noreturn]] void ERROR(const char* msg, ...);
  *
- * - The 1st arg is the name of the function where it's called
- * - The 2nd arg is printf-style format argument specifying the error message
+ * - The 1st arg is printf-style format argument specifying the error message
  * - The remaining args arguments are used to format error message
  *
  * \note
@@ -34,26 +47,25 @@ void Check_Configuration(parameters const& P);
  * at least 1 variadic argument (even in cases when ``msg`` doesn't format
  * any arguments). There is no way around this until C++ 20.
  */
-#define ERROR(func_name, ...) Abort_With_Err_(func_name, __FILE__, __LINE__, __VA_ARGS__)
+#define ERROR(...) Abort_With_Err_(__CHOLLA_PRETTY_FUNC__, __FILE__, __LINE__, __VA_ARGS__)
 
 /*!
  * \brief if the condition is false, print an error-message (with printf
  * formatting) & abort the program.
  *
  * This macro should be treated as a function with the signature:
- *   [[noreturn]] void ASSERT(bool cond, const char* func_name, const char* msg, ...);
+ *   [[noreturn]] void ASSERT(bool cond, const char* msg, ...);
  *
  * - The 1st arg is a boolean condition. When true, this does noth
- * - The 2nd arg is the name of the function where it's called
- * - The 3rd arg is printf-style format argument specifying the error message
+ * - The 2nd arg is printf-style format argument specifying the error message
  * - The remaining args arguments are used to format error message
  *
  * \note
  * the behavior is independent of the ``NDEBUG`` macro
  */
-#define ASSERT(cond, func_name, ...)                             \
-  if (not(cond)) {                                               \
-    Abort_With_Err_(func_name, __FILE__, __LINE__, __VA_ARGS__); \
+#define ASSERT(cond, ...)                                                     \
+  if (not(cond)) {                                                            \
+    Abort_With_Err_(__CHOLLA_PRETTY_FUNC__, __FILE__, __LINE__, __VA_ARGS__); \
   }
 
 #endif /*ERROR_HANDLING_CHOLLA_H*/

--- a/src/utils/error_handling.h
+++ b/src/utils/error_handling.h
@@ -37,7 +37,7 @@ void Check_Configuration(parameters const& P);
  * \brief print an error-message (with printf formatting) & abort the program.
  *
  * This macro should be treated as a function with the signature:
- *   [[noreturn]] void ERROR(const char* msg, ...);
+ *   [[noreturn]] void CHOLLA_ERROR(const char* msg, ...);
  *
  * - The 1st arg is printf-style format argument specifying the error message
  * - The remaining args arguments are used to format error message
@@ -47,14 +47,14 @@ void Check_Configuration(parameters const& P);
  * at least 1 variadic argument (even in cases when ``msg`` doesn't format
  * any arguments). There is no way around this until C++ 20.
  */
-#define ERROR(...) Abort_With_Err_(__CHOLLA_PRETTY_FUNC__, __FILE__, __LINE__, __VA_ARGS__)
+#define CHOLLA_ERROR(...) Abort_With_Err_(__CHOLLA_PRETTY_FUNC__, __FILE__, __LINE__, __VA_ARGS__)
 
 /*!
  * \brief if the condition is false, print an error-message (with printf
  * formatting) & abort the program.
  *
  * This macro should be treated as a function with the signature:
- *   [[noreturn]] void ASSERT(bool cond, const char* msg, ...);
+ *   [[noreturn]] void CHOLLA_ASSERT(bool cond, const char* msg, ...);
  *
  * - The 1st arg is a boolean condition. When true, this does noth
  * - The 2nd arg is printf-style format argument specifying the error message
@@ -63,7 +63,7 @@ void Check_Configuration(parameters const& P);
  * \note
  * the behavior is independent of the ``NDEBUG`` macro
  */
-#define ASSERT(cond, ...)                                                     \
+#define CHOLLA_ASSERT(cond, ...)                                              \
   if (not(cond)) {                                                            \
     Abort_With_Err_(__CHOLLA_PRETTY_FUNC__, __FILE__, __LINE__, __VA_ARGS__); \
   }


### PR DESCRIPTION
This PR primarily introduces new ``ERROR`` and ``ASSERT`` macros to simplify the process of reporting errors/aborting.

(I kind of forged ahead with this before asking - I'm happy to drop this if the reviewers dislike it)

### A brief note about ``[[noreturn]]``

I've annotated ``chexit`` (and another function introduced  in this PR) with the ``[[noreturn]]``. Just in case you're unaware of what this means, this is the portable way to introduce "attributes" to functions that was introduced in C++ 11. Furthermore, [noreturn](https://en.cppreference.com/w/cpp/language/attributes/noreturn) is the name of an attribute (also introduced in C++11) that informs the compiler that the annotated function never returns.

This annotation helps avoid compiler warnings about functions not-returning a result in a function like the hypothetical one shown in the following spoiler tag:

<details>
  <summary>Contrived example function</summary>

```c++
std::string get_boundary_name(int type) {
  if (type == 0) {
    return "no boundary";
  } else if (type == 1) {
    return "periodic";
  } else if (type == 2) {
    return "reflective";
  } else if (type == 3) {
    return "transmissive";
  } else if (type == 4) {
    return "custom";
  } else if (type == 5) {
    return "mpi";
  } else {
    chprintf("encountered an unknown boundary type: %d\n", type);
    chexit(-1);
  }
}
```

</details>

### About ``ERROR`` and ``ABORT``

- these were inspired by similarly named macros from Enzo-E that I've always found to be incredibly useful! (I implemented these from scratch and actually improved the interface).
- These macros should be treated as functions. ``ERROR`` cause the program to print an error to ``stderr``, with some extra meta-data (e.g. process number, file-name and location where it was called). ``ASSERT`` checks a boolean condition, and if that condition evaluates to ``false`` it is equivalent to evaluating ``ERROR``.
- They effectively have the following signatures
    ```c++
    [[noreturn]] void ERROR(const char* msg, ...);
    [[noreturn]] void ASSERT(bool cond, const char* msg, ...);
    ```
    where:
    - ``msg`` is the error-msg that will be printed. 
    - when ``msg`` is specified with printf-style formatting, the remaining arguments are used to specify the output.
    - ``cond`` is the condition that is to be checked by the assertion statement. ``ASSERT`` only produces the program
- ``ASSERT`` and ``ERROR`` are defined as macros rather than as functions so that they can automatically print the function-name, file-name, and line number where the error occurred. Under the hood they call a newly-defined function called ``Abort_With_Err_``.

Potential future improvements:

- In the original Enzo-E version, a backtrace is also printed out when an error is raised in this fashion. This is definitely something we can add in the future (we would need to use an ifdef statement to check whether we are using glibc), but at this moment, it's a little unclear how useful that would be.
- We can print out the failed assertion statement in ``ASSERT`` (like what is done in the standard library's ``assert`` macro).

### Bugfix: moved value-check of ``::gama``

To test out the new macros, I replaced a few snippets of existing code to make use of ``ERROR`` or ``ASSERT`` (and then intentionally passed parameters to make the code fail). 

One of the places where I did this was in ``Check_Configuration``, where the value of ``::gama`` got checked. 
- When I did this, I realized that logic in the old version of the check was wrong. It caused the code to abort when ``gama > 1`` - the error message said that code was failing because `gama` was less than or equal to 1. 
- When I corrected the code, the code started to crash
- It turns out that this check was happening before ``::gama`` was being initialized from the ``P.gamma`` (i.e. it had a value of `0`).
- To fix this, I moved this check of the value of ``::gama`` into ``Set_Gammas`` - the function where ``::gama`` is initialized.
