### PR TITLE
Reconstruction Kernel Fusion 2: New Loading and Conversion Utility Functions

### DIFF
--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -104,7 +104,7 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      gama, 0, n_fields);
   #endif
   #ifdef PPMC
-  hipLaunchKernelGGL(PPMC_VL, dimGrid, dimBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama, 0);
+  hipLaunchKernelGGL(PPMC_VL<0>, dimGrid, dimBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama);
   #endif
   GPU_Error_Check();
 

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -92,7 +92,7 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      n_fields);
   #endif
   #ifdef PLMC
-  hipLaunchKernelGGL(PLMC_cuda, dimGrid, dimBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0,
+  hipLaunchKernelGGL(PLMC_cuda<0>, dimGrid, dimBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama,
                      n_fields);
   #endif
   #ifdef PLMP

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -114,8 +114,8 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      dt, gama, 1, n_fields);
   #endif  // PPMP
   #ifdef PPMC
-  hipLaunchKernelGGL(PPMC_VL, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama, 0);
-  hipLaunchKernelGGL(PPMC_VL, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama, 1);
+  hipLaunchKernelGGL(PPMC_VL<0>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<1>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama);
   #endif  // PPMC
   GPU_Error_Check();
 

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -102,10 +102,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      dt, gama, 1, n_fields);
   #endif
   #ifdef PLMC
-  hipLaunchKernelGGL(PLMC_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama,
-                     1, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<0>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt,
+                     gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<1>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt,
+                     gama, n_fields);
   #endif
   #ifdef PPMP
   hipLaunchKernelGGL(PPMP_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, n_ghost, dx,

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -250,12 +250,12 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   #endif  // PLMP
   #ifdef PLMC
   cuda_utilities::AutomaticLaunchParams static const plmc_vl_launch_params(PLMC_cuda<0>, n_cells);
-  hipLaunchKernelGGL(PLMC_cuda<0>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, n_fields);
-  hipLaunchKernelGGL(PLMC_cuda<1>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, n_fields);
-  hipLaunchKernelGGL(PLMC_cuda<2>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<0>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(),
+                     0, 0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<1>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(),
+                     0, 0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<2>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(),
+                     0, 0, dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, n_fields);
   #endif  // PLMC
   #ifdef PPMP
   cuda_utilities::AutomaticLaunchParams static const ppmp_launch_params(PPMP_cuda, n_cells);
@@ -268,12 +268,12 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   #endif  // PPMP
   #ifdef PPMC
   cuda_utilities::AutomaticLaunchParams static const ppmc_vl_launch_params(PPMC_VL<0>, n_cells);
-  hipLaunchKernelGGL(PPMC_VL<0>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama);
-  hipLaunchKernelGGL(PPMC_VL<1>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama);
-  hipLaunchKernelGGL(PPMC_VL<2>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<0>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<1>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<2>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, gama);
   #endif  // PPMC
   GPU_Error_Check();
 

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -249,13 +249,13 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, n_ghost, dz, dt, gama, 2, n_fields);
   #endif  // PLMP
   #ifdef PLMC
-  cuda_utilities::AutomaticLaunchParams static const plmc_vl_launch_params(PLMC_cuda, n_cells);
-  hipLaunchKernelGGL(PLMC_cuda, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0, n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, 1, n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
-                     0, dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, 2, n_fields);
+  cuda_utilities::AutomaticLaunchParams static const plmc_vl_launch_params(PLMC_cuda<0>, n_cells);
+  hipLaunchKernelGGL(PLMC_cuda<0>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<1>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, n_fields);
+  hipLaunchKernelGGL(PLMC_cuda<2>, plmc_vl_launch_params.get_numBlocks(), plmc_vl_launch_params.get_threadsPerBlock(), 0,
+                     0, dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, n_fields);
   #endif  // PLMC
   #ifdef PPMP
   cuda_utilities::AutomaticLaunchParams static const ppmp_launch_params(PPMP_cuda, n_cells);

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -145,8 +145,7 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
   // Step 2: Calculate first-order upwind fluxes
   #ifdef EXACT
-  cuda_utilities::AutomaticLaunchParams static const exact_launch_params(Calculate_Exact_Fluxes_CUDA,
-                                                                         n_cellsCalculate_Exact_Fluxes_CUDA);
+  cuda_utilities::AutomaticLaunchParams static const exact_launch_params(Calculate_Exact_Fluxes_CUDA, n_cells);
   hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
                      exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
                      n_fields);

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -267,13 +267,13 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, n_ghost, dz, dt, gama, 2, n_fields);
   #endif  // PPMP
   #ifdef PPMC
-  cuda_utilities::AutomaticLaunchParams static const ppmc_vl_launch_params(PPMC_VL, n_cells);
-  hipLaunchKernelGGL(PPMC_VL, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama, 0);
-  hipLaunchKernelGGL(PPMC_VL, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama, 1);
-  hipLaunchKernelGGL(PPMC_VL, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, gama, 2);
+  cuda_utilities::AutomaticLaunchParams static const ppmc_vl_launch_params(PPMC_VL<0>, n_cells);
+  hipLaunchKernelGGL(PPMC_VL<0>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lx, Q_Rx, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<1>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Ly, Q_Ry, nx, ny, nz, gama);
+  hipLaunchKernelGGL(PPMC_VL<2>, ppmc_vl_launch_params.get_numBlocks(), ppmc_vl_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lz, Q_Rz, nx, ny, nz, gama);
   #endif  // PPMC
   GPU_Error_Check();
 

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -74,7 +74,7 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
   GPU_Error_Check();
 #endif
 #ifdef PPMC
-  hipLaunchKernelGGL(PPMC_CTU, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0);
+  hipLaunchKernelGGL(PPMC_CTU<0>, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama);
   GPU_Error_Check();
 #endif
 

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -64,7 +64,7 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
   GPU_Error_Check();
 #endif
 #ifdef PLMC
