### PR TITLE
Patch to fix logic of floor warning messages

### DIFF
--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -185,27 +185,27 @@ void Parse_Params(char *param_file, struct Parameters *parms, int argc, char **a
     Parse_Param(name, value, parms);
     chprintf("Override with %s=%s\n", name, value);
   }
-  #ifdef TEMPERATURE_FLOOR
+#ifdef TEMPERATURE_FLOOR
   if (parms->temperature_floor == 0) {
     chprintf(
         "WARNING: temperature floor is set to its default value (zero)! It can be set to a different value in the "
         "input parameter file.\n");
   }
-  #endif
-  #ifdef DENSITY_FLOOR
+#endif
+#ifdef DENSITY_FLOOR
   if (parms->density_floor == 0) {
     chprintf(
         "WARNING: density floor is set to its default value (zero)! It can be set to a different value in the input "
         "parameter file.\n");
   }
-  #endif
-  #ifdef SCALAR_FLOOR
+#endif
+#ifdef SCALAR_FLOOR
   if (parms->scalar_floor == 0) {
     chprintf(
         "WARNING: scalar floor is set to its default value (zero)! It can be set to a different value in the input "
         "parameter file.\n");
   }
-  #endif
+#endif
 }
 
 /*! \fn void Parse_Param(char *name,char *value, struct Parameters *parms);

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -185,6 +185,27 @@ void Parse_Params(char *param_file, struct Parameters *parms, int argc, char **a
     Parse_Param(name, value, parms);
     chprintf("Override with %s=%s\n", name, value);
   }
+  #ifdef TEMPERATURE_FLOOR
+  if (parms->temperature_floor == 0) {
+    chprintf(
+        "WARNING: temperature floor is set to its default value (zero)! It can be set to a different value in the "
+        "input parameter file.\n");
+  }
+  #endif
+  #ifdef DENSITY_FLOOR
+  if (parms->density_floor == 0) {
+    chprintf(
+        "WARNING: density floor is set to its default value (zero)! It can be set to a different value in the input "
+        "parameter file.\n");
+  }
+  #endif
+  #ifdef SCALAR_FLOOR
+  if (parms->scalar_floor == 0) {
+    chprintf(
+        "WARNING: scalar floor is set to its default value (zero)! It can be set to a different value in the input "
+        "parameter file.\n");
+  }
+  #endif
 }
 
 /*! \fn void Parse_Param(char *name,char *value, struct Parameters *parms);
@@ -443,29 +464,14 @@ void Parse_Param(char *name, char *value, struct Parameters *parms)
 #ifdef TEMPERATURE_FLOOR
   } else if (strcmp(name, "temperature_floor") == 0) {
     parms->temperature_floor = atof(value);
-    if (parms->temperature_floor == 0) {
-      chprintf(
-          "WARNING: temperature floor is set to its default value (zero)! It can be set to a different value in the "
-          "input parameter file.\n");
-    }
 #endif
 #ifdef DENSITY_FLOOR
   } else if (strcmp(name, "density_floor") == 0) {
     parms->density_floor = atof(value);
-    if (parms->density_floor == 0) {
-      chprintf(
-          "WARNING: density floor is set to its default value (zero)! It can be set to a different value in the input "
-          "parameter file.\n");
-    }
 #endif
 #ifdef SCALAR_FLOOR
   } else if (strcmp(name, "scalar_floor") == 0) {
     parms->scalar_floor = atof(value);
-    if (parms->scalar_floor == 0) {
-      chprintf(
-          "WARNING: scalar floor is set to its default value (zero)! It can be set to a different value in the input "
-          "parameter file.\n");
-    }
 #endif
 #ifdef ANALYSIS
   } else if (strcmp(name, "analysis_scale_outputs_file") == 0) {


### PR DESCRIPTION
As raised in Issue #372, the previous version of the warning messages for the temperature, density, and scalar floors only worked when the `temperature_floor`, `density_floor`, and `scalar_floor` parameters were set in the input parameter file. The intended behavior is for them to be thrown when the parameters are _not_ set or are set to zero by checking whether their values in the header are zero (the default value). I moved the check and error messages outside of `Parse_Param` after it is called. Otherwise, the warning is thrown multiple times as `Parse_Param` loops over the other parameters. Let me know if it looks okay.

Thanks @brantr for catching this!