### PR TITLE
Restart Tests in Jenkins Pipeline if they Fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,12 +73,15 @@ pipeline
                     {
                         steps
                         {
-                            sh  '''
-                                source builds/run_tests.sh
-                                setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
+                            retry(2)
+                            {
+                                sh  '''
+                                    source builds/run_tests.sh
+                                    setupTests -c gcc -t ${CHOLLA_MAKE_TYPE}
 
-                                runTests
-                                '''
+                                    runTests
+                                    '''
+                            }
                         }
                     }
                     stage('Run Clang Tidy')


### PR DESCRIPTION
~Work in progress. I just need this up so that I can actually test it~

It's ready now. If any of the tests fail they should retry once and I've already witnessed that working. The Jenkins docs are a little unclear about the meaning of the argument to the `retry` command so it might be set to retry twice instead of once, if we see that behavior we can just lower that argument to 1.