-  hipLaunchKernelGGL(PLMC_cuda, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0,
+  hipLaunchKernelGGL(PLMC_cuda<0>, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama,
                      n_fields);
   GPU_Error_Check();
 #endif

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -65,9 +65,9 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
                      gama, 1, n_fields);
 #endif
 #ifdef PLMC
-  hipLaunchKernelGGL(PLMC_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0,
+  hipLaunchKernelGGL(PLMC_cuda<0>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama,
                      n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, 1,
+  hipLaunchKernelGGL(PLMC_cuda<1>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama,
                      n_fields);
 #endif
 #ifdef PPMP

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -77,8 +77,8 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
                      gama, 1, n_fields);
 #endif
 #ifdef PPMC
-  hipLaunchKernelGGL(PPMC_CTU, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0);
-  hipLaunchKernelGGL(PPMC_CTU, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, 1);
+  hipLaunchKernelGGL(PPMC_CTU<0>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama);
+  hipLaunchKernelGGL(PPMC_CTU<1>, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama);
 #endif
   GPU_Error_Check();
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -115,9 +115,9 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
                      gama, 2, n_fields);
   #endif  // PPMP
   #ifdef PPMC
-  hipLaunchKernelGGL(PPMC_CTU, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0);
-  hipLaunchKernelGGL(PPMC_CTU, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, 1);
-  hipLaunchKernelGGL(PPMC_CTU, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, 2);
+  hipLaunchKernelGGL(PPMC_CTU<0>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama);
+  hipLaunchKernelGGL(PPMC_CTU<1>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama);
+  hipLaunchKernelGGL(PPMC_CTU<2>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama);
   GPU_Error_Check();
   #endif  // PPMC
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -99,11 +99,11 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
                      gama, 2, n_fields);
   #endif  // PLMP
   #ifdef PLMC
-  hipLaunchKernelGGL(PLMC_cuda, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama, 0,
+  hipLaunchKernelGGL(PLMC_cuda<0>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, dx, dt, gama,
                      n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama, 1,
+  hipLaunchKernelGGL(PLMC_cuda<1>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, nx, ny, nz, dy, dt, gama,
                      n_fields);
-  hipLaunchKernelGGL(PLMC_cuda, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama, 2,
+  hipLaunchKernelGGL(PLMC_cuda<2>, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, nx, ny, nz, dz, dt, gama,
                      n_fields);
   #endif
   #ifdef PPMP

--- a/src/reconstruction/plmc_cuda.h
+++ b/src/reconstruction/plmc_cuda.h
@@ -15,7 +15,8 @@
  gamma, int dir)
  *  \brief When passed a stencil of conserved variables, returns the left and
  right boundary values for the interface calculated using plm. */
+template <int dir>
 __global__ __launch_bounds__(TPB) void PLMC_cuda(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx,
-                                                 int ny, int nz, Real dx, Real dt, Real gamma, int dir, int n_fields);
+                                                 int ny, int nz, Real dx, Real dt, Real gamma, int n_fields);
 
 #endif  // PLMC_CUDA_H

--- a/src/reconstruction/plmc_cuda_tests.cu
+++ b/src/reconstruction/plmc_cuda_tests.cu
@@ -148,8 +148,21 @@ TEST(tHYDROPlmcReconstructor, CorrectInputExpectCorrectOutput)
     cuda_utilities::DeviceVector<double> dev_interface_right(host_grid.size(), true);
 
     // Launch kernel
-    hipLaunchKernelGGL(PLMC_cuda, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
-                       dev_interface_right.data(), nx_rot, ny_rot, nz_rot, dx, dt, gamma, direction, n_fields);
+    std::cout << "direction = " << direction << std::endl;
+    switch (direction) {
+      case 0:
+        hipLaunchKernelGGL(PLMC_cuda<0>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx_rot, ny_rot, nz_rot, dx, dt, gamma, n_fields);
+        break;
+      case 1:
+        hipLaunchKernelGGL(PLMC_cuda<1>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx_rot, ny_rot, nz_rot, dx, dt, gamma, n_fields);
+        break;
+      case 2:
+        hipLaunchKernelGGL(PLMC_cuda<2>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx_rot, ny_rot, nz_rot, dx, dt, gamma, n_fields);
+        break;
+    }
     GPU_Error_Check();
     GPU_Error_Check(cudaDeviceSynchronize());
 
@@ -261,8 +274,20 @@ TEST(tMHDPlmcReconstructor, CorrectInputExpectCorrectOutput)
     cuda_utilities::DeviceVector<double> dev_interface_right(n_cells_interface, true);
 
     // Launch kernel
-    hipLaunchKernelGGL(PLMC_cuda, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
-                       dev_interface_right.data(), nx, ny, nz, dx, dt, gamma, direction, n_fields);
+    switch (direction) {
+      case 0:
+        hipLaunchKernelGGL(PLMC_cuda<0>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma, n_fields);
+        break;
+      case 1:
+        hipLaunchKernelGGL(PLMC_cuda<1>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma, n_fields);
+        break;
+      case 2:
+        hipLaunchKernelGGL(PLMC_cuda<2>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma, n_fields);
+        break;
+    }
     GPU_Error_Check();
     GPU_Error_Check(cudaDeviceSynchronize());
 

--- a/src/reconstruction/ppmc_cuda.h
+++ b/src/reconstruction/ppmc_cuda.h
@@ -14,6 +14,7 @@
  * in the characteristic variables to monotonize the slopes followed by limiting the interface states using the limiter
  * from Colella & Woodward 1984.
  *
+ * \tparam dir The direction to reconstruct. 0=X, 1=Y, 2=Z
  * \param[in] dev_conserved The conserved variable array
  * \param[out] dev_bounds_L The array of left interfaces
  * \param[out] dev_bounds_R The array of right interfaces
@@ -23,10 +24,10 @@
  * \param[in] dx The length of the cells in the `dir` direction
  * \param[in] dt The time step
  * \param[in] gamma The adiabatic index
- * \param[in] dir The direction to reconstruct. 0=X, 1=Y, 2=Z
  */
+template <int dir>
 __global__ void PPMC_CTU(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx, int ny, int nz, Real dx,
-                         Real dt, Real gamma, int dir);
+                         Real dt, Real gamma);
 
 /*!
  * \brief Computes the left and right interface states using PPM with limiting in the characteristic variables. Used for

--- a/src/reconstruction/ppmc_cuda.h
+++ b/src/reconstruction/ppmc_cuda.h
@@ -38,6 +38,7 @@ __global__ void PPMC_CTU(Real *dev_conserved, Real *dev_bounds_L, Real *dev_boun
  * oscillatory, and faster than the method described in Stone et al. 2008 which is used in PPMC_CTU. The difference is
  * most pronounced in the Brio & Wu shock tube where the PPM oscillations are much smaller using this method.
  *
+ * \tparam dir The direction to reconstruct. 0=X, 1=Y, 2=Z
  * \param[in] dev_conserved The conserved variable array
  * \param[out] dev_bounds_L The array of left interfaces
  * \param[out] dev_bounds_R The array of right interfaces
@@ -45,9 +46,9 @@ __global__ void PPMC_CTU(Real *dev_conserved, Real *dev_bounds_L, Real *dev_boun
  * \param[in] ny The number of cells in the Y-direction
  * \param[in] nz The number of cells in the Z-direction
  * \param[in] gamma The adiabatic index
- * \param[in] dir The direction to reconstruct. 0=X, 1=Y, 2=Z
  */
