### PR TITLE
Add script to run clang-tidy on all builds

### DIFF
--- a/tools/cholla-nv-compute-sanitizer.sh
+++ b/tools/cholla-nv-compute-sanitizer.sh
@@ -83,7 +83,7 @@ if [ -z "$tool" ]; then
 fi
 
 # Get Paths
-cholla_root=$(git rev-parse --show-toplevel)
+cholla_root="$(dirname "$(dirname "$(readlink -fm "$0")")")"
 cholla_exe=$(find "${cholla_root}" -name cholla.*)
 cholla_parameter_file="${cholla_root}/examples/3D/sod.txt"
 COMPUTE_SANITIZER=$(which compute-sanitizer)

--- a/tools/clang-format_runner.sh
+++ b/tools/clang-format_runner.sh
@@ -9,7 +9,8 @@
 # - GNU Find, the default macos version won't work
 
 # Get the location of Cholla
-cholla_root=$(git rev-parse --show-toplevel)
+cholla_root="$(dirname "$(dirname "$(readlink -fm "$0")")")"
+cd $cholla_root
 
 # Get a list of all the files to format
 readarray -t files <<<$(find ${cholla_root} -regex '.*\.\(h\|hpp\|c\|cpp\|cu\|cuh\)$' -print)

--- a/tools/clang-tidy_runner.sh
+++ b/tools/clang-tidy_runner.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Description:
+# Run clang-tidy on all build types in parallel. Note that this spawns 2x the
+# number of build types threads since each type has a thread for the CPU code
+# and a thread for the GPU code
+
+# If ctrl-c is sent trap it and kill all clang-tidy processes
+trap "kill -- -$$" EXIT
+
+# cd into the Cholla directory. Default to ${HOME}/Code/cholla
+cholla_root="$(dirname "$(dirname "$(readlink -fm "$0")")")"
+cd $cholla_root
+
+# Run all clang-tidy build types in parallel
+builds=( hydro gravity disk particles cosmology mhd dust)
+for build in "${builds[@]}"
+do
+  make tidy TYPE=$build &
+done
+
+# Wait for clang-tidy to finish
+wait


### PR DESCRIPTION
`tools/clang-tidy_runner.sh` will run clang-tidy on all builds in parallel.

Other scripts in the tools directory got an updated method of determining the cholla directory that works if invoked from outside the directory.