### PR TITLE
Method to Identify Slow GPUs + Output bugfix

### DIFF
--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -469,7 +469,7 @@ Real Grid3D::Update_Grid(void)
   }
 
 #ifdef CPU_TIME
-  Timer.Hydro_Integrator.End();
+  Timer.Hydro_Integrator.End(true);
 #endif  // CPU_TIME
 
 #ifdef CUDA

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,7 +354,9 @@ int main(int argc, char *argv[])
 #ifdef N_STEPS_LIMIT
     // Exit the loop when reached the limit number of steps (optional)
     if (G.H.n_step == N_STEPS_LIMIT) {
+  #ifdef OUTPUT
       WriteData(G, P, nfile);
+  #endif  // OUTPUT
       break;
     }
 #endif

--- a/src/utils/gpu.hpp
+++ b/src/utils/gpu.hpp
@@ -67,6 +67,7 @@ static constexpr int maxWarpsPerBlock = 1024 / WARPSIZE;
   #define cudaPointerGetAttributes           hipPointerGetAttributes
   #define cudaOccupancyMaxPotentialBlockSize hipOccupancyMaxPotentialBlockSize
   #define cudaMemGetInfo                     hipMemGetInfo
+  #define cudaDeviceGetPCIBusId              hipDeviceGetPCIBusId
 
   // Texture definitions
   #define cudaArray           hipArray

--- a/src/utils/timing_functions.cpp
+++ b/src/utils/timing_functions.cpp
@@ -55,7 +55,7 @@ void OneTime::End(bool const print_high_values)
 
   #ifdef MPI_CHOLLA
   // Print out information if the process is unusually slow
-  if (time >= 1.1 * t_avg and print_high_values) {
+  if ((time >= 1.1 * t_avg) and (n_steps > 0) and print_high_values) {
     // Get node ID
     std::string node_id(MPI_MAX_PROCESSOR_NAME, ' ');
     int length;
@@ -72,6 +72,8 @@ void OneTime::End(bool const print_high_values)
         gpu_id.end());
 
     std::cerr << "WARNING: Rank took longer than expected to execute." << std::endl
+              << "         Node Time: " << time << std::endl
+              << "         Avg Time: " << t_avg << std::endl
               << "         Node ID: " << node_id << std::endl
               << "         GPU PCI Bus ID: " << gpu_id << std::endl;
   }

--- a/src/utils/timing_functions.h
+++ b/src/utils/timing_functions.h
@@ -28,7 +28,7 @@ class OneTime
   }
   void Start();
   void Subtract(Real time_to_subtract);
-  void End();
+  void End(bool const print_high_values = false);
   void PrintStep();
   void PrintAverage();
   void PrintAll();


### PR DESCRIPTION
## Identifying Slow GPUs

Added a section to `OneTime::end()` that checks if the rank took more than 10% longer than average. If it did then it prints the node ID and GPU PCIe Bus ID to std::cerr. This is not enabled for all timers by default and enabling it requires passing the proper argument to `OneTime::end()`; it's currently enabled only for the `Hydro_Integrator` timer

This should let us figure out if the weird performance issues on Frontier are Cholla or a small number of slow GPUs.

## Output Bugfix

If a maximum number of timesteps was set with `N_STEPS_LIMIT` then the final time step would still output even if the `OUTPUT` macro was not provided. Added ifdef statement to fix this.