+template <int dir>
 __global__ __launch_bounds__(TPB) void PPMC_VL(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int nx,
-                                               int ny, int nz, Real gamma, int dir);
+                                               int ny, int nz, Real gamma);
 
 #endif  // PPMC_CUDA_H

--- a/src/reconstruction/ppmc_cuda_tests.cu
+++ b/src/reconstruction/ppmc_cuda_tests.cu
@@ -227,8 +227,20 @@ TEST(tALLPpmcVLReconstructor, CorrectInputExpectCorrectOutput)
     cuda_utilities::DeviceVector<double> dev_interface_right(nx * ny * nz * (n_fields - 1), true);
 
     // Launch kernel
-    hipLaunchKernelGGL(PPMC_VL, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
-                       dev_interface_right.data(), nx, ny, nz, gamma, direction);
+    switch (direction) {
+      case 0:
+        hipLaunchKernelGGL(PPMC_VL<0>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, gamma);
+        break;
+      case 1:
+        hipLaunchKernelGGL(PPMC_VL<1>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, gamma);
+        break;
+      case 2:
+        hipLaunchKernelGGL(PPMC_VL<2>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, gamma);
+        break;
+    }
     GPU_Error_Check();
     GPU_Error_Check(cudaDeviceSynchronize());
 

--- a/src/reconstruction/ppmc_cuda_tests.cu
+++ b/src/reconstruction/ppmc_cuda_tests.cu
@@ -87,8 +87,20 @@ TEST(tHYDROPpmcCTUReconstructor, CorrectInputExpectCorrectOutput)
     cuda_utilities::DeviceVector<double> dev_interface_right(host_grid.size(), true);
 
     // Launch kernel
-    hipLaunchKernelGGL(PPMC_CTU, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
-                       dev_interface_right.data(), nx, ny, nz, dx, dt, gamma, direction);
+    switch (direction) {
+      case 0:
+        hipLaunchKernelGGL(PPMC_CTU<0>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma);
+        break;
+      case 1:
+        hipLaunchKernelGGL(PPMC_CTU<1>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma);
+        break;
+      case 2:
+        hipLaunchKernelGGL(PPMC_CTU<2>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),
+                           dev_interface_right.data(), nx, ny, nz, dx, dt, gamma);
+        break;
+    }
     GPU_Error_Check();
     GPU_Error_Check(cudaDeviceSynchronize());
 

