### PR TITLE
Fix issue 301

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,8 +345,9 @@ int main(int argc, char *argv[])
       // add one to the output file count
       nfile++;
 #endif  // OUTPUT
-      // update to the next output time
-      outtime += P.outstep;
+      if (G.H.t == outtime) {
+        outtime += P.outstep;  // update to the next output time
+      }
     }
 
 #ifdef CPU_TIME

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -252,8 +252,10 @@ int main(int argc, char *argv[])
     // calculate the timestep by calling MPI_Allreduce
     G.set_dt(dti);
 
-    if (G.H.t + G.H.dt > outtime) {
-      G.H.dt = outtime - G.H.t;
+    // adjust timestep based on the next available scheduled time
+    const Real next_scheduled_time = fmin(outtime, P.tout);
+    if (G.H.t + G.H.dt > next_scheduled_time) {
+      G.H.dt = next_scheduled_time - G.H.t;
     }
 
 #if defined(SUPERNOVA) && defined(PARTICLE_AGE)


### PR DESCRIPTION
I adjusted logic for clamping the timestep
- Previously, ``main`` would only clamp the next timestep based on when the time that the next output was scheduled for (this was based on incrementing ``outtime`` with ``outstep``). This produced some weird behavior when the ``OUTPUT_ALWAYS`` macro is defined. As documented in issue https://github.com/cholla-hydro/cholla/issues/301, when that macro is enabled the simulation would write the final output slightly after ``tout``.
- Now, timesteps are adjusted so that the simulation after the current timestep does not exceed the next output-time or ``tout``

I also adjusted the logic for incrementing `outtime` (which tracks the next simulation time when output is written). This change ensures that the simulation will take the same timesteps whether or not ``OUTPUT_ALWAYS`` is enabled. (Previously, when the code was compiled with ``OUTPUT_ALWAYS`` it might skip the timesteps that were based on the value of the ``outstep`` parameter)