--- a/src/reconstruction/reconstruction_internals.h
+++ b/src/reconstruction/reconstruction_internals.h
@@ -48,7 +48,7 @@ enum Kind {
   chosen = plmc
 #elif defined(PPMP)
   chosen = ppmp
-#elif defined(PLMC)
+#elif defined(PPMC)
   chosen = ppmc
 #else
   #error "no reconstruction selected"

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -91,8 +91,8 @@ struct Conserved {
   /// Default constructor, should init everything to zero
   Conserved() = default;
   /// Manual constructor, mostly used for testing and doesn't init all members
-  Conserved(Real const in_density, Vector const& in_momentum, Real const in_energy,
-            Vector const& in_magnetic = {0, 0, 0}, Real const in_gas_energy = 0.0)
+  Conserved(Real const in_density, VectorXYZ const& in_momentum, Real const in_energy,
+            VectorXYZ const& in_magnetic = {0, 0, 0}, Real const in_gas_energy = 0.0)
       : density(in_density), momentum(in_momentum), energy(in_energy)
   {
 #ifdef MHD

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -91,8 +91,8 @@ struct Conserved {
   /// Default constructor, should init everything to zero
   Conserved() = default;
   /// Manual constructor, mostly used for testing and doesn't init all members
-  Conserved(Real const in_density, Vector const &in_momentum, Real const in_energy,
-            Vector const &in_magnetic = {0, 0, 0}, Real const in_gas_energy = 0.0)
+  Conserved(Real const in_density, Vector const& in_momentum, Real const in_energy,
+            Vector const& in_magnetic = {0, 0, 0}, Real const in_gas_energy = 0.0)
       : density(in_density), momentum(in_momentum), energy(in_energy)
   {
 #ifdef MHD

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -87,6 +87,22 @@ struct Conserved {
 #ifdef SCALAR
   Real scalar[grid_enum::nscalars];
 #endif  // SCALAR
+
+  /// Default constructor, should init everything to zero
+  Conserved() = default;
+  /// Manual constructor, mostly used for testing and doesn't init all members
+  Conserved(Real const in_density, Vector const &in_momentum, Real const in_energy,
+            Vector const &in_magnetic = {0, 0, 0}, Real const in_gas_energy = 0.0)
+      : density(in_density), momentum(in_momentum), energy(in_energy)
+  {
+#ifdef MHD
+    magnetic = in_magnetic;
+#endif  // mhd
+
+#ifdef DE
+    gas_energy = in_gas_energy;
+#endif  // DE
+  };
 };
 // =====================================================================================================================
 

--- a/src/utils/hydro_utilities.h
+++ b/src/utils/hydro_utilities.h
@@ -212,6 +212,23 @@ inline __host__ __device__ Real Calc_Sound_Speed(Real const &P, Real const &d, R
 }
 
 // =====================================================================================================================
+/*!
+ * \brief Load the conserved variables from a single cell. Note that with MHD this returns cell-centered magnetic
+ * fields, not face centered fields.
+ *
+ * \tparam dir The direction to load the data in. i.e. which direction is the cell x, y, and z. If dir = 0 then local
+ * xyz is the same as the true xyz. If dir = 1 then local xyz is true yzx, for dir = 2 then local xyz is true zxy. This
+ * option is so that the reconstructors, and any other split kernels, can load data that is in the appropriated
+ * direction for that kernel.
+ * \param[in] dev_conserved The pointer to the conserved variable array
+ * \param[in] xid The index for the x location
+ * \param[in] yid The index for the y location
+ * \param[in] zid The index for the z location
+ * \param[in] nx The total number of cells in the x direction
+ * \param[in] ny The total number of cells in the y direction
+ * \param[in] n_cells The total number of cells
+ * \return Conserved The cell centered conserved variables in the cell at location xid, yid, zid.
+ */
 template <size_t dir = 0>
 inline __host__ __device__ Conserved Load_Cell_Conserved(Real const *dev_conserved, size_t const xid, size_t const yid,
                                                          size_t const zid, size_t const nx, size_t const ny,
@@ -267,6 +284,13 @@ inline __host__ __device__ Conserved Load_Cell_Conserved(Real const *dev_conserv
 // =====================================================================================================================
 
 // =====================================================================================================================
+/*!
+ * \brief Convert Conserved cell centered variables to primitive variables
+ *
+ * \param conserved_in The conserved variables to convert
+ * \param gamma The adiabatic index
+ * \return Primitive The cell centered primitive variables
+ */
 __inline__ __host__ __device__ Primitive Conserved_2_Primitive(Conserved const &conserved_in, Real const gamma)
 {
   Primitive output;
@@ -320,6 +344,13 @@ __inline__ __host__ __device__ Primitive Conserved_2_Primitive(Conserved const &
 // =====================================================================================================================
 
 // =====================================================================================================================
+/*!
+ * \brief Convert primitive cell centered variables to conserved variables
+ *
+ * \param primitive_in The primitive variables to convert
+ * \param gamma The adiabatic index
+ * \return Conserved The cell centered conserved variables
+ */
 __inline__ __host__ __device__ Conserved Primitive_2_Conserved(Primitive const &primitive_in, Real const gamma)
 {
   Conserved output;
@@ -362,6 +393,24 @@ __inline__ __host__ __device__ Conserved Primitive_2_Conserved(Primitive const &
 // =====================================================================================================================
 
 // =====================================================================================================================
+/*!
+ * \brief Load the primitive variables from a single cell. Note that with MHD this returns cell-centered magnetic
+ * fields, not face centered fields.
+ *
+ * \tparam dir The direction to load the data in. i.e. which direction is the cell x, y, and z. If dir = 0 then local
+ * xyz is the same as the true xyz. If dir = 1 then local xyz is true yzx, for dir = 2 then local xyz is true zxy. This
+ * option is so that the reconstructors, and any other split kernels, can load data that is in the appropriated
+ * direction for that kernel.
+ * \param[in] dev_conserved The pointer to the conserved variable array
+ * \param[in] xid The index for the x location
+ * \param[in] yid The index for the y location
+ * \param[in] zid The index for the z location
+ * \param[in] nx The total number of cells in the x direction
+ * \param[in] ny The total number of cells in the y direction
+ * \param[in] n_cells The total number of cells
+ * \param[in] gamma The adiabatic index
+ * \return Primitive The cell centered conserved variables in the cell at location xid, yid, zid.
+ */
 template <size_t dir = 0>
 inline __host__ __device__ Primitive Load_Cell_Primitive(Real const *dev_conserved, size_t const xid, size_t const yid,
                                                          size_t const zid, size_t const nx, size_t const ny,

--- a/src/utils/hydro_utilities.h
+++ b/src/utils/hydro_utilities.h
@@ -362,7 +362,14 @@ __inline__ __host__ __device__ Conserved Primitive_2_Conserved(Primitive const &
 // =====================================================================================================================
 
 // =====================================================================================================================
-// Load_Cell_Primitive
+template <size_t dir = 0>
+inline __host__ __device__ Primitive Load_Cell_Primitive(Real const *dev_conserved, size_t const xid, size_t const yid,
+                                                         size_t const zid, size_t const nx, size_t const ny,
+                                                         size_t const n_cells, Real const gamma)
+{
+  Conserved const conserved_cell = Load_Cell_Conserved<dir>(dev_conserved, xid, yid, zid, nx, ny, n_cells);
+  return Conserved_2_Primitive(conserved_cell, gamma);
+}
 // =====================================================================================================================
 
 }  // namespace hydro_utilities

--- a/src/utils/hydro_utilities_tests.cpp
+++ b/src/utils/hydro_utilities_tests.cpp
@@ -421,3 +421,29 @@ TEST(tALLConserved2Primitive, CorrectInputExpectCorrectOutput)
                                    "gas_energy_specific");
 #endif  // DE
 }
+
+TEST(tALLPrimitive2Conserved, CorrectInputExpectCorrectOutput)
+{
+  Real const gamma = 5. / 3.;
+  hydro_utilities::Primitive input_data{2, {2, 3, 4}, 90, {6, 7, 8}, 9};
+  hydro_utilities::Conserved test_data = hydro_utilities::Primitive_2_Conserved(input_data, gamma);
+
+  hydro_utilities::Conserved fiducial_data{2, {4, 6, 8}, 163.99999999999997, {6, 7, 8}, 18};
+#ifdef MHD
+  fiducial_data.energy = 238.49999999999997;
+#endif  // MHD
+
+  testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
+  testing_utilities::Check_Results(fiducial_data.momentum.x, test_data.momentum.x, "momentum.x");
+  testing_utilities::Check_Results(fiducial_data.momentum.y, test_data.momentum.y, "momentum.y");
+  testing_utilities::Check_Results(fiducial_data.momentum.z, test_data.momentum.z, "momentum.z");
+  testing_utilities::Check_Results(fiducial_data.energy, test_data.energy, "energy");
+#ifdef MHD
+  testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
+  testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
+  testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+#endif  // MHD
+#ifdef DE
+  testing_utilities::Check_Results(fiducial_data.gas_energy, test_data.gas_energy, "gas_energy");
+#endif  // DE
+}

--- a/src/utils/hydro_utilities_tests.cpp
+++ b/src/utils/hydro_utilities_tests.cpp
@@ -375,9 +375,8 @@ TEST(tALLLoadCellConserved, CorrectInputExpectCorrectOutput)
     }
 
     // Check results
-    hydro_utilities::Conserved fiducial_data{13, {40, 67, 94}, 60500};
+    hydro_utilities::Conserved fiducial_data{13, {40, 67, 94}, 60500, {147.5, 173.5, 197.5}};
 #ifdef MHD
-    fiducial_data.magnetic = {147.5, 173.5, 197.5};
     testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
     testing_utilities::Check_Results(fiducial_data.momentum.x, test_data.momentum.x, "momentum.x");
     testing_utilities::Check_Results(fiducial_data.momentum.y, test_data.momentum.y, "momentum.y");
@@ -394,4 +393,31 @@ TEST(tALLLoadCellConserved, CorrectInputExpectCorrectOutput)
     testing_utilities::Check_Results(fiducial_data.energy, test_data.energy, "energy");
 #endif  // MHD
   }
+}
+
+TEST(tALLConserved2Primitive, CorrectInputExpectCorrectOutput)
+{
+  Real const gamma = 5. / 3.;
+  hydro_utilities::Conserved input_data{2, {2, 3, 4}, 90, {6, 7, 8}, 9};
+  hydro_utilities::Primitive test_data = hydro_utilities::Conserved_2_Primitive(input_data, gamma);
+
+  hydro_utilities::Primitive fiducial_data{2, {1, 1.5, 2}, 55.166666666666671, {6, 7, 8}, 4.5};
+#ifdef MHD
+  fiducial_data.pressure = 5.5000000000000009;
+#endif  // MHD
+
+  testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
+  testing_utilities::Check_Results(fiducial_data.velocity.x, test_data.velocity.x, "velocity.x");
+  testing_utilities::Check_Results(fiducial_data.velocity.y, test_data.velocity.y, "velocity.y");
+  testing_utilities::Check_Results(fiducial_data.velocity.z, test_data.velocity.z, "velocity.z");
+  testing_utilities::Check_Results(fiducial_data.pressure, test_data.pressure, "pressure");
+#ifdef MHD
+  testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
+  testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
+  testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+#endif  // MHD
+#ifdef DE
+  testing_utilities::Check_Results(fiducial_data.gas_energy_specific, test_data.gas_energy_specific,
+                                   "gas_energy_specific");
+#endif  // DE
 }

--- a/src/utils/hydro_utilities_tests.cpp
+++ b/src/utils/hydro_utilities_tests.cpp
@@ -310,13 +310,13 @@ TEST(tALLLoadCellPrimitive, CorrectInputExpectCorrectOutput)
     hydro_utilities::Primitive const fiducial_data{
         13, {3.0769230769230771, 5.1538461538461542, 7.2307692307692308}, 9662.3910256410272, {147.5, 173.5, 197.5}};
     testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-    testing_utilities::Check_Results(fiducial_data.velocity.x, test_data.velocity.x, "velocity.x");
-    testing_utilities::Check_Results(fiducial_data.velocity.y, test_data.velocity.y, "velocity.y");
-    testing_utilities::Check_Results(fiducial_data.velocity.z, test_data.velocity.z, "velocity.z");
+    testing_utilities::Check_Results(fiducial_data.velocity.x(), test_data.velocity.x(), "velocity.x()");
+    testing_utilities::Check_Results(fiducial_data.velocity.y(), test_data.velocity.y(), "velocity.y()");
+    testing_utilities::Check_Results(fiducial_data.velocity.z(), test_data.velocity.z(), "velocity.z()");
     testing_utilities::Check_Results(fiducial_data.pressure, test_data.pressure, "pressure");
-    testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
-    testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
-    testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+    testing_utilities::Check_Results(fiducial_data.magnetic.x(), test_data.magnetic.x(), "magnetic.x()");
+    testing_utilities::Check_Results(fiducial_data.magnetic.y(), test_data.magnetic.y(), "magnetic.y()");
+    testing_utilities::Check_Results(fiducial_data.magnetic.z(), test_data.magnetic.z(), "magnetic.z()");
 #else  // MHD
     hydro_utilities::Primitive fiducial_data{
         13, {3.0769230769230771, 5.1538461538461542, 7.2307692307692308}, 39950.641025641031};
@@ -324,9 +324,9 @@ TEST(tALLLoadCellPrimitive, CorrectInputExpectCorrectOutput)
     fiducial_data.pressure = 39950.641025641031;
   #endif  // DE
     testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-    testing_utilities::Check_Results(fiducial_data.velocity.x, test_data.velocity.x, "velocity.x");
-    testing_utilities::Check_Results(fiducial_data.velocity.y, test_data.velocity.y, "velocity.y");
-    testing_utilities::Check_Results(fiducial_data.velocity.z, test_data.velocity.z, "velocity.z");
+    testing_utilities::Check_Results(fiducial_data.velocity.x(), test_data.velocity.x(), "velocity.x");
+    testing_utilities::Check_Results(fiducial_data.velocity.y(), test_data.velocity.y(), "velocity.y");
+    testing_utilities::Check_Results(fiducial_data.velocity.z(), test_data.velocity.z(), "velocity.z");
     testing_utilities::Check_Results(fiducial_data.pressure, test_data.pressure, "pressure");
 #endif    // MHD
   }
@@ -378,18 +378,18 @@ TEST(tALLLoadCellConserved, CorrectInputExpectCorrectOutput)
     hydro_utilities::Conserved fiducial_data{13, {40, 67, 94}, 60500, {147.5, 173.5, 197.5}};
 #ifdef MHD
     testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-    testing_utilities::Check_Results(fiducial_data.momentum.x, test_data.momentum.x, "momentum.x");
-    testing_utilities::Check_Results(fiducial_data.momentum.y, test_data.momentum.y, "momentum.y");
-    testing_utilities::Check_Results(fiducial_data.momentum.z, test_data.momentum.z, "momentum.z");
+    testing_utilities::Check_Results(fiducial_data.momentum.x(), test_data.momentum.x(), "momentum.x");
+    testing_utilities::Check_Results(fiducial_data.momentum.y(), test_data.momentum.y(), "momentum.y");
+    testing_utilities::Check_Results(fiducial_data.momentum.z(), test_data.momentum.z(), "momentum.z");
     testing_utilities::Check_Results(fiducial_data.energy, test_data.energy, "energy");
-    testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
-    testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
-    testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+    testing_utilities::Check_Results(fiducial_data.magnetic.x(), test_data.magnetic.x(), "magnetic.x");
+    testing_utilities::Check_Results(fiducial_data.magnetic.y(), test_data.magnetic.y(), "magnetic.y");
+    testing_utilities::Check_Results(fiducial_data.magnetic.z(), test_data.magnetic.z(), "magnetic.z");
 #else   // MHD
     testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-    testing_utilities::Check_Results(fiducial_data.momentum.x, test_data.momentum.x, "momentum.x");
-    testing_utilities::Check_Results(fiducial_data.momentum.y, test_data.momentum.y, "momentum.y");
-    testing_utilities::Check_Results(fiducial_data.momentum.z, test_data.momentum.z, "momentum.z");
+    testing_utilities::Check_Results(fiducial_data.momentum.x(), test_data.momentum.x(), "momentum.x");
+    testing_utilities::Check_Results(fiducial_data.momentum.y(), test_data.momentum.y(), "momentum.y");
+    testing_utilities::Check_Results(fiducial_data.momentum.z(), test_data.momentum.z(), "momentum.z");
     testing_utilities::Check_Results(fiducial_data.energy, test_data.energy, "energy");
 #endif  // MHD
   }
@@ -407,14 +407,14 @@ TEST(tALLConserved2Primitive, CorrectInputExpectCorrectOutput)
 #endif  // MHD
 
   testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-  testing_utilities::Check_Results(fiducial_data.velocity.x, test_data.velocity.x, "velocity.x");
-  testing_utilities::Check_Results(fiducial_data.velocity.y, test_data.velocity.y, "velocity.y");
-  testing_utilities::Check_Results(fiducial_data.velocity.z, test_data.velocity.z, "velocity.z");
+  testing_utilities::Check_Results(fiducial_data.velocity.x(), test_data.velocity.x(), "velocity.x");
+  testing_utilities::Check_Results(fiducial_data.velocity.y(), test_data.velocity.y(), "velocity.y");
+  testing_utilities::Check_Results(fiducial_data.velocity.z(), test_data.velocity.z(), "velocity.z");
   testing_utilities::Check_Results(fiducial_data.pressure, test_data.pressure, "pressure");
 #ifdef MHD
-  testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
-  testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
-  testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+  testing_utilities::Check_Results(fiducial_data.magnetic.x(), test_data.magnetic.x(), "magnetic.x");
+  testing_utilities::Check_Results(fiducial_data.magnetic.y(), test_data.magnetic.y(), "magnetic.y");
+  testing_utilities::Check_Results(fiducial_data.magnetic.z(), test_data.magnetic.z(), "magnetic.z");
 #endif  // MHD
 #ifdef DE
   testing_utilities::Check_Results(fiducial_data.gas_energy_specific, test_data.gas_energy_specific,
@@ -434,14 +434,14 @@ TEST(tALLPrimitive2Conserved, CorrectInputExpectCorrectOutput)
 #endif  // MHD
 
   testing_utilities::Check_Results(fiducial_data.density, test_data.density, "density");
-  testing_utilities::Check_Results(fiducial_data.momentum.x, test_data.momentum.x, "momentum.x");
-  testing_utilities::Check_Results(fiducial_data.momentum.y, test_data.momentum.y, "momentum.y");
-  testing_utilities::Check_Results(fiducial_data.momentum.z, test_data.momentum.z, "momentum.z");
+  testing_utilities::Check_Results(fiducial_data.momentum.x(), test_data.momentum.x(), "momentum.x");
+  testing_utilities::Check_Results(fiducial_data.momentum.y(), test_data.momentum.y(), "momentum.y");
+  testing_utilities::Check_Results(fiducial_data.momentum.z(), test_data.momentum.z(), "momentum.z");
   testing_utilities::Check_Results(fiducial_data.energy, test_data.energy, "energy");
 #ifdef MHD
-  testing_utilities::Check_Results(fiducial_data.magnetic.x, test_data.magnetic.x, "magnetic.x");
-  testing_utilities::Check_Results(fiducial_data.magnetic.y, test_data.magnetic.y, "magnetic.y");
-  testing_utilities::Check_Results(fiducial_data.magnetic.z, test_data.magnetic.z, "magnetic.z");
+  testing_utilities::Check_Results(fiducial_data.magnetic.x(), test_data.magnetic.x(), "magnetic.x");
+  testing_utilities::Check_Results(fiducial_data.magnetic.y(), test_data.magnetic.y(), "magnetic.y");
+  testing_utilities::Check_Results(fiducial_data.magnetic.z(), test_data.magnetic.z(), "magnetic.z");
 #endif  // MHD
 #ifdef DE
   testing_utilities::Check_Results(fiducial_data.gas_energy, test_data.gas_energy, "gas_energy");

--- a/src/utils/math_utilities.h
+++ b/src/utils/math_utilities.h
@@ -16,6 +16,7 @@
 // Local Includes
 #include "../global/global.h"
 #include "../global/global_cuda.h"
+#include "../utils/basic_structs.h"
 #include "../utils/gpu.hpp"
 
 namespace math_utils
@@ -97,5 +98,35 @@ inline __device__ __host__ Real SquareMagnitude(Real const &v1, Real const &v2, 
   return dotProduct(v1, v2, v3, v1, v2, v3);
 };
 // =========================================================================
+
+// =====================================================================================================================
+/*!
+ * \brief Cyclically permute a Vector once. i.e. (x,y,z) becomes (y,z,x)
+ *
+ * \param[in,out] vec The vector to permute
+ */
+inline __device__ __host__ void Cyclic_Permute_Once(hydro_utilities::Vector &vec)
+{
+  Real temp = vec.x;
+  vec.x     = vec.y;
+  vec.y     = vec.z;
+  vec.z     = temp;
+}
+// =====================================================================================================================
+
+// =====================================================================================================================
+/*!
+ * \brief Cyclically permute a Vector twice. i.e. (x,y,z) becomes (z,x,y)
+ *
+ * \param[in,out] vec The vector to permute
+ */
+inline __device__ __host__ void Cyclic_Permute_Twice(hydro_utilities::Vector &vec)
+{
+  Real temp = vec.y;
+  vec.x     = vec.z;
+  vec.y     = vec.x;
+  vec.z     = temp;
+}
+// =====================================================================================================================
 
 }  // namespace math_utils

--- a/src/utils/math_utilities.h
+++ b/src/utils/math_utilities.h
@@ -123,8 +123,8 @@ inline __device__ __host__ void Cyclic_Permute_Once(hydro_utilities::Vector &vec
 inline __device__ __host__ void Cyclic_Permute_Twice(hydro_utilities::Vector &vec)
 {
   Real temp = vec.y;
-  vec.x     = vec.z;
   vec.y     = vec.x;
+  vec.x     = vec.z;
   vec.z     = temp;
 }
 // =====================================================================================================================

--- a/src/utils/math_utilities.h
+++ b/src/utils/math_utilities.h
@@ -105,12 +105,12 @@ inline __device__ __host__ Real SquareMagnitude(Real const &v1, Real const &v2, 
  *
  * \param[in,out] vec The vector to permute
  */
-inline __device__ __host__ void Cyclic_Permute_Once(hydro_utilities::Vector &vec)
+inline __device__ __host__ void Cyclic_Permute_Once(hydro_utilities::VectorXYZ &vec)
 {
-  Real temp = vec.x;
-  vec.x     = vec.y;
-  vec.y     = vec.z;
-  vec.z     = temp;
+  Real temp = vec.x();
+  vec.x()   = vec.y();
+  vec.y()   = vec.z();
+  vec.z()   = temp;
 }
 // =====================================================================================================================
 
@@ -120,12 +120,12 @@ inline __device__ __host__ void Cyclic_Permute_Once(hydro_utilities::Vector &vec
  *
  * \param[in,out] vec The vector to permute
  */
-inline __device__ __host__ void Cyclic_Permute_Twice(hydro_utilities::Vector &vec)
+inline __device__ __host__ void Cyclic_Permute_Twice(hydro_utilities::VectorXYZ &vec)
 {
-  Real temp = vec.y;
-  vec.y     = vec.x;
-  vec.x     = vec.z;
-  vec.z     = temp;
+  Real temp = vec.y();
+  vec.y()   = vec.x();
+  vec.x()   = vec.z();
+  vec.z()   = temp;
 }
 // =====================================================================================================================
 

--- a/src/utils/math_utilities_tests.cpp
+++ b/src/utils/math_utilities_tests.cpp
@@ -13,6 +13,7 @@
 
 // Local Includes
 #include "../global/global.h"
+#include "../utils/basic_structs.h"
 #include "../utils/math_utilities.h"
 #include "../utils/testing_utilities.h"
 
@@ -73,5 +74,41 @@ TEST(tALLSquareMagnitude, CorrectInputExpectCorrectOutput)
 
   // Now check results
   testing_utilities::Check_Results(fiducial_square_magnitude, test_square_magnitude, "dot product");
+}
+// =========================================================================
+
+// =========================================================================
+/*!
+ * \brief Test the math_utils::Cyclic_Permute_Once function
+ *
+ */
+TEST(tALLCyclicPermuteOnce, CorrectInputExpectCorrectOutput)
+{
+  hydro_utilities::Vector test_vec{1, 2, 3};
+
+  math_utils::Cyclic_Permute_Once(test_vec);
+
+  // Now check results
+  testing_utilities::Check_Results(2, test_vec.x, "Failure in x term");
+  testing_utilities::Check_Results(3, test_vec.y, "Failure in y term");
+  testing_utilities::Check_Results(1, test_vec.z, "Failure in z term");
+}
+// =========================================================================
+
+// =========================================================================
+/*!
+ * \brief Test the math_utils::Cyclic_Permute_Twice function
+ *
+ */
+TEST(tALLCyclicPermuteTwice, CorrectInputExpectCorrectOutput)
+{
+  hydro_utilities::Vector test_vec{1, 2, 3};
+
+  math_utils::Cyclic_Permute_Twice(test_vec);
+
+  // Now check results
+  testing_utilities::Check_Results(3, test_vec.x, "Failure in x term");
+  testing_utilities::Check_Results(1, test_vec.y, "Failure in y term");
+  testing_utilities::Check_Results(2, test_vec.z, "Failure in z term");
 }
 // =========================================================================

--- a/src/utils/math_utilities_tests.cpp
+++ b/src/utils/math_utilities_tests.cpp
@@ -84,14 +84,14 @@ TEST(tALLSquareMagnitude, CorrectInputExpectCorrectOutput)
  */
 TEST(tALLCyclicPermuteOnce, CorrectInputExpectCorrectOutput)
 {
-  hydro_utilities::Vector test_vec{1, 2, 3};
+  hydro_utilities::VectorXYZ test_vec{1, 2, 3};
 
   math_utils::Cyclic_Permute_Once(test_vec);
 
   // Now check results
-  testing_utilities::Check_Results(2, test_vec.x, "Failure in x term");
-  testing_utilities::Check_Results(3, test_vec.y, "Failure in y term");
-  testing_utilities::Check_Results(1, test_vec.z, "Failure in z term");
+  testing_utilities::Check_Results(2, test_vec.x(), "Failure in x term");
+  testing_utilities::Check_Results(3, test_vec.y(), "Failure in y term");
+  testing_utilities::Check_Results(1, test_vec.z(), "Failure in z term");
 }
 // =========================================================================
 
@@ -102,13 +102,13 @@ TEST(tALLCyclicPermuteOnce, CorrectInputExpectCorrectOutput)
  */
 TEST(tALLCyclicPermuteTwice, CorrectInputExpectCorrectOutput)
 {
-  hydro_utilities::Vector test_vec{1, 2, 3};
+  hydro_utilities::VectorXYZ test_vec{1, 2, 3};
 
   math_utils::Cyclic_Permute_Twice(test_vec);
 
   // Now check results
-  testing_utilities::Check_Results(3, test_vec.x, "Failure in x term");
-  testing_utilities::Check_Results(1, test_vec.y, "Failure in y term");
-  testing_utilities::Check_Results(2, test_vec.z, "Failure in z term");
+  testing_utilities::Check_Results(3, test_vec.x(), "Failure in x term");
+  testing_utilities::Check_Results(1, test_vec.y(), "Failure in y term");
+  testing_utilities::Check_Results(2, test_vec.z(), "Failure in z term");
 }
 // =========================================================================


### PR DESCRIPTION
# Summary

The primary purpose of this PR is to introduce 4 new utility functions for loading grid data and converting between the primitive and conserved variables. This builds off of PR #371 and will show changes from both that PR and this PR until #371 is merged into `dev`. Most of the relevant changes are in the following files:

- hydro_utilities.h
- plmc_cuda.h and .cu
- ppmc_cuda.h and .cu

The data loading functions are both templates that take the direction as a template parameter and default to `dir = 0`. Per Issue #308 we've seen that this can improve performance noticeably. After integrating these new templated functions into PLMC and PPMC (and making them templates in the same way) I found a ~6% improvement in performance on a single V100.  ([timing data](https://github.com/cholla-hydro/cholla/files/14271116/run_timing.log))


## `hydro_utilities::Load_Cell_Conserved`

This function loads the conserved data from the `dev_conserved` array and returns an assembled `Conserved` object.

## `hydro_utilities::Load_Cell_Primitive`

This function calls `hydro_utilities::Load_Cell_Conserved` and then `hydro_utilities::Conserved_2_Primitive` to load the conserved data, convert it to primitive, and returns a `Primitive` object.

## `hydro_utilities::Conserved_2_Primitive`

Converts the conserved variables in a `Conserved` object into primitive variables in a `Primitive` object and returns it.

## `hydro_utilities::Primitive_2_Conserved`

Converts the primitive variables in a `Primitive` object into conserved variables in a `Conserved` object and returns it.

## `math_utils::Cyclic_Permute_Once` and `math_utils::Cyclic_Permute_Twice`

These two functions take a `hydro_utilities::Vector` object and cyclically permute its members once or twice. It's used in the `Load_Cell_Conserved` function and I split it out on its own for clarity and because I thought it might be more generally useful. I tried to think of a single function that would do this more elegantly but I couldn't figure out a way, if you have suggestions I would be happy to hear them.

## Other

- Added a constructor for `hydro_utilities::Conserved`
- Fixed a bug in `reconstruction::Kind`, it had `PLMC` twice when one of them should have been `PPMC`.