### PR TITLE
Reconstruction Kernel Fusion 3: Fusing PCM with the Riemann Solvers

### DIFF
--- a/builds/make.type.dust
+++ b/builds/make.type.dust
@@ -37,8 +37,6 @@ DFLAGS    += -DPROJECTION
 
 DFLAGS    += $(OUTPUT)
 
-DFLAGS    += -DOUTPUT_ALWAYS
-
 #Select if the Hydro Conserved data will reside in the GPU
 #and the MPI transfers are done from the GPU
 #If not specified, MPI_GPU is off by default

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -17,6 +17,7 @@
   #include "../reconstruction/plmp_cuda.h"
   #include "../reconstruction/ppmc_cuda.h"
   #include "../reconstruction/ppmp_cuda.h"
+  #include "../reconstruction/reconstruction.h"
   #include "../riemann_solvers/exact_cuda.h"
   #include "../riemann_solvers/hllc_cuda.h"
   #include "../riemann_solvers/roe_cuda.h"
@@ -75,8 +76,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      n_fields);
   #endif
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dimGrid, dimBlock, 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   GPU_Error_Check();
 
@@ -118,8 +119,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      n_fields);
   #endif
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,
+                     0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   GPU_Error_Check();
 

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -68,8 +68,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
 
   // Step 2: Calculate first-order upwind fluxes
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dimGrid, dimBlock, 0,
+                     0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dimGrid, dimBlock, 0, 0,
@@ -111,8 +111,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
 
   // Step 5: Calculate the fluxes again
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock,
+                     0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,

--- a/src/integrators/VL_1D_cuda.cu
+++ b/src/integrators/VL_1D_cuda.cu
@@ -72,8 +72,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      0, n_fields);
   #endif
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dimGrid, dimBlock, 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dimGrid, dimBlock, 0, 0,
@@ -115,8 +115,8 @@ void VL_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost, Rea
                      0, n_fields);
   #endif
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,
+                     0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -70,10 +70,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
 
   // Step 2: Calculate first-order upwind fluxes
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 1>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dim2dGrid, dim1dBlock, 0,
@@ -122,10 +122,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
 
   // Step 5: Calculate the fluxes again
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid, dim1dBlock,

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -10,7 +10,6 @@
   #include "../global/global_cuda.h"
   #include "../hydro/hydro_cuda.h"
   #include "../integrators/VL_2D_cuda.h"
-  #include "../reconstruction/pcm_cuda.h"
   #include "../reconstruction/plmc_cuda.h"
   #include "../reconstruction/plmp_cuda.h"
   #include "../reconstruction/ppmc_cuda.h"
@@ -62,11 +61,8 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
     memory_allocated = true;
   }
 
-  // Step 1: Use PCM reconstruction to put conserved variables into interface
-  // arrays
-  hipLaunchKernelGGL(PCM_Reconstruction_2D, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, nx, ny,
-                     n_ghost, gama, n_fields);
-  GPU_Error_Check();
+  // Step 1: Use PCM reconstruction to put conserved variables into interface arrays
+  // This step has been fused into the Riemann solver kernels
 
   // Step 2: Calculate first-order upwind fluxes
   #ifdef EXACT

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -15,6 +15,7 @@
   #include "../reconstruction/plmp_cuda.h"
   #include "../reconstruction/ppmc_cuda.h"
   #include "../reconstruction/ppmp_cuda.h"
+  #include "../reconstruction/reconstruction.h"
   #include "../riemann_solvers/exact_cuda.h"
   #include "../riemann_solvers/hllc_cuda.h"
   #include "../riemann_solvers/roe_cuda.h"
@@ -81,10 +82,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      1, n_fields);
   #endif
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 1>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   GPU_Error_Check();
 
@@ -133,10 +134,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      1, n_fields);
   #endif
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   GPU_Error_Check();
 

--- a/src/integrators/VL_2D_cuda.cu
+++ b/src/integrators/VL_2D_cuda.cu
@@ -76,10 +76,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      gama, 1, n_fields);
   #endif
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama,
-                     1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dim2dGrid, dim1dBlock, 0,
+                     0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 1>), dim2dGrid, dim1dBlock, 0,
+                     0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>), dim2dGrid, dim1dBlock,
@@ -128,10 +128,10 @@ void VL_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int y_of
                      gama, 1, n_fields);
   #endif
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama,
-                     1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   #endif
   #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -143,75 +143,69 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   cuda_utilities::AutomaticLaunchParams static const exact_pcm_launch_params(
       Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
-                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
-                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
-                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // EXACT
   #ifdef ROE
   cuda_utilities::AutomaticLaunchParams static const roe_pcm_launch_params(
       Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
-                     roe_pcm_launch_params.get_numBlocks(),
-                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_pcm_launch_params.get_numBlocks(), roe_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
-                     roe_pcm_launch_params.get_numBlocks(),
-                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_pcm_launch_params.get_numBlocks(), roe_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
-                     roe_pcm_launch_params.get_numBlocks(),
-                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_pcm_launch_params.get_numBlocks(), roe_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // ROE
   #ifdef HLLC
   cuda_utilities::AutomaticLaunchParams static const hllc_pcm_launch_params(
       Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
-                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_pcm_launch_params.get_numBlocks(), hllc_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
-                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_pcm_launch_params.get_numBlocks(), hllc_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
-                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_pcm_launch_params.get_numBlocks(), hllc_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
   cuda_utilities::AutomaticLaunchParams static const hll_pcm_launch_params(
       Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
-                     hll_pcm_launch_params.get_numBlocks(),
-                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hll_pcm_launch_params.get_numBlocks(), hll_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
-                     hll_pcm_launch_params.get_numBlocks(),
-                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hll_pcm_launch_params.get_numBlocks(), hll_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
-                     hll_pcm_launch_params.get_numBlocks(),
-                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hll_pcm_launch_params.get_numBlocks(), hll_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLL
   #ifdef HLLD
   cuda_utilities::AutomaticLaunchParams static const hlld_pcm_launch_params(
       mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
-                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lx, Q_Rx, &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hlld_pcm_launch_params.get_numBlocks(), hlld_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lx, Q_Rx, &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz,
+                     n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
-                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Ly, Q_Ry, &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hlld_pcm_launch_params.get_numBlocks(), hlld_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Ly, Q_Ry, &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz,
+                     n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
-                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
-                     Q_Lz, Q_Rz, &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     hlld_pcm_launch_params.get_numBlocks(), hlld_pcm_launch_params.get_threadsPerBlock(), 0, 0,
+                     dev_conserved, Q_Lz, Q_Rz, &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz,
+                     n_cells, gama, n_fields);
   #endif  // HLLD
   GPU_Error_Check();
 
@@ -287,74 +281,77 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
       Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
                      exact_higher_order_launch_params.get_numBlocks(),
-                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
                      exact_higher_order_launch_params.get_numBlocks(),
-                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
                      exact_higher_order_launch_params.get_numBlocks(),
-                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z,
+                     nx, ny, nz, n_cells, gama, n_fields);
   #endif  // EXACT
   #ifdef ROE
   cuda_utilities::AutomaticLaunchParams static const roe_higher_order_launch_params(
       Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
                      roe_higher_order_launch_params.get_numBlocks(),
-                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
                      roe_higher_order_launch_params.get_numBlocks(),
-                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
                      roe_higher_order_launch_params.get_numBlocks(),
-                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
-                     n_fields);
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z,
+                     nx, ny, nz, n_cells, gama, n_fields);
   #endif  // ROE
   #ifdef HLLC
   cuda_utilities::AutomaticLaunchParams static const hllc_higher_order_launch_params(
       Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
-                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_higher_order_launch_params.get_numBlocks(),
+                     hllc_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
-                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_higher_order_launch_params.get_numBlocks(),
+                     hllc_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y,
+                     nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
-                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
+                     hllc_higher_order_launch_params.get_numBlocks(),
+                     hllc_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z,
+                     nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
   cuda_utilities::AutomaticLaunchParams static const hll_higher_order_launch_params(
       Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
-                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
-                     dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+                     hll_higher_order_launch_params.get_numBlocks, hll_higher_order_launch_params.get_threadsPerBlock,
+                     0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
-                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
-                     dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+                     hll_higher_order_launch_params.get_numBlocks, hll_higher_order_launch_params.get_threadsPerBlock,
+                     0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
-                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
-                     dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
+                     hll_higher_order_launch_params.get_numBlocks, hll_higher_order_launch_params.get_threadsPerBlock,
+                     0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLL
   #ifdef HLLD
   cuda_utilities::AutomaticLaunchParams static const hlld_higher_order_launch_params(
       mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
-                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lx, Q_Rx, &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, nx,
-                     ny, nz, n_cells, gama, n_fields);
+                     hlld_higher_order_launch_params.get_numBlocks(),
+                     hlld_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx,
+                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
-                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Ly, Q_Ry, &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, nx,
-                     ny, nz, n_cells, gama, n_fields);
+                     hlld_higher_order_launch_params.get_numBlocks(),
+                     hlld_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry,
+                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz, n_cells, gama, n_fields);
   hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
-                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
-                     dev_conserved_half, Q_Lz, Q_Rz, &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, nx,
-                     ny, nz, n_cells, gama, n_fields);
+                     hlld_higher_order_launch_params.get_numBlocks(),
+                     hlld_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz,
+                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLD
   GPU_Error_Check();
 

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -169,16 +169,17 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // ROE
   #ifdef HLLC
-  cuda_utilities::AutomaticLaunchParams static const hllc_launch_params(Calculate_HLLC_Fluxes_CUDA, n_cells);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
-                     n_fields);
+  cuda_utilities::AutomaticLaunchParams static const hllc_pcm_launch_params(
+      Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
   cuda_utilities::AutomaticLaunchParams static const hll_launch_params(Calculate_HLL_Fluxes_CUDA, n_cells);
@@ -305,15 +306,17 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // ROE
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, hllc_launch_params.get_numBlocks(),
-                     hllc_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
-                     n_fields);
+  cuda_utilities::AutomaticLaunchParams static const hllc_higher_order_launch_params(
+      Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
+                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
+                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
+                     hllc_higher_order_launch_params.numBlocks(), hllc_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
   hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -182,15 +182,19 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
-  cuda_utilities::AutomaticLaunchParams static const hll_launch_params(Calculate_HLL_Fluxes_CUDA, n_cells);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
+  cuda_utilities::AutomaticLaunchParams static const hll_pcm_launch_params(
+      Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hll_pcm_launch_params.get_numBlocks(),
+                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hll_pcm_launch_params.get_numBlocks(),
+                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hll_pcm_launch_params.get_numBlocks(),
+                     hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);
   #endif  // HLL
   #ifdef HLLD
@@ -319,13 +323,18 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
-                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
-                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1, n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
-                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2, n_fields);
-  #endif  // HLLC
+  cuda_utilities::AutomaticLaunchParams static const hll_higher_order_launch_params(
+      Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
+                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
+                     dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
+                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
+                     dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
+                     hll_higher_order_launch_params.numBlocks, hll_higher_order_launch_params.threadsPerBlock, 0, 0,
+                     dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
+  #endif  // HLL
   #ifdef HLLD
   cuda_utilities::AutomaticLaunchParams static const hlld_higher_order_launch_params(
       mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -157,15 +157,19 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // EXACT
   #ifdef ROE
-  cuda_utilities::AutomaticLaunchParams static const roe_launch_params(Calculate_Roe_Fluxes_CUDA, n_cells);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
+  cuda_utilities::AutomaticLaunchParams static const roe_pcm_launch_params(
+      Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     roe_pcm_launch_params.get_numBlocks(),
+                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     roe_pcm_launch_params.get_numBlocks(),
+                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     roe_pcm_launch_params.get_numBlocks(),
+                     roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);
   #endif  // ROE
   #ifdef HLLC
@@ -299,14 +303,19 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // EXACT
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
+  cuda_utilities::AutomaticLaunchParams static const roe_higher_order_launch_params(
+      Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
+                     roe_higher_order_launch_params.get_numBlocks(),
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
+                     roe_higher_order_launch_params.get_numBlocks(),
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, roe_launch_params.get_numBlocks(),
-                     roe_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
+                     roe_higher_order_launch_params.get_numBlocks(),
+                     roe_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);
   #endif  // ROE
   #ifdef HLLC

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -145,10 +145,10 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
                      exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
                      exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
                      exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // EXACT
@@ -159,11 +159,11 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      roe_pcm_launch_params.get_numBlocks(),
                      roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
                      roe_pcm_launch_params.get_numBlocks(),
                      roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
                      roe_pcm_launch_params.get_numBlocks(),
                      roe_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);
@@ -174,10 +174,10 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
                      hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
                      hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
                      hllc_pcm_launch_params.numBlocks(), hllc_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
                      Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
@@ -188,11 +188,11 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      hll_pcm_launch_params.get_numBlocks(),
                      hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
                      hll_pcm_launch_params.get_numBlocks(),
                      hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
                      hll_pcm_launch_params.get_numBlocks(),
                      hll_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -193,16 +193,20 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // HLL
   #ifdef HLLD
-  cuda_utilities::AutomaticLaunchParams static const hlld_launch_params(mhd::Calculate_HLLD_Fluxes_CUDA, n_cells);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx,
-                     &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, n_cells, gama, 0, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry,
-                     &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, n_cells, gama, 1, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz,
-                     &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, n_cells, gama, 2, n_fields);
+  cuda_utilities::AutomaticLaunchParams static const hlld_pcm_launch_params(
+      mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lx, Q_Rx, &(dev_conserved[(grid_enum::magnetic_x)*n_cells]), F_x, nx, ny, nz, n_cells, gama,
+                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 1>),
+                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Ly, Q_Ry, &(dev_conserved[(grid_enum::magnetic_y)*n_cells]), F_y, nx, ny, nz, n_cells, gama,
+                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 2>),
+                     hlld_pcm_launch_params.numBlocks(), hlld_pcm_launch_params.threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lz, Q_Rz, &(dev_conserved[(grid_enum::magnetic_z)*n_cells]), F_z, nx, ny, nz, n_cells, gama,
+                     n_fields);
   #endif  // HLLD
   GPU_Error_Check();
 
@@ -312,26 +316,28 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      n_fields);
   #endif  // HLLC
   #ifdef HLL
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.get_numBlocks(),
-                     hll_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
-                     n_fields);
+  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
+                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0, n_fields);
+  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
+                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1, n_fields);
+  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, hll_launch_params.numBlocks, hll_launch_params.threadsPerBlock, 0, 0,
+                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2, n_fields);
   #endif  // HLLC
   #ifdef HLLD
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx,
-                     &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, n_cells, gama, 0, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry,
-                     &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, n_cells, gama, 1, n_fields);
-  hipLaunchKernelGGL(mhd::Calculate_HLLD_Fluxes_CUDA, hlld_launch_params.get_numBlocks(),
-                     hlld_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz,
-                     &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, n_cells, gama, 2, n_fields);
+  cuda_utilities::AutomaticLaunchParams static const hlld_higher_order_launch_params(
+      mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
+                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lx, Q_Rx, &(dev_conserved_half[(grid_enum::magnetic_x)*n_cells]), F_x, nx,
+                     ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
+                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Ly, Q_Ry, &(dev_conserved_half[(grid_enum::magnetic_y)*n_cells]), F_y, nx,
+                     ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
+                     hlld_higher_order_launch_params.numBlocks(), hlld_higher_order_launch_params.threadsPerBlock(), 0, 0,
+                     dev_conserved_half, Q_Lz, Q_Rz, &(dev_conserved_half[(grid_enum::magnetic_z)*n_cells]), F_z, nx,
+                     ny, nz, n_cells, gama, n_fields);
   #endif  // HLLD
   GPU_Error_Check();
 

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -145,16 +145,17 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
   // Step 2: Calculate first-order upwind fluxes
   #ifdef EXACT
-  cuda_utilities::AutomaticLaunchParams static const exact_launch_params(Calculate_Exact_Fluxes_CUDA, n_cells);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
-                     n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
-                     n_fields);
+  cuda_utilities::AutomaticLaunchParams static const exact_pcm_launch_params(
+      Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>),
+                     exact_pcm_launch_params.get_numBlocks(), exact_pcm_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved,
+                     Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // EXACT
   #ifdef ROE
   cuda_utilities::AutomaticLaunchParams static const roe_pcm_launch_params(
@@ -292,14 +293,19 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
   // Step 5: Calculate the fluxes again
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
+  cuda_utilities::AutomaticLaunchParams static const exact_higher_order_launch_params(
+      Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>, n_cells);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>),
+                     exact_higher_order_launch_params.get_numBlocks(),
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama, 1,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>),
+                     exact_higher_order_launch_params.get_numBlocks(),
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama,
                      n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, exact_launch_params.get_numBlocks(),
-                     exact_launch_params.get_threadsPerBlock(), 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama, 2,
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 2>),
+                     exact_higher_order_launch_params.get_numBlocks(),
+                     exact_higher_order_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved_half, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama,
                      n_fields);
   #endif  // EXACT
   #ifdef ROE

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -15,6 +15,7 @@
 #include "../reconstruction/plmp_cuda.h"
 #include "../reconstruction/ppmc_cuda.h"
 #include "../reconstruction/ppmp_cuda.h"
+#include "../reconstruction/reconstruction.h"
 #include "../riemann_solvers/exact_cuda.h"
 #include "../riemann_solvers/hllc_cuda.h"
 #include "../riemann_solvers/roe_cuda.h"
@@ -88,8 +89,8 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
                      n_fields);
 #endif
 #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,
+                     0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
 #endif
   GPU_Error_Check();
 

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -10,7 +10,6 @@
 #include "../hydro/hydro_cuda.h"
 #include "../integrators/simple_1D_cuda.h"
 #include "../io/io.h"
-#include "../reconstruction/pcm_cuda.h"
 #include "../reconstruction/plmc_cuda.h"
 #include "../reconstruction/plmp_cuda.h"
 #include "../reconstruction/ppmc_cuda.h"
@@ -54,11 +53,6 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
   }
 
 // Step 1: Do the reconstruction
-#ifdef PCM
-  hipLaunchKernelGGL(PCM_Reconstruction_1D, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, n_ghost, gama,
-                     n_fields);
-  GPU_Error_Check();
-#endif
 #ifdef PLMP
   hipLaunchKernelGGL(PLMP_cuda, dimGrid, dimBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, n_ghost, dx, dt, gama,
                      0, n_fields);

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -85,8 +85,8 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
                      0, n_fields);
 #endif
 #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama, 0,
-                     n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,
+                     0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
 #endif
 #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,

--- a/src/integrators/simple_1D_cuda.cu
+++ b/src/integrators/simple_1D_cuda.cu
@@ -81,8 +81,8 @@ void Simple_Algorithm_1D_CUDA(Real *d_conserved, int nx, int x_off, int n_ghost,
 
 // Step 2: Calculate the fluxes
 #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dimGrid, dimBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
 #endif
 #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dimGrid, dimBlock, 0,

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -13,6 +13,7 @@
 #include "../reconstruction/plmp_cuda.h"
 #include "../reconstruction/ppmc_cuda.h"
 #include "../reconstruction/ppmp_cuda.h"
+#include "../reconstruction/reconstruction.h"
 #include "../riemann_solvers/exact_cuda.h"
 #include "../riemann_solvers/hllc_cuda.h"
 #include "../riemann_solvers/roe_cuda.h"
@@ -96,10 +97,10 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
                      1, n_fields);
 #endif
 #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
 #endif
   GPU_Error_Check();
 

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -8,7 +8,6 @@
 #include "../global/global_cuda.h"
 #include "../hydro/hydro_cuda.h"
 #include "../integrators/simple_2D_cuda.h"
-#include "../reconstruction/pcm_cuda.h"
 #include "../reconstruction/plmc_cuda.h"
 #include "../reconstruction/plmp_cuda.h"
 #include "../reconstruction/ppmc_cuda.h"
@@ -55,10 +54,6 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
   }
 
 // Step 1: Do the reconstruction
-#ifdef PCM
-  hipLaunchKernelGGL(PCM_Reconstruction_2D, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, nx, ny,
-                     n_ghost, gama, n_fields);
-#endif
 #ifdef PLMP
   hipLaunchKernelGGL(PLMP_cuda, dim2dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, n_ghost, dx, dt,
                      gama, 0, n_fields);

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -85,10 +85,10 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
 
 // Step 2: Calculate the fluxes
 #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
 #endif
 #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid, dim1dBlock,

--- a/src/integrators/simple_2D_cuda.cu
+++ b/src/integrators/simple_2D_cuda.cu
@@ -91,10 +91,10 @@ void Simple_Algorithm_2D_CUDA(Real *d_conserved, int nx, int ny, int x_off, int 
                      gama, 1, n_fields);
 #endif
 #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim2dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama,
-                     1, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim2dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
 #endif
 #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim2dGrid,

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -17,6 +17,7 @@
   #include "../reconstruction/plmp_cuda.h"
   #include "../reconstruction/ppmc_cuda.h"
   #include "../reconstruction/ppmp_cuda.h"
+  #include "../reconstruction/reconstruction.h"
   #include "../riemann_solvers/exact_cuda.h"
   #include "../riemann_solvers/hll_cuda.h"
   #include "../riemann_solvers/hllc_cuda.h"
@@ -139,12 +140,12 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
                      2, n_fields);
   #endif  // ROE
   #ifdef HLLC
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
-  hipLaunchKernelGGL(Calculate_HLLC_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost,
-                     gama, 2, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 2>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
   hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -132,12 +132,12 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
                      gama, 2, n_fields);
   #endif  // EXACT
   #ifdef ROE
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama,
-                     1, n_fields);
-  hipLaunchKernelGGL(Calculate_Roe_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama,
-                     2, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 2>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // ROE
   #ifdef HLLC
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid,

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -148,12 +148,12 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
                      dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLLC
   #ifdef HLL
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost, gama,
-                     0, n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost, gama,
-                     1, n_fields);
-  hipLaunchKernelGGL(Calculate_HLL_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost, gama,
-                     2, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_HLL_Fluxes_CUDA<reconstruction::Kind::chosen, 2>), dim1dGrid, dim1dBlock,
+                     0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // HLL
   GPU_Error_Check();
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -12,7 +12,6 @@
   #include "../hydro/hydro_cuda.h"
   #include "../integrators/simple_3D_cuda.h"
   #include "../io/io.h"
-  #include "../reconstruction/pcm_cuda.h"
   #include "../reconstruction/plmc_cuda.h"
   #include "../reconstruction/plmp_cuda.h"
   #include "../reconstruction/ppmc_cuda.h"
@@ -85,12 +84,7 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
   GPU_Error_Check(cudaMemcpy(dev_grav_potential, temp_potential, n_cells * sizeof(Real), cudaMemcpyHostToDevice));
   #endif
 
-  // Step 1: Construct left and right interface values using updated conserved
-  // variables
-  #ifdef PCM
-  hipLaunchKernelGGL(PCM_Reconstruction_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry, Q_Lz,
-                     Q_Rz, nx, ny, nz, n_ghost, gama, n_fields);
-  #endif
+  // Step 1: Construct left and right interface values using updated conserved variables
   #ifdef PLMP
   hipLaunchKernelGGL(PLMP_cuda, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, nx, ny, nz, n_ghost, dx, dt,
                      gama, 0, n_fields);

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -124,12 +124,12 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
 
   // Step 2: Calculate the fluxes
   #ifdef EXACT
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_ghost,
-                     gama, 0, n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_ghost,
-                     gama, 1, n_fields);
-  hipLaunchKernelGGL(Calculate_Exact_Fluxes_CUDA, dim1dGrid, dim1dBlock, 0, 0, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_ghost,
-                     gama, 2, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, F_x, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Ly, Q_Ry, F_y, nx, ny, nz, n_cells, gama, n_fields);
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 2>), dim1dGrid,
+                     dim1dBlock, 0, 0, dev_conserved, Q_Lz, Q_Rz, F_z, nx, ny, nz, n_cells, gama, n_fields);
   #endif  // EXACT
   #ifdef ROE
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>), dim1dGrid, dim1dBlock,

--- a/src/reconstruction/pcm_cuda.h
+++ b/src/reconstruction/pcm_cuda.h
@@ -58,7 +58,6 @@ reconstruction::InterfaceState __device__ __host__ inline PCM_Reconstruction(Rea
 #endif  // SCALAR
 
   return interface_state;
-  // repeat function call for second side
 }
 }  // namespace reconstruction
 #endif  // PCM_CUDA_H

--- a/src/reconstruction/pcm_cuda.h
+++ b/src/reconstruction/pcm_cuda.h
@@ -9,6 +9,20 @@
 
 namespace reconstruction
 {
+  /*!
+ * \brief Perform PCM reconstruction for a given cell
+ *
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in] dev_conserved The converved variable array
+ * \param[in] xid The x-direction cell id
+ * \param[in] yid The y-direction cell id
+ * \param[in] zid The z-direction cell id
+ * \param[in] nx The number of cells in the x-direction
+ * \param[in] ny The number of cells in the y-direction
+ * \param[in] n_cells The total number of cells
+ * \param[in] gamma The adiabatic index
+ * \return reconstruction::InterfaceState The interface state at xid, yid, zid
+ */
 template <size_t direction>
 reconstruction::InterfaceState __device__ __host__ inline PCM_Reconstruction(Real const *dev_conserved,
                                                                              size_t const xid, size_t const yid,

--- a/src/reconstruction/pcm_cuda.h
+++ b/src/reconstruction/pcm_cuda.h
@@ -4,6 +4,9 @@
 #ifndef PCM_CUDA_H
 #define PCM_CUDA_H
 
+#include "../utils/basic_structs.h"
+#include "../utils/hydro_utilities.h"
+
 __global__ void PCM_Reconstruction_1D(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int n_cells,
                                       int n_ghost, Real gamma, int n_fields);
 
@@ -16,4 +19,46 @@ __global__ void PCM_Reconstruction_3D(Real *dev_conserved, Real *dev_bounds_Lx, 
                                       Real *dev_bounds_Rz, int nx, int ny, int nz, int n_ghost, Real gamma,
                                       int n_fields);
 
+namespace reconstruction
+{
+template <size_t direction>
+reconstruction::InterfaceState __device__ __host__ inline PCM_Reconstruction(Real const *dev_conserved,
+                                                                             size_t const xid, size_t const yid,
+                                                                             size_t const zid, size_t const nx,
+                                                                             size_t const ny, size_t const n_cells,
+                                                                             Real const gamma)
+{
+  // Load cell conserved
+  hydro_utilities::Conserved conserved_data =
+      hydro_utilities::Load_Cell_Conserved<direction>(dev_conserved, xid, yid, zid, nx, ny, n_cells);
+
+  // Convert cell to primitives
+  hydro_utilities::Primitive primitive_data = hydro_utilities::Conserved_2_Primitive(conserved_data, gamma);
+
+  // Integrate cell values into an InterfaceState
+  reconstruction::InterfaceState interface_state;
+
+  interface_state.density  = conserved_data.density;
+  interface_state.velocity = primitive_data.velocity;
+  interface_state.momentum = conserved_data.momentum;
+  interface_state.pressure = primitive_data.pressure;
+  interface_state.energy   = conserved_data.energy;
+
+#ifdef MHD
+  interface_state.total_pressure = mhd::utils::computeTotalPressure(primitive_data.pressure, conserved_data.magnetic);
+  interface_state.magnetic       = conserved_data.magnetic;
+#endif  // MHD
+#ifdef DE
+  interface_state.gas_energy_specific = primitive_data.gas_energy_specific;
+#endif  // DE
+#ifdef SCALAR
+  for (size_t i = 0; i < grid_enum::nscalars; i++) {
+    interface_state.scalar_specific[i] = primitive_data.scalar_specific[i];
+  }
+#endif  // SCALAR
+
+  return interface_state;
+  // repeat function call for second side
+}
+}  // namespace reconstruction
 #endif  // PCM_CUDA_H

--- a/src/reconstruction/pcm_cuda.h
+++ b/src/reconstruction/pcm_cuda.h
@@ -9,7 +9,7 @@
 
 namespace reconstruction
 {
-  /*!
+/*!
  * \brief Perform PCM reconstruction for a given cell
  *
  * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z

--- a/src/reconstruction/pcm_cuda.h
+++ b/src/reconstruction/pcm_cuda.h
@@ -1,23 +1,11 @@
 /*! \file pcm_cuda.h
- *  \brief Declarations of the cuda pcm kernels */
+ *  \brief Declarations of the pcm function */
 
 #ifndef PCM_CUDA_H
 #define PCM_CUDA_H
 
 #include "../utils/basic_structs.h"
 #include "../utils/hydro_utilities.h"
-
-__global__ void PCM_Reconstruction_1D(Real *dev_conserved, Real *dev_bounds_L, Real *dev_bounds_R, int n_cells,
-                                      int n_ghost, Real gamma, int n_fields);
-
-__global__ void PCM_Reconstruction_2D(Real *dev_conserved, Real *dev_bounds_Lx, Real *dev_bounds_Rx,
-                                      Real *dev_bounds_Ly, Real *dev_bounds_Ry, int nx, int ny, int n_ghost, Real gamma,
-                                      int n_fields);
-
-__global__ void PCM_Reconstruction_3D(Real *dev_conserved, Real *dev_bounds_Lx, Real *dev_bounds_Rx,
-                                      Real *dev_bounds_Ly, Real *dev_bounds_Ry, Real *dev_bounds_Lz,
-                                      Real *dev_bounds_Rz, int nx, int ny, int nz, int n_ghost, Real gamma,
-                                      int n_fields);
 
 namespace reconstruction
 {

--- a/src/reconstruction/pcm_cuda_tests.cu
+++ b/src/reconstruction/pcm_cuda_tests.cu
@@ -16,29 +16,6 @@
 #include "../utils/basic_structs.h"
 #include "../utils/testing_utilities.h"
 
-void Check_Interface(reconstruction::InterfaceState const &test_data,
-                     reconstruction::InterfaceState const &fiducial_data, size_t const direction)
-{
-  std::string const message = "Direction " + std::to_string(direction);
-
-  testing_utilities::Check_Results(test_data.density, fiducial_data.density, "density " + message);
-  testing_utilities::Check_Results(test_data.energy, fiducial_data.energy, "energy " + message);
-  testing_utilities::Check_Results(test_data.pressure, fiducial_data.pressure, "pressure " + message);
-  testing_utilities::Check_Results(test_data.velocity.x, fiducial_data.velocity.x, "velocity.x " + message);
-  testing_utilities::Check_Results(test_data.velocity.y, fiducial_data.velocity.y, "velocity.y " + message);
-  testing_utilities::Check_Results(test_data.velocity.z, fiducial_data.velocity.z, "velocity.z " + message);
-  testing_utilities::Check_Results(test_data.momentum.x, fiducial_data.momentum.x, "momentum.x " + message);
-  testing_utilities::Check_Results(test_data.momentum.y, fiducial_data.momentum.y, "momentum.y " + message);
-  testing_utilities::Check_Results(test_data.momentum.z, fiducial_data.momentum.z, "momentum.z " + message);
-
-#ifdef MHD
-  testing_utilities::Check_Results(test_data.total_pressure, fiducial_data.total_pressure, "total_pressure" + message);
-  testing_utilities::Check_Results(test_data.magnetic.x, fiducial_data.magnetic.x, "magnetic.x " + message);
-  testing_utilities::Check_Results(test_data.magnetic.y, fiducial_data.magnetic.y, "magnetic.y " + message);
-  testing_utilities::Check_Results(test_data.magnetic.z, fiducial_data.magnetic.z, "magnetic.z " + message);
-#endif  // MHD
-}
-
 TEST(tAllReconstructionPCM, CorrectInputExpectCorrectOutput)
 {
   // Set up PRNG to use
@@ -83,7 +60,7 @@ TEST(tAllReconstructionPCM, CorrectInputExpectCorrectOutput)
           9.9999999999999995e-21, {3.6497594046359176, 1.9592441096173099, 0.9613575629289659},    9.041794778299586};
 
   // Check correctness
-  Check_Interface(test_interface_0, fiducial_interface_0, 0);
-  Check_Interface(test_interface_1, fiducial_interface_1, 1);
-  Check_Interface(test_interface_2, fiducial_interface_2, 2);
+  testing_utilities::Check_Interface(test_interface_0, fiducial_interface_0, 0);
+  testing_utilities::Check_Interface(test_interface_1, fiducial_interface_1, 1);
+  testing_utilities::Check_Interface(test_interface_2, fiducial_interface_2, 2);
 }

--- a/src/reconstruction/pcm_cuda_tests.cu
+++ b/src/reconstruction/pcm_cuda_tests.cu
@@ -1,0 +1,89 @@
+/*!
+ * \file pcm_cuda_tests.cu
+ * \brief Contains the tests for the code in pcm_cuda.h and pcm_cuda.cu
+ */
+
+// STL Includes
+#include <random>
+
+// External Includes
+#include <gtest/gtest.h>  // Include GoogleTest and related libraries/headers
+
+// Local Includes
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+#include "../reconstruction/pcm_cuda.h"
+#include "../utils/basic_structs.h"
+#include "../utils/testing_utilities.h"
+
+void Check_Interface(reconstruction::InterfaceState const &test_data,
+                     reconstruction::InterfaceState const &fiducial_data, size_t const direction)
+{
+  std::string const message = "Direction " + std::to_string(direction);
+
+  testing_utilities::Check_Results(test_data.density, fiducial_data.density, "density " + message);
+  testing_utilities::Check_Results(test_data.energy, fiducial_data.energy, "energy " + message);
+  testing_utilities::Check_Results(test_data.pressure, fiducial_data.pressure, "pressure " + message);
+  testing_utilities::Check_Results(test_data.velocity.x, fiducial_data.velocity.x, "velocity.x " + message);
+  testing_utilities::Check_Results(test_data.velocity.y, fiducial_data.velocity.y, "velocity.y " + message);
+  testing_utilities::Check_Results(test_data.velocity.z, fiducial_data.velocity.z, "velocity.z " + message);
+  testing_utilities::Check_Results(test_data.momentum.x, fiducial_data.momentum.x, "momentum.x " + message);
+  testing_utilities::Check_Results(test_data.momentum.y, fiducial_data.momentum.y, "momentum.y " + message);
+  testing_utilities::Check_Results(test_data.momentum.z, fiducial_data.momentum.z, "momentum.z " + message);
+
+#ifdef MHD
+  testing_utilities::Check_Results(test_data.total_pressure, fiducial_data.total_pressure, "total_pressure" + message);
+  testing_utilities::Check_Results(test_data.magnetic.x, fiducial_data.magnetic.x, "magnetic.x " + message);
+  testing_utilities::Check_Results(test_data.magnetic.y, fiducial_data.magnetic.y, "magnetic.y " + message);
+  testing_utilities::Check_Results(test_data.magnetic.z, fiducial_data.magnetic.z, "magnetic.z " + message);
+#endif  // MHD
+}
+
+TEST(tAllReconstructionPCM, CorrectInputExpectCorrectOutput)
+{
+  // Set up PRNG to use
+  std::mt19937_64 prng(42);
+  std::uniform_real_distribution<double> doubleRand(0.1, 5);
+
+  // Mock up needed information
+  size_t const nx      = 3;
+  size_t const ny      = 3;
+  size_t const nz      = 3;
+  size_t const xid     = 1;
+  size_t const yid     = 1;
+  size_t const zid     = 1;
+  size_t const n_cells = nx * ny * nz;
+  double const dx      = doubleRand(prng);
+  double const dt      = doubleRand(prng);
+  double const gamma   = 5.0 / 3.0;
+
+  // Setup host grid. Fill host grid with random values and randomly assign values
+  std::vector<double> host_grid(n_cells * grid_enum::num_fields);
+  for (Real &val : host_grid) {
+    val = doubleRand(prng);
+  }
+
+  // Test each direction
+  reconstruction::InterfaceState test_interface_0 =
+      reconstruction::PCM_Reconstruction<0>(host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma);
+  reconstruction::InterfaceState test_interface_1 =
+      reconstruction::PCM_Reconstruction<1>(host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma);
+  reconstruction::InterfaceState test_interface_2 =
+      reconstruction::PCM_Reconstruction<2>(host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma);
+
+  // Fiducial values
+  reconstruction::InterfaceState fiducial_interface_0{
+      4.7339225843521469,     {0.57689124878761044, 0.81171783817468879, 0.78775336609408397}, 2.140751210734309,
+      9.9999999999999995e-21, {1.9592441096173099, 0.9613575629289659, 3.6497594046359176},    9.0417947782995878},
+      fiducial_interface_1{
+          4.7339225843521469,     {0.81171783817468879, 0.78775336609408397, 0.57689124878761044}, 2.140751210734309,
+          9.9999999999999995e-21, {0.9613575629289659, 3.6497594046359176, 1.9592441096173099},    9.041794778299586},
+      fiducial_interface_2{
+          4.7339225843521469,     {0.78775336609408397, 0.57689124878761044, 0.81171783817468879}, 2.140751210734309,
+          9.9999999999999995e-21, {3.6497594046359176, 1.9592441096173099, 0.9613575629289659},    9.041794778299586};
+
+  // Check correctness
+  Check_Interface(test_interface_0, fiducial_interface_0, 0);
+  Check_Interface(test_interface_1, fiducial_interface_1, 1);
+  Check_Interface(test_interface_2, fiducial_interface_2, 2);
+}

--- a/src/reconstruction/plmc_cuda_tests.cu
+++ b/src/reconstruction/plmc_cuda_tests.cu
@@ -148,7 +148,6 @@ TEST(tHYDROPlmcReconstructor, CorrectInputExpectCorrectOutput)
     cuda_utilities::DeviceVector<double> dev_interface_right(host_grid.size(), true);
 
     // Launch kernel
-    std::cout << "direction = " << direction << std::endl;
     switch (direction) {
       case 0:
         hipLaunchKernelGGL(PLMC_cuda<0>, dev_grid.size(), 1, 0, 0, dev_grid.data(), dev_interface_left.data(),

--- a/src/reconstruction/reconstruction.h
+++ b/src/reconstruction/reconstruction.h
@@ -13,6 +13,23 @@
 
 namespace reconstruction
 {
+/*!
+ * \brief Compute the interface states
+ *
+ * \tparam reconstruction_order What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in] dev_conserved
+ * \param[in] xid
+ * \param[in] yid
+ * \param[in] zid
+ * \param[in] nx
+ * \param[in] ny
+ * \param[in] n_cells
+ * \param[in] gamma
+ * \param[out] left_interface
+ * \param[out] right_interface
+ */
 template <int reconstruction_order, size_t direction>
 auto __device__ __host__ inline Reconstruct_Interface_States(Real const *dev_conserved, size_t const xid,
                                                              size_t const yid, size_t const zid, size_t const nx,

--- a/src/reconstruction/reconstruction_internals.h
+++ b/src/reconstruction/reconstruction_internals.h
@@ -249,8 +249,25 @@ bool __device__ __host__ __inline__ Riemann_Thread_Guard(size_t const nx, size_t
     order = 3;
   }
 
-  return xid < order - 1 or yid < order - 1 or zid < order - 1 or xid >= nx - order + 1 or yid >= ny - order + 1 or
-         zid >= nz - order + 1;
+  // X check
+  bool out_of_bounds_thread = xid < order - 1 or xid >= nx - order + 1;
+
+  // Y check, only used for 2D and 3D
+  if (ny > 1) {
+    out_of_bounds_thread = yid < order - 1 or yid >= ny - order + 1 or out_of_bounds_thread;
+  }
+
+  // z check, only used for 3D
+  if (nz > 1) {
+    out_of_bounds_thread = zid < order - 1 or zid >= nz - order + 1 or out_of_bounds_thread;
+  }
+  // This is needed in the case that nz == 1 to avoid overrun
+  else {
+    out_of_bounds_thread = zid >= nz or out_of_bounds_thread;
+  }
+
+  return out_of_bounds_thread;
+  return out_of_bounds_thread;
 }
 // =====================================================================================================================
 

--- a/src/reconstruction/reconstruction_internals.h
+++ b/src/reconstruction/reconstruction_internals.h
@@ -267,7 +267,6 @@ bool __device__ __host__ __inline__ Riemann_Thread_Guard(size_t const nx, size_t
   }
 
   return out_of_bounds_thread;
-  return out_of_bounds_thread;
 }
 // =====================================================================================================================
 

--- a/src/reconstruction/reconstruction_internals.h
+++ b/src/reconstruction/reconstruction_internals.h
@@ -248,18 +248,19 @@ bool __device__ __host__ __inline__ Riemann_Thread_Guard(size_t const nx, size_t
   } else if constexpr (reconstruction == reconstruction::Kind::ppmc or reconstruction == reconstruction::Kind::ppmp) {
     order = 3;
   }
-
+  bool out_of_bounds_thread = false;
   // X check
-  bool out_of_bounds_thread = xid < order - 1 or xid >= nx - order + 1;
-
+  if (nx > 1) {
+    out_of_bounds_thread = xid < order - 1 or xid >= nx - order or out_of_bounds_thread;
+  }
   // Y check, only used for 2D and 3D
   if (ny > 1) {
-    out_of_bounds_thread = yid < order - 1 or yid >= ny - order + 1 or out_of_bounds_thread;
+    out_of_bounds_thread = yid < order - 1 or yid >= ny - order or out_of_bounds_thread;
   }
 
   // z check, only used for 3D
   if (nz > 1) {
-    out_of_bounds_thread = zid < order - 1 or zid >= nz - order + 1 or out_of_bounds_thread;
+    out_of_bounds_thread = zid < order - 1 or zid >= nz - order or out_of_bounds_thread;
   }
   // This is needed in the case that nz == 1 to avoid overrun
   else {

--- a/src/reconstruction/reconstruction_internals.h
+++ b/src/reconstruction/reconstruction_internals.h
@@ -224,6 +224,38 @@ hydro_utilities::Primitive __device__ __host__ __inline__ Load_Data(
 
 // =====================================================================================================================
 /*!
+ * \brief Determine if a thread is within the allowed range
+ *
+ * \tparam reconstruction A member of reconstruction::Kind used to determine the order of reconstruction
+ * \param nx The number of cells in the X-direction
+ * \param ny The number of cells in the Y-direction
+ * \param nz The number of cells in the Z-direction
+ * \param xid The X thread index
+ * \param yid The Y thread index
+ * \param zid The Z thread index
+ * \return true The thread is NOT in the allowed range
+ * \return false The thread is in the allowed range
+ */
+template <int reconstruction>
+bool __device__ __host__ __inline__ Riemann_Thread_Guard(size_t const nx, size_t const ny, size_t const nz,
+                                                         size_t const xid, size_t const yid, size_t const zid)
+{
+  int order;
+  if constexpr (reconstruction == reconstruction::Kind::pcm) {
+    order = 1;
+  } else if constexpr (reconstruction == reconstruction::Kind::plmc or reconstruction == reconstruction::Kind::plmp) {
+    order = 2;
+  } else if constexpr (reconstruction == reconstruction::Kind::ppmc or reconstruction == reconstruction::Kind::ppmp) {
+    order = 3;
+  }
+
+  return xid < order - 1 or yid < order - 1 or zid < order - 1 or xid >= nx - order + 1 or yid >= ny - order + 1 or
+         zid >= nz - order + 1;
+}
+// =====================================================================================================================
+
+// =====================================================================================================================
+/*!
  * \brief Compute a simple slope. Equation is `coef * (right - left)`.
  *
  * \param[in] left The data with the lower index (on the "left" side)

--- a/src/reconstruction/reconstruction_internals_tests.cu
+++ b/src/reconstruction/reconstruction_internals_tests.cu
@@ -207,13 +207,13 @@ TEST(tALLReconstructionRiemannThreadGuard, CorrectInputExpectCorrectOutput)
 {
   // Test parameters
   int const order = 3;
-  int const nx    = 5;
-  int const ny    = 5;
-  int const nz    = 5;
+  int const nx    = 6;
+  int const ny    = 6;
+  int const nz    = 6;
 
   // fiducial data
   std::vector<int> fiducial_vals(nx * ny * nz, 1);
-  fiducial_vals.at(62) = 0;
+  fiducial_vals.at(86) = 0;
 
   // loop through all values of the indices and check them
   for (int xid = 0; xid < nx; xid++) {

--- a/src/reconstruction/reconstruction_internals_tests.cu
+++ b/src/reconstruction/reconstruction_internals_tests.cu
@@ -196,7 +196,35 @@ TEST(tALLReconstructionThreadGuard, CorrectInputExpectCorrectOutput)
 
         // Compare
         int id = cuda_utilities::compute1DIndex(xid, yid, zid, nx, ny);
-        ASSERT_EQ(test_val, fiducial_vals.at(id))
+        EXPECT_EQ(test_val, fiducial_vals.at(id))
+            << "Test value not equal to fiducial value at id = " << id << std::endl;
+      }
+    }
+  }
+}
+
+TEST(tALLReconstructionRiemannThreadGuard, CorrectInputExpectCorrectOutput)
+{
+  // Test parameters
+  int const order = 3;
+  int const nx    = 5;
+  int const ny    = 5;
+  int const nz    = 5;
+
+  // fiducial data
+  std::vector<int> fiducial_vals(nx * ny * nz, 1);
+  fiducial_vals.at(62) = 0;
+
+  // loop through all values of the indices and check them
+  for (int xid = 0; xid < nx; xid++) {
+    for (int yid = 0; yid < ny; yid++) {
+      for (int zid = 0; zid < nz; zid++) {
+        // Get the test value
+        bool test_val = reconstruction::Riemann_Thread_Guard<order>(nx, ny, nz, xid, yid, zid);
+
+        // Compare
+        int id = cuda_utilities::compute1DIndex(xid, yid, zid, nx, ny);
+        EXPECT_EQ(test_val, fiducial_vals.at(id))
             << "Test value not equal to fiducial value at id = " << id << std::endl;
       }
     }

--- a/src/reconstruction/reconstruction_tests.cu
+++ b/src/reconstruction/reconstruction_tests.cu
@@ -1,0 +1,81 @@
+/*!
+ * \file pcm_cuda_tests.cu
+ * \brief Contains the tests for the code in pcm_cuda.h and pcm_cuda.cu
+ */
+
+// STL Includes
+#include <random>
+
+// External Includes
+#include <gtest/gtest.h>  // Include GoogleTest and related libraries/headers
+
+// Local Includes
+#include "../global/global.h"
+#include "../global/global_cuda.h"
+#include "../io/io.h"
+#include "../reconstruction/reconstruction.h"
+#include "../utils/basic_structs.h"
+#include "../utils/testing_utilities.h"
+TEST(tAllReconstructInterfaceStates, PcmCorrectInputExpectCorrectOutput)
+{
+  // Set up PRNG to use
+  std::mt19937_64 prng(42);
+  std::uniform_real_distribution<double> doubleRand(0.1, 5);
+
+  // Mock up needed information
+  size_t const nx      = 7;
+  size_t const ny      = 7;
+  size_t const nz      = 7;
+  size_t const xid     = 3;
+  size_t const yid     = 3;
+  size_t const zid     = 3;
+  size_t const n_cells = nx * ny * nz;
+  double const dx      = doubleRand(prng);
+  double const dt      = doubleRand(prng);
+  double const gamma   = 5.0 / 3.0;
+
+  // Setup host grid. Fill host grid with random values and randomly assign values
+  std::vector<double> host_grid(n_cells * grid_enum::num_fields);
+  for (Real &val : host_grid) {
+    val = doubleRand(prng);
+  }
+
+  // Test each direction
+  reconstruction::InterfaceState test_interface_pcm_l_0, test_interface_pcm_r_0, test_interface_pcm_l_1,
+      test_interface_pcm_r_1, test_interface_pcm_l_2, test_interface_pcm_r_2;
+
+  reconstruction::Reconstruct_Interface_States<reconstruction::Kind::pcm, 0>(
+      host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma, test_interface_pcm_l_0, test_interface_pcm_r_0);
+  reconstruction::Reconstruct_Interface_States<reconstruction::Kind::pcm, 1>(
+      host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma, test_interface_pcm_l_1, test_interface_pcm_r_1);
+  reconstruction::Reconstruct_Interface_States<reconstruction::Kind::pcm, 2>(
+      host_grid.data(), xid, yid, zid, nx, ny, n_cells, gamma, test_interface_pcm_l_2, test_interface_pcm_r_2);
+
+  // Fiducial values
+  reconstruction::InterfaceState fiducial_interface_pcm_l_0{
+      1.6206985712721595,     {1.9275471960012214, 2.0380692774425846, 1.9771827902007457}, 4.5791453055608384,
+      9.9999999999999995e-21, {4.1622274705137627, 2.1906071705977261, 3.1997462690190144}, 16.180636739137334},
+      fiducial_interface_pcm_r_0{
+          1.5162490166443841,     {0.74079082506491523, 1.4295471037207337, 0.49525487240256766}, 1.6382470722683291,
+          9.9999999999999995e-21, {2.6539699941465473, 2.6775840565878508, 2.4794718891665037},   10.180396979545293},
+      fiducial_interface_pcm_l_1{
+          1.6206985712721595,     {2.0380692774425846, 1.9771827902007457, 1.9275471960012214}, 4.5791453055608384,
+          9.9999999999999995e-21, {2.1906071705977261, 3.1997462690190144, 4.1622274705137627}, 16.180636739137338},
+      fiducial_interface_pcm_r_1{
+          3.8412847012400144,     {1.1260155024295584, 0.37985902941387084, 0.31356489904284668}, 4.1037970369599064,
+          9.9999999999999995e-21, {2.7361340285756826, 4.5077114382460621, 3.2694920805403553},   19.247735148770136},
+      fiducial_interface_pcm_l_2{
+          1.6206985712721595,     {1.9771827902007457, 1.9275471960012214, 2.0380692774425846}, 4.5791453055608384,
+          9.9999999999999995e-21, {3.1997462690190144, 4.1622274705137627, 2.1906071705977261}, 16.180636739137334},
+      fiducial_interface_pcm_r_2{
+          0.75619040256911529,    {4.3870709307030475, 0.53201818469160067, 3.0376042247856248}, 4.181424078824616,
+          9.9999999999999995e-21, {3.0291890161755175, 3.4009589976457022, 2.1042141607876181},  12.585112716922399};
+
+  // Check correctness
+  testing_utilities::Check_Interface(test_interface_pcm_l_0, fiducial_interface_pcm_l_0, 0);
+  testing_utilities::Check_Interface(test_interface_pcm_r_0, fiducial_interface_pcm_r_0, 0);
+  testing_utilities::Check_Interface(test_interface_pcm_l_1, fiducial_interface_pcm_l_1, 0);
+  testing_utilities::Check_Interface(test_interface_pcm_r_1, fiducial_interface_pcm_r_1, 0);
+  testing_utilities::Check_Interface(test_interface_pcm_l_2, fiducial_interface_pcm_l_2, 0);
+  testing_utilities::Check_Interface(test_interface_pcm_r_2, fiducial_interface_pcm_r_2, 0);
+}

--- a/src/riemann_solvers/exact_cuda.cu
+++ b/src/riemann_solvers/exact_cuda.cu
@@ -45,10 +45,6 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real cons
                         // energy
   Real vm, pm;          // velocity and pressure in the star region
 
-#ifdef DE
-  Real E_kin, E, dge;
-#endif
-
   // Thread guard to avoid overrun
   if (not reconstruction::Riemann_Thread_Guard<reconstruction>(nx, ny, nz, xid, yid, zid)) {
     // =========================

--- a/src/riemann_solvers/exact_cuda.cu
+++ b/src/riemann_solvers/exact_cuda.cu
@@ -62,18 +62,19 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real cons
       left_state.velocity.y() = dev_bounds_L[o2 * n_cells + tid] / left_state.density;
       left_state.velocity.z() = dev_bounds_L[o3 * n_cells + tid] / left_state.density;
 #ifdef DE  // PRESSURE_DE
-    E     = dev_bounds_L[4 * n_cells + tid];
-    E_kin = 0.5 * left_state.density *
-            (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-             left_state.velocity.z() * left_state.velocity.z());
-    dge                 = dev_bounds_L[(n_fields - 1) * n_cells + tid];
-    left_state.pressure = hydro_utilities::Get_Pressure_From_DE(E, E - E_kin, dge, gamma);
+      E     = dev_bounds_L[4 * n_cells + tid];
+      E_kin = 0.5 * left_state.density *
+              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+               left_state.velocity.z() * left_state.velocity.z());
+      dge                 = dev_bounds_L[(n_fields - 1) * n_cells + tid];
+      left_state.pressure = hydro_utilities::Get_Pressure_From_DE(E, E - E_kin, dge, gamma);
 #else
-    left_state.pressure = (dev_bounds_L[4 * n_cells + tid] - 0.5 * left_state.density *
-                                                                 (left_state.velocity.x() * left_state.velocity.x() +
-                                                                  left_state.velocity.y() * left_state.velocity.y() +
-                                                                  left_state.velocity.z() * left_state.velocity.z())) *
-                          (gamma - 1.0);
+      left_state.pressure =
+          (dev_bounds_L[4 * n_cells + tid] -
+           0.5 * left_state.density *
+               (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+                left_state.velocity.z() * left_state.velocity.z())) *
+          (gamma - 1.0);
 #endif  // PRESSURE_DE
       left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
@@ -84,24 +85,25 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real cons
 #ifdef DE
       left_state.gas_energy_specific = dge / left_state.density;
 #endif
-    right_state.density      = dev_bounds_R[tid];
-    right_state.velocity.x() = dev_bounds_R[o1 * n_cells + tid] / right_state.density;
-    right_state.velocity.y() = dev_bounds_R[o2 * n_cells + tid] / right_state.density;
-    right_state.velocity.z() = dev_bounds_R[o3 * n_cells + tid] / right_state.density;
+      right_state.density      = dev_bounds_R[tid];
+      right_state.velocity.x() = dev_bounds_R[o1 * n_cells + tid] / right_state.density;
+      right_state.velocity.y() = dev_bounds_R[o2 * n_cells + tid] / right_state.density;
+      right_state.velocity.z() = dev_bounds_R[o3 * n_cells + tid] / right_state.density;
 #ifdef DE  // PRESSURE_DE
-    E     = dev_bounds_R[4 * n_cells + tid];
-    E_kin = 0.5 * right_state.density *
-            (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
-             right_state.velocity.z() * right_state.velocity.z());
-    dge                  = dev_bounds_R[(n_fields - 1) * n_cells + tid];
-    right_state.pressure = hydro_utilities::Get_Pressure_From_DE(E, E - E_kin, dge, gamma);
+      E = dev_bounds_R[4 * n_cells + tid];
+      E_kin =
+          0.5 * right_state.density *
+          (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
+           right_state.velocity.z() * right_state.velocity.z());
+      dge                  = dev_bounds_R[(n_fields - 1) * n_cells + tid];
+      right_state.pressure = hydro_utilities::Get_Pressure_From_DE(E, E - E_kin, dge, gamma);
 #else
-    right_state.pressure =
-        (dev_bounds_R[4 * n_cells + tid] - 0.5 * right_state.density *
-                                               (right_state.velocity.x() * right_state.velocity.x() +
-                                                right_state.velocity.y() * right_state.velocity.y() +
-                                                right_state.velocity.z() * right_state.velocity.z())) *
-        (gamma - 1.0);
+      right_state.pressure =
+          (dev_bounds_R[4 * n_cells + tid] - 0.5 * right_state.density *
+                                                 (right_state.velocity.x() * right_state.velocity.x() +
+                                                  right_state.velocity.y() * right_state.velocity.y() +
+                                                  right_state.velocity.z() * right_state.velocity.z())) *
+          (gamma - 1.0);
 #endif  // PRESSURE_DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR

--- a/src/riemann_solvers/exact_cuda.cu
+++ b/src/riemann_solvers/exact_cuda.cu
@@ -62,11 +62,12 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real cons
       left_state.velocity.y() = dev_bounds_L[o2 * n_cells + tid] / left_state.density;
       left_state.velocity.z() = dev_bounds_L[o3 * n_cells + tid] / left_state.density;
 #ifdef DE  // PRESSURE_DE
-      E     = dev_bounds_L[4 * n_cells + tid];
-      E_kin = 0.5 * left_state.density *
-              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-               left_state.velocity.z() * left_state.velocity.z());
-      dge                 = dev_bounds_L[(n_fields - 1) * n_cells + tid];
+      Real E = dev_bounds_L[4 * n_cells + tid];
+      Real E_kin =
+          0.5 * left_state.density *
+          (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+           left_state.velocity.z() * left_state.velocity.z());
+      Real dge            = dev_bounds_L[(n_fields - 1) * n_cells + tid];
       left_state.pressure = hydro_utilities::Get_Pressure_From_DE(E, E - E_kin, dge, gamma);
 #else
       left_state.pressure =

--- a/src/riemann_solvers/exact_cuda.cu
+++ b/src/riemann_solvers/exact_cuda.cu
@@ -11,33 +11,29 @@
 #include "../utils/gpu.hpp"
 #include "../utils/hydro_utilities.h"
 
-/*! \fn Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int
- * n_fields) \brief Exact Riemann solver based on the Fortran code given in
- * Sec. 4.9 of Toro (1999). */
-__global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                            int nz, int n_ghost, Real gamma, int dir, int n_fields)
+template <int reconstruction, uint direction>
+__global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                            Real const *dev_bounds_R, Real *dev_flux, int const nx, int const ny,
+                                            int const nz, int const n_cells, Real const gamma, int const n_fields)
 {
   // get a thread index
   int blockId = blockIdx.x + blockIdx.y * gridDim.x;
   int tid     = threadIdx.x + blockId * blockDim.x;
-  int zid     = tid / (nx * ny);
-  int yid     = (tid - zid * nx * ny) / nx;
-  int xid     = tid - zid * nx * ny - yid * nx;
+  int xid, yid, zid;
+  cuda_utilities::compute3DIndices(tid, nx, ny, xid, yid, zid);
 
-  int n_cells = nx * ny * nz;
   int o1, o2, o3;
-  if (dir == 0) {
+  if constexpr (direction == 0) {
     o1 = 1;
     o2 = 2;
     o3 = 3;
   }
-  if (dir == 1) {
+  if constexpr (direction == 1) {
     o1 = 2;
     o2 = 3;
     o3 = 1;
   }
-  if (dir == 2) {
+  if constexpr (direction == 2) {
     o1 = 3;
     o2 = 1;
     o3 = 2;
@@ -53,14 +49,22 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
   Real E_kin, E, dge;
 #endif
 
-  // Each thread executes the solver independently
-  // if (xid > n_ghost-3 && xid < nx-n_ghost+1 && yid < ny && zid < nz)
-  if (xid < nx && yid < ny && zid < nz) {
-    // retrieve primitive variables
-    left_state.density      = dev_bounds_L[tid];
-    left_state.velocity.x() = dev_bounds_L[o1 * n_cells + tid] / left_state.density;
-    left_state.velocity.y() = dev_bounds_L[o2 * n_cells + tid] / left_state.density;
-    left_state.velocity.z() = dev_bounds_L[o3 * n_cells + tid] / left_state.density;
+  // Thread guard to avoid overrun
+  if (not reconstruction::Riemann_Thread_Guard<reconstruction>(nx, ny, nz, xid, yid, zid)) {
+    // =========================
+    // Load the interface states
+    // =========================
+
+    // Check if the reconstruction chosen is implemented as a device function yet
+    if constexpr (reconstruction == reconstruction::Kind::pcm) {
+      reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
+                                                                              n_cells, gamma, left_state, right_state);
+    } else {
+      // retrieve primitive variables
+      left_state.density      = dev_bounds_L[tid];
+      left_state.velocity.x() = dev_bounds_L[o1 * n_cells + tid] / left_state.density;
+      left_state.velocity.y() = dev_bounds_L[o2 * n_cells + tid] / left_state.density;
+      left_state.velocity.z() = dev_bounds_L[o3 * n_cells + tid] / left_state.density;
 #ifdef DE  // PRESSURE_DE
     E     = dev_bounds_L[4 * n_cells + tid];
     E_kin = 0.5 * left_state.density *
@@ -75,14 +79,14 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
                                                                   left_state.velocity.z() * left_state.velocity.z())) *
                           (gamma - 1.0);
 #endif  // PRESSURE_DE
-    left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
+      left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      left_state.scalar_specific[i] = dev_bounds_L[(5 + i) * n_cells + tid] / left_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        left_state.scalar_specific[i] = dev_bounds_L[(5 + i) * n_cells + tid] / left_state.density;
+      }
 #endif
 #ifdef DE
-    left_state.gas_energy_specific = dge / left_state.density;
+      left_state.gas_energy_specific = dge / left_state.density;
 #endif
     right_state.density      = dev_bounds_R[tid];
     right_state.velocity.x() = dev_bounds_R[o1 * n_cells + tid] / right_state.density;
@@ -103,16 +107,16 @@ __global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds
                                                 right_state.velocity.z() * right_state.velocity.z())) *
         (gamma - 1.0);
 #endif  // PRESSURE_DE
-    right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
+      right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      right_state.scalar_specific[i] = dev_bounds_R[(5 + i) * n_cells + tid] / right_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        right_state.scalar_specific[i] = dev_bounds_R[(5 + i) * n_cells + tid] / right_state.density;
+      }
 #endif
 #ifdef DE
-    right_state.gas_energy_specific = dge / right_state.density;
+      right_state.gas_energy_specific = dge / right_state.density;
 #endif
-
+    }
     // compute sounds speeds in left and right regions
     cl = sqrt(gamma * left_state.pressure / left_state.density);
     cr = sqrt(gamma * right_state.pressure / right_state.density);
@@ -344,3 +348,26 @@ __device__ void sample_CUDA(const Real pm, const Real vm, Real *d, Real *v, Real
     }
   }
 }
+
+// Instantiate the templates we need
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::pcm, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+
+#ifndef PCM
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Exact_Fluxes_CUDA<reconstruction::Kind::chosen, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+#endif  // PCM

--- a/src/riemann_solvers/exact_cuda.h
+++ b/src/riemann_solvers/exact_cuda.h
@@ -7,12 +7,25 @@
 
 #include "../global/global.h"
 
-/*! \fn Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int
- * n_fields) \brief Exact Riemann solver based on the Fortran code given in
- * Sec. 4.9 of Toro (1999). */
-__global__ void Calculate_Exact_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                            int nz, int n_ghost, Real gamma, int dir, int n_fields);
+/*!
+ * \brief Exact Riemann solver based on the Fortran code given in Sec. 4.9 of Toro (1999).
+ *
+ * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in]  dev_bounds_L The interface states on the left side of the
+ * interface
+ * \param[in]  dev_bounds_R The interface states on the right side of
+ * the interface
+ * \param[out] dev_flux The output flux
+ * \param[in]  n_cells Total number of cells
+ * \param[in]  n_ghost Number of ghost cells on each side
+ * \param[in]  n_fields The total number of fields
+ */
+template <int reconstruction, uint direction>
+__global__ void Calculate_Exact_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                            Real const *dev_bounds_R, Real *dev_flux, int const nx, int const ny,
+                                            int const nz, int const n_cells, Real const gamma, int const n_fields);
 
 __device__ Real guessp_CUDA(Real dl, Real vxl, Real pl, Real cl, Real dr, Real vxr, Real pr, Real cr, Real gamma);
 

--- a/src/riemann_solvers/hll_cuda.cu
+++ b/src/riemann_solvers/hll_cuda.cu
@@ -78,11 +78,11 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
       left_state.gas_energy_specific = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
-    right_state.density      = dev_bounds_R[tid];
-    right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
-    right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
-    right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
-    right_state.energy       = dev_bounds_R[4 * n_cells + tid];
+      right_state.density      = dev_bounds_R[tid];
+      right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
+      right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
+      right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
+      right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
         right_state.scalar_specific[i] = dev_bounds_R[(5 + i) * n_cells + tid];
@@ -92,47 +92,48 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
       right_state.gas_energy_specific = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
-    // calculate primitive variables
-    left_state.velocity.x() = left_state.momentum.x() / left_state.density;
-    left_state.velocity.y() = left_state.momentum.y() / left_state.density;
-    left_state.velocity.z() = left_state.momentum.z() / left_state.density;
+      // calculate primitive variables
+      left_state.velocity.x() = left_state.momentum.x() / left_state.density;
+      left_state.velocity.y() = left_state.momentum.y() / left_state.density;
+      left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * left_state.density *
-            (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-             left_state.velocity.z() * left_state.velocity.z());
-    left_state.pressure = hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin,
-                                                                left_state.gas_energy_specific, gamma);
+      E_kin = 0.5 * left_state.density *
+              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+               left_state.velocity.z() * left_state.velocity.z());
+      left_state.pressure = hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin,
+                                                                  left_state.gas_energy_specific, gamma);
 #else
-    left_state.pressure = (left_state.energy - 0.5 * left_state.density *
-                                                   (left_state.velocity.x() * left_state.velocity.x() +
-                                                    left_state.velocity.y() * left_state.velocity.y() +
-                                                    left_state.velocity.z() * left_state.velocity.z())) *
-                          (gamma - 1.0);
+      left_state.pressure = (left_state.energy - 0.5 * left_state.density *
+                                                     (left_state.velocity.x() * left_state.velocity.x() +
+                                                      left_state.velocity.y() * left_state.velocity.y() +
+                                                      left_state.velocity.z() * left_state.velocity.z())) *
+                            (gamma - 1.0);
 #endif  // DE
-    left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
-    // #ifdef SCALAR
-    // for (int i=0; i<NSCALARS; i++) {
-    //   scl[i] = left_state.scalar_specific[i] / left_state.density;
-    // }
-    // #endif
-    // #ifdef DE
-    // gel = left_state.gas_energy_specific / left_state.density;
-    // #endif
-    right_state.velocity.x() = right_state.momentum.x() / right_state.density;
-    right_state.velocity.y() = right_state.momentum.y() / right_state.density;
-    right_state.velocity.z() = right_state.momentum.z() / right_state.density;
+      left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
+      // #ifdef SCALAR
+      // for (int i=0; i<NSCALARS; i++) {
+      //   scl[i] = left_state.scalar_specific[i] / left_state.density;
+      // }
+      // #endif
+      // #ifdef DE
+      // gel = left_state.gas_energy_specific / left_state.density;
+      // #endif
+      right_state.velocity.x() = right_state.momentum.x() / right_state.density;
+      right_state.velocity.y() = right_state.momentum.y() / right_state.density;
+      right_state.velocity.z() = right_state.momentum.z() / right_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * right_state.density *
-            (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
-             right_state.velocity.z() * right_state.velocity.z());
-    right_state.pressure = hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin,
-                                                                 right_state.gas_energy_specific, gamma);
+      E_kin =
+          0.5 * right_state.density *
+          (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
+           right_state.velocity.z() * right_state.velocity.z());
+      right_state.pressure = hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin,
+                                                                   right_state.gas_energy_specific, gamma);
 #else
-    right_state.pressure = (right_state.energy - 0.5 * right_state.density *
-                                                     (right_state.velocity.x() * right_state.velocity.x() +
-                                                      right_state.velocity.y() * right_state.velocity.y() +
-                                                      right_state.velocity.z() * right_state.velocity.z())) *
-                           (gamma - 1.0);
+      right_state.pressure = (right_state.energy - 0.5 * right_state.density *
+                                                       (right_state.velocity.x() * right_state.velocity.x() +
+                                                        right_state.velocity.y() * right_state.velocity.y() +
+                                                        right_state.velocity.z() * right_state.velocity.z())) *
+                             (gamma - 1.0);
 #endif  // DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
     }

--- a/src/riemann_solvers/hll_cuda.cu
+++ b/src/riemann_solvers/hll_cuda.cu
@@ -25,19 +25,10 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
   // specific versions despite the name in the struct
   reconstruction::InterfaceState left_state, right_state;
 
-  // Real g1 = gamma - 1.0;
-  // Real Hl, Hr;
-  // Real sqrtdl, sqrtdr, vx, vy, vz, H;
-  // Real vsq, asq, a;
-  // Real lambda_m, lambda_p;
   Real f_d_l, f_mx_l, f_my_l, f_mz_l, f_E_l;
   Real f_d_r, f_mx_r, f_my_r, f_mz_r, f_E_r;
-  // Real dls, drs, mxls, mxrs, myls, myrs, mzls, mzrs, left_state.energys, Ers;
   Real f_d, f_mx, f_my, f_mz, f_E;
   Real Sl, Sr, cfl, cfr;
-#ifdef DE
-  Real f_ge_l, f_ge_r, f_ge, E_kin;
-#endif
 #ifdef SCALAR
   Real f_sc_l[NSCALARS], f_sc_r[NSCALARS], f_sc[NSCALARS];
 #endif
@@ -261,9 +252,9 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
           ((Sr * f_mz_l) - (Sl * f_mz_r) + Sl * Sr * (right_state.momentum.z() - left_state.momentum.z())) / (Sr - Sl);
       f_E = ((Sr * f_E_l) - (Sl * f_E_r) + Sl * Sr * (right_state.energy - left_state.energy)) / (Sr - Sl);
 #ifdef DE
-      f_ge = ((Sr * f_ge_l) - (Sl * f_ge_r) +
-              Sl * Sr * (right_state.gas_energy_specific - left_state.gas_energy_specific)) /
-             (Sr - Sl);
+      Real f_ge = ((Sr * f_ge_l) - (Sl * f_ge_r) +
+                   Sl * Sr * (right_state.gas_energy_specific - left_state.gas_energy_specific)) /
+                  (Sr - Sl);
 #endif
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {

--- a/src/riemann_solvers/hll_cuda.cu
+++ b/src/riemann_solvers/hll_cuda.cu
@@ -97,9 +97,10 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
       left_state.velocity.y() = left_state.momentum.y() / left_state.density;
       left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-      E_kin = 0.5 * left_state.density *
-              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-               left_state.velocity.z() * left_state.velocity.z());
+      Real E_kin =
+          0.5 * left_state.density *
+          (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+           left_state.velocity.z() * left_state.velocity.z());
       left_state.pressure = hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin,
                                                                   left_state.gas_energy_specific, gamma);
 #else
@@ -188,7 +189,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
     f_mz_l = left_state.momentum.z() * left_state.velocity.x();
     f_E_l  = (left_state.energy + left_state.pressure) * left_state.velocity.x();
 #ifdef DE
-    f_ge_l = left_state.gas_energy_specific * left_state.velocity.x();
+    Real f_ge_l = left_state.gas_energy_specific * left_state.velocity.x();
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
@@ -202,7 +203,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
     f_mz_r = right_state.momentum.z() * right_state.velocity.x();
     f_E_r  = (right_state.energy + right_state.pressure) * right_state.velocity.x();
 #ifdef DE
-    f_ge_r = right_state.gas_energy_specific * right_state.velocity.x();
+    Real f_ge_r = right_state.gas_energy_specific * right_state.velocity.x();
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {

--- a/src/riemann_solvers/hll_cuda.h
+++ b/src/riemann_solvers/hll_cuda.h
@@ -6,11 +6,24 @@
 
 #include "../global/global.h"
 
-/*! \fn Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int
- * n_fields) \brief Roe Riemann solver based on the version described in Stone
- * et al, 2008. */
-__global__ void Calculate_HLL_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                          int nz, int n_ghost, Real gamma, int dir, int n_fields);
+/*!
+ * \brief HLL Riemann solver
+ *
+ * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in]  dev_bounds_L The interface states on the left side of the
+ * interface
+ * \param[in]  dev_bounds_R The interface states on the right side of
+ * the interface
+ * \param[out] dev_flux The output flux
+ * \param[in]  n_cells Total number of cells
+ * \param[in]  n_ghost Number of ghost cells on each side
+ * \param[in]  n_fields The total number of fields
+ */
+template <int reconstruction, uint direction>
+__global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R,
+                                          Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells,
+                                          Real const gamma, int const n_fields);
 
 #endif  // HLLC_CUDA_H

--- a/src/riemann_solvers/hllc_cuda.cu
+++ b/src/riemann_solvers/hllc_cuda.cu
@@ -84,11 +84,11 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
       Real gas_energy_left = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
-    right_state.density      = dev_bounds_R[tid];
-    right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
-    right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
-    right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
-    right_state.energy       = dev_bounds_R[4 * n_cells + tid];
+      right_state.density      = dev_bounds_R[tid];
+      right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
+      right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
+      right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
+      right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
         dscr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
@@ -98,22 +98,22 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
       Real gas_energy_right = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
-    // calculate primitive variables
-    left_state.velocity.x() = left_state.momentum.x() / left_state.density;
-    left_state.velocity.y() = left_state.momentum.y() / left_state.density;
-    left_state.velocity.z() = left_state.momentum.z() / left_state.density;
+      // calculate primitive variables
+      left_state.velocity.x() = left_state.momentum.x() / left_state.density;
+      left_state.velocity.y() = left_state.momentum.y() / left_state.density;
+      left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * left_state.density *
-            (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-             left_state.velocity.z() * left_state.velocity.z());
-    left_state.pressure =
-        hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
+      E_kin = 0.5 * left_state.density *
+              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+               left_state.velocity.z() * left_state.velocity.z());
+      left_state.pressure =
+          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
 #else
-    left_state.pressure = (left_state.energy - 0.5 * left_state.density *
-                                                   (left_state.velocity.x() * left_state.velocity.x() +
-                                                    left_state.velocity.y() * left_state.velocity.y() +
-                                                    left_state.velocity.z() * left_state.velocity.z())) *
-                          (gamma - 1.0);
+      left_state.pressure = (left_state.energy - 0.5 * left_state.density *
+                                                     (left_state.velocity.x() * left_state.velocity.x() +
+                                                      left_state.velocity.y() * left_state.velocity.y() +
+                                                      left_state.velocity.z() * left_state.velocity.z())) *
+                            (gamma - 1.0);
 #endif  // PRESSURE_DE
       left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
@@ -124,21 +124,22 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
 #ifdef DE
       left_state.gas_energy_specific = gas_energy_left / left_state.density;
 #endif
-    right_state.velocity.x() = right_state.momentum.x() / right_state.density;
-    right_state.velocity.y() = right_state.momentum.y() / right_state.density;
-    right_state.velocity.z() = right_state.momentum.z() / right_state.density;
+      right_state.velocity.x() = right_state.momentum.x() / right_state.density;
+      right_state.velocity.y() = right_state.momentum.y() / right_state.density;
+      right_state.velocity.z() = right_state.momentum.z() / right_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * right_state.density *
-            (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
-             right_state.velocity.z() * right_state.velocity.z());
-    right_state.pressure =
-        hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
+      E_kin =
+          0.5 * right_state.density *
+          (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
+           right_state.velocity.z() * right_state.velocity.z());
+      right_state.pressure =
+          hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
 #else
-    right_state.pressure = (right_state.energy - 0.5 * right_state.density *
-                                                     (right_state.velocity.x() * right_state.velocity.x() +
-                                                      right_state.velocity.y() * right_state.velocity.y() +
-                                                      right_state.velocity.z() * right_state.velocity.z())) *
-                           (gamma - 1.0);
+      right_state.pressure = (right_state.energy - 0.5 * right_state.density *
+                                                       (right_state.velocity.x() * right_state.velocity.x() +
+                                                        right_state.velocity.y() * right_state.velocity.y() +
+                                                        right_state.velocity.z() * right_state.velocity.z())) *
+                             (gamma - 1.0);
 #endif  // PRESSURE_DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR

--- a/src/riemann_solvers/hllc_cuda.cu
+++ b/src/riemann_solvers/hllc_cuda.cu
@@ -103,11 +103,12 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
       left_state.velocity.y() = left_state.momentum.y() / left_state.density;
       left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-      E_kin = 0.5 * left_state.density *
-              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-               left_state.velocity.z() * left_state.velocity.z());
+      Real E_kin =
+          0.5 * left_state.density *
+          (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+           left_state.velocity.z() * left_state.velocity.z());
       left_state.pressure =
-          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
+          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, gas_energy_left, gamma);
 #else
       left_state.pressure = (left_state.energy - 0.5 * left_state.density *
                                                      (left_state.velocity.x() * left_state.velocity.x() +
@@ -132,8 +133,8 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
           0.5 * right_state.density *
           (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
            right_state.velocity.z() * right_state.velocity.z());
-      right_state.pressure =
-          hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
+      right_state.pressure = hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin,
+                                                                   gas_energy_right, gamma);
 #else
       right_state.pressure = (right_state.energy - 0.5 * right_state.density *
                                                        (right_state.velocity.x() * right_state.velocity.x() +
@@ -195,7 +196,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
     f_mz_l = left_state.momentum.z() * left_state.velocity.x();
     f_E_l  = (left_state.energy + left_state.pressure) * left_state.velocity.x();
 #ifdef DE
-    f_ge_l = dgel * left_state.velocity.x();
+    Real f_ge_l = left_state.gas_energy_specific * left_state.density * left_state.velocity.x();
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
@@ -209,7 +210,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
     f_mz_r = right_state.momentum.z() * right_state.velocity.x();
     f_E_r  = (right_state.energy + right_state.pressure) * right_state.velocity.x();
 #ifdef DE
-    f_ge_r = dger * right_state.velocity.x();
+    Real f_ge_r = right_state.gas_energy_specific * right_state.density * right_state.velocity.x();
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {

--- a/src/riemann_solvers/hllc_cuda.cu
+++ b/src/riemann_solvers/hllc_cuda.cu
@@ -10,77 +10,80 @@
 #include "../utils/gpu.hpp"
 #include "../utils/hydro_utilities.h"
 
-/*! \fn Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int
- * n_fields) \brief HLLC Riemann solver based on the version described in Toro
- * (2006), Sec. 10.4. */
-__global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                           int nz, int n_ghost, Real gamma, int dir, int n_fields)
+template <int reconstruction, uint direction>
+__global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                           Real const *dev_bounds_R, Real *dev_flux, int const nx, int const ny,
+                                           int const nz, int const n_cells, Real const gamma, int const n_fields)
 {
   // get a thread index
   int blockId = blockIdx.x + blockIdx.y * gridDim.x;
   int tid     = threadIdx.x + blockId * blockDim.x;
-  int zid     = tid / (nx * ny);
-  int yid     = (tid - zid * nx * ny) / nx;
-  int xid     = tid - zid * nx * ny - yid * nx;
+  int xid, yid, zid;
+  cuda_utilities::compute3DIndices(tid, nx, ny, xid, yid, zid);
 
-  int n_cells = nx * ny * nz;
+  // Thread guard to avoid overrun
+  if (not reconstruction::Riemann_Thread_Guard<reconstruction>(nx, ny, nz, xid, yid, zid)) {
+    reconstruction::InterfaceState left_state, right_state;
 
-  reconstruction::InterfaceState left_state, right_state;
-
-  Real g1 = gamma - 1.0;
-  Real Hl, Hr;
-  Real sqrtdl, sqrtdr, vx, vy, vz, H;
-  Real vsq, asq, a;
-  Real lambda_m, lambda_p;
-  Real f_d_l, f_mx_l, f_my_l, f_mz_l, f_E_l;
-  Real f_d_r, f_mx_r, f_my_r, f_mz_r, f_E_r;
-  Real dls, drs, mxls, mxrs, myls, myrs, mzls, mzrs, Els, Ers;
-  Real f_d, f_mx, f_my, f_mz, f_E;
-  Real Sl, Sr, Sm, cfl, cfr, ps;
+    Real g1 = gamma - 1.0;
+    Real Hl, Hr;
+    Real sqrtdl, sqrtdr, vx, vy, vz, H;
+    Real vsq, asq, a;
+    Real lambda_m, lambda_p;
+    Real f_d_l, f_mx_l, f_my_l, f_mz_l, f_E_l;
+    Real f_d_r, f_mx_r, f_my_r, f_mz_r, f_E_r;
+    Real dls, drs, mxls, mxrs, myls, myrs, mzls, mzrs, Els, Ers;
+    Real f_d, f_mx, f_my, f_mz, f_E;
+    Real Sl, Sr, Sm, cfl, cfr, ps;
 #ifdef DE
-  Real dgel, dger, gels, gers, f_ge_l, f_ge_r, f_ge, E_kin;
+    Real dgel, dger, gels, gers, f_ge_l, f_ge_r, f_ge, E_kin;
 #endif
 #ifdef SCALAR
-  Real dscl[NSCALARS], dscr[NSCALARS], scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS],
-      f_sc[NSCALARS];
+    Real dscl[NSCALARS], dscr[NSCALARS], scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS],
+        f_sc[NSCALARS];
 #endif
 
-  Real etah = 0;
+    Real etah = 0;
 
-  int o1, o2, o3;
-  if (dir == 0) {
-    o1 = 1;
-    o2 = 2;
-    o3 = 3;
-  }
-  if (dir == 1) {
-    o1 = 2;
-    o2 = 3;
-    o3 = 1;
-  }
-  if (dir == 2) {
-    o1 = 3;
-    o2 = 1;
-    o3 = 2;
-  }
-
-  // Each thread executes the solver independently
-  // if (xid > n_ghost-3 && xid < nx-n_ghost+1 && yid < ny && zid < nz)
-  if (xid < nx && yid < ny && zid < nz) {
-    // retrieve conserved variables
-    left_state.density      = dev_bounds_L[tid];
-    left_state.momentum.x() = dev_bounds_L[o1 * n_cells + tid];
-    left_state.momentum.y() = dev_bounds_L[o2 * n_cells + tid];
-    left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
-    left_state.energy       = dev_bounds_L[4 * n_cells + tid];
-#ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      dscl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+    int o1, o2, o3;
+    if constexpr (direction == 0) {
+      o1 = 1;
+      o2 = 2;
+      o3 = 3;
     }
+    if constexpr (direction == 1) {
+      o1 = 2;
+      o2 = 3;
+      o3 = 1;
+    }
+    if constexpr (direction == 2) {
+      o1 = 3;
+      o2 = 1;
+      o3 = 2;
+    }
+
+    // =========================
+    // Load the interface states
+    // =========================
+
+    // Check if the reconstruction chosen is implemented as a device function yet
+    if constexpr (reconstruction == reconstruction::Kind::pcm) {
+      reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
+                                                                              n_cells, gamma, left_state, right_state);
+    } else {
+      // retrieve conserved variables
+      left_state.density      = dev_bounds_L[tid];
+      left_state.momentum.x() = dev_bounds_L[o1 * n_cells + tid];
+      left_state.momentum.y() = dev_bounds_L[o2 * n_cells + tid];
+      left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
+      left_state.energy       = dev_bounds_L[4 * n_cells + tid];
+#ifdef SCALAR
+      for (int i = 0; i < NSCALARS; i++) {
+        dscl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+      }
 #endif
 #ifdef DE
-    dgel = dev_bounds_L[(n_fields - 1) * n_cells + tid];
+      dgel = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
     right_state.density      = dev_bounds_R[tid];
@@ -89,12 +92,12 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
     right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
     right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      dscr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        dscr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
+      }
 #endif
 #ifdef DE
-    dger = dev_bounds_R[(n_fields - 1) * n_cells + tid];
+      dger = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
     // calculate primitive variables
@@ -114,14 +117,14 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
                                                     left_state.velocity.z() * left_state.velocity.z())) *
                           (gamma - 1.0);
 #endif  // PRESSURE_DE
-    left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
+      left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      left_state.scalar_specific[i] = dscl[i] / left_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        left_state.scalar_specific[i] = dscl[i] / left_state.density;
+      }
 #endif
 #ifdef DE
-    left_state.gas_energy_specific = dgel / left_state.density;
+      left_state.gas_energy_specific = dgel / left_state.density;
 #endif
     right_state.velocity.x() = right_state.momentum.x() / right_state.density;
     right_state.velocity.y() = right_state.momentum.y() / right_state.density;
@@ -139,15 +142,16 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
                                                       right_state.velocity.z() * right_state.velocity.z())) *
                            (gamma - 1.0);
 #endif  // PRESSURE_DE
-    right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
+      right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      right_state.scalar_specific[i] = dscr[i] / right_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        right_state.scalar_specific[i] = dscr[i] / right_state.density;
+      }
 #endif
 #ifdef DE
-    right_state.gas_energy_specific = dger / right_state.density;
+      right_state.gas_energy_specific = dger / right_state.density;
 #endif
+    }
 
     // calculate the enthalpy in each cell
     Hl = (left_state.energy + left_state.pressure) / left_state.density;
@@ -329,3 +333,26 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_
     }
   }
 }
+
+// Instantiate the templates we need
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::pcm, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+
+#ifndef PCM
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_HLLC_Fluxes_CUDA<reconstruction::Kind::chosen, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+#endif  // PCM

--- a/src/riemann_solvers/hllc_cuda.h
+++ b/src/riemann_solvers/hllc_cuda.h
@@ -6,11 +6,24 @@
 
 #include "../global/global.h"
 
-/*! \fn Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, int dir, int
- * n_fields) \brief Roe Riemann solver based on the version described in Stone
- * et al, 2008. */
-__global__ void Calculate_HLLC_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                           int nz, int n_ghost, Real gamma, int dir, int n_fields);
+/*!
+ * \brief HLLC Riemann solver based on the version described in Toro (2006), Sec. 10.4.
+ *
+ * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in]  dev_bounds_L The interface states on the left side of the
+ * interface
+ * \param[in]  dev_bounds_R The interface states on the right side of
+ * the interface
+ * \param[out] dev_flux The output flux
+ * \param[in]  n_cells Total number of cells
+ * \param[in]  n_ghost Number of ghost cells on each side
+ * \param[in]  n_fields The total number of fields
+ */
+template <int reconstruction, uint direction>
+__global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                           Real const *dev_bounds_R, Real *dev_flux, int const nx, int const ny,
+                                           int const nz, int const n_cells, Real const gamma, int const n_fields);
 
 #endif  // HLLC_CUDA_H

--- a/src/riemann_solvers/hlld_cuda.cu
+++ b/src/riemann_solvers/hlld_cuda.cu
@@ -28,36 +28,36 @@
 namespace mhd
 {
 // =========================================================================
-__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_bounds_L, Real const *dev_bounds_R,
-                                           Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
-                                           Real const gamma, int const direction, int const n_fields)
+template <int reconstruction, uint direction>
+__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                           Real const *dev_bounds_R, Real const *dev_magnetic_face, Real *dev_flux,
+                                           int const nx, int const ny, int const nz, int const n_cells,
+                                           Real const gamma, int const n_fields)
 {
   // get a thread index
   int const threadId = threadIdx.x + blockIdx.x * blockDim.x;
+  int xid, yid, zid;
+  cuda_utilities::compute3DIndices(threadId, nx, ny, xid, yid, zid);
 
   // Thread guard to avoid overrun
-  if (threadId >= n_cells) {
+  if (reconstruction::Riemann_Thread_Guard<reconstruction>(nx, ny, nz, xid, yid, zid)) {
     return;
   }
 
   // Offsets & indices
   int o1, o2, o3;
-  switch (direction) {
-    case 0:
-      o1 = grid_enum::momentum_x;
-      o2 = grid_enum::momentum_y;
-      o3 = grid_enum::momentum_z;
-      break;
-    case 1:
-      o1 = grid_enum::momentum_y;
-      o2 = grid_enum::momentum_z;
-      o3 = grid_enum::momentum_x;
-      break;
-    case 2:
-      o1 = grid_enum::momentum_z;
-      o2 = grid_enum::momentum_x;
-      o3 = grid_enum::momentum_y;
-      break;
+  if constexpr (direction == 0) {
+    o1 = grid_enum::momentum_x;
+    o2 = grid_enum::momentum_y;
+    o3 = grid_enum::momentum_z;
+  } else if constexpr (direction == 1) {
+    o1 = grid_enum::momentum_y;
+    o2 = grid_enum::momentum_z;
+    o3 = grid_enum::momentum_x;
+  } else if constexpr (direction == 2) {
+    o1 = grid_enum::momentum_z;
+    o2 = grid_enum::momentum_x;
+    o3 = grid_enum::momentum_y;
   }
 
   // ============================
@@ -66,10 +66,15 @@ __global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_bounds_L, Real const 
   // The magnetic field in the X-direction
   Real const magneticX = dev_magnetic_face[threadId];
 
-  reconstruction::InterfaceState const stateL =
-      mhd::internal::loadState(dev_bounds_L, magneticX, gamma, threadId, n_cells, o1, o2, o3);
-  reconstruction::InterfaceState const stateR =
-      mhd::internal::loadState(dev_bounds_R, magneticX, gamma, threadId, n_cells, o1, o2, o3);
+  reconstruction::InterfaceState stateL, stateR;
+  // Check if the reconstruction chosen is implemented as a device function yet
+  if constexpr (reconstruction == reconstruction::Kind::pcm) {
+    reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
+                                                                            n_cells, gamma, stateL, stateR);
+  } else {
+    stateL = mhd::internal::loadState(dev_bounds_L, magneticX, gamma, threadId, n_cells, o1, o2, o3);
+    stateR = mhd::internal::loadState(dev_bounds_R, magneticX, gamma, threadId, n_cells, o1, o2, o3);
+  }
 
   // Compute the approximate Left and Right wave speeds
   mhd::internal::Speeds speed = mhd::internal::approximateLRWaveSpeeds(stateL, stateR, magneticX, gamma);
@@ -517,4 +522,27 @@ __device__ __host__ mhd::internal::Flux computeDoubleStarFluxes(mhd::internal::D
 
 }  // namespace internal
 }  // end namespace mhd
-#endif  // MHD
+
+// Instantiate the templates we need
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::pcm, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+
+  #ifndef PCM
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void mhd::Calculate_HLLD_Fluxes_CUDA<reconstruction::Kind::chosen, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real const *dev_magnetic_face,
+    Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+  #endif  // PCM
+#endif    // MHD

--- a/src/riemann_solvers/hlld_cuda.h
+++ b/src/riemann_solvers/hlld_cuda.h
@@ -29,17 +29,18 @@ namespace mhd
  * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
  * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
  * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
- * \param[in]  dev_bounds_L The interface states on the left side of the
- * interface
- * \param[in]  dev_bounds_R The interface states on the right side of
- * the interface
- * \param[in]  dev_magnetic_face A pointer to the begining of the
- * conserved magnetic field array that is stored at the interface. I.e. for the
- * X-direction solve this would be the begining of the X-direction fields
- * \param[out] dev_flux The output flux
- * \param[in]  n_cells Total number of cells
- * \param[in]  n_ghost Number of ghost cells on each side
- * \param[in]  n_fields The total number of fields
+ * \param[in] dev_conserved The conserved variables array
+ * \param[in] dev_bounds_L The interface states on the left side of the interface
+ * \param[in] dev_bounds_R The interface states on the right side of the interface
+ * \param[in] dev_magnetic_face A pointer to the begining of the conserved magnetic field array that is stored at the
+ * interface. I.e. for the X-direction solve this would be the begining of the X-direction fields
+ * \param[in] dev_flux The output flux
+ * \param[in] nx The number of cells in the x-direction
+ * \param[in] ny The number of cells in the y-direction
+ * \param[in] nz The number of cells in the z-direction
+ * \param[in] n_cells The total number of cells
+ * \param[in] gamma The adiabatic index
+ * \param[in] n_fields The number of fields
  */
 template <int reconstruction, uint direction>
 __global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,

--- a/src/riemann_solvers/hlld_cuda.h
+++ b/src/riemann_solvers/hlld_cuda.h
@@ -26,6 +26,9 @@ namespace mhd
 /*!
  * \brief Compute the HLLD fluxes from Miyoshi & Kusano 2005
  *
+ * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
  * \param[in]  dev_bounds_L The interface states on the left side of the
  * interface
  * \param[in]  dev_bounds_R The interface states on the right side of
@@ -36,13 +39,13 @@ namespace mhd
  * \param[out] dev_flux The output flux
  * \param[in]  n_cells Total number of cells
  * \param[in]  n_ghost Number of ghost cells on each side
- * \param[in]  dir The direction that the solve is taking place in. 0=X, 1=Y,
- * 2=Z
  * \param[in]  n_fields The total number of fields
  */
-__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_bounds_L, Real const *dev_bounds_R,
-                                           Real const *dev_magnetic_face, Real *dev_flux, int const n_cells,
-                                           Real const gamma, int const direction, int const n_fields);
+template <int reconstruction, uint direction>
+__global__ void Calculate_HLLD_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L,
+                                           Real const *dev_bounds_R, Real const *dev_magnetic_face, Real *dev_flux,
+                                           int const nx, int const ny, int const nz, int const n_cells,
+                                           Real const gamma, int const n_fields);
 
 /*!
  * \brief Namespace to hold private functions used within the HLLD

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -38,9 +38,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
   sum_0 = sum_1 = sum_2 = sum_3 = sum_4 = 0.0;
   Real test0, test1, test2, test3, test4;
   int hlle_flag = 0;
-#ifdef DE
-  Real dgel, dger, f_ge_l, f_ge_r, E_kin;
-#endif
+
 #ifdef SCALAR
   Real dscalarl[NSCALARS], dscalarr[NSCALARS], f_scalar_l[NSCALARS], f_scalar_r[NSCALARS];
 #endif
@@ -85,7 +83,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       }
 #endif
 #ifdef DE
-      dgel = dev_bounds_L[(n_fields - 1) * n_cells + tid];
+      Real gas_energy_left = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
     right_state.density      = dev_bounds_R[tid];
@@ -99,7 +97,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       }
 #endif
 #ifdef DE
-      dger = dev_bounds_R[(n_fields - 1) * n_cells + tid];
+      Real gas_energy_right = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
     // calculate primitive variables
@@ -126,7 +124,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       }
 #endif
 #ifdef DE
-      left_state.gas_energy_specific = dgel / left_state.density;
+      left_state.gas_energy_specific = gas_energy_left / left_state.density;
 #endif
     right_state.velocity.x() = right_state.momentum.x() / right_state.density;
     right_state.velocity.y() = right_state.momentum.y() / right_state.density;
@@ -151,7 +149,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       }
 #endif
 #ifdef DE
-      right_state.gas_energy_specific = dger / right_state.density;
+      right_state.gas_energy_specific = gas_energy_right / right_state.density;
 #endif
     }
     // calculate the enthalpy in each cell

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -10,21 +10,16 @@
 #include "../utils/gpu.hpp"
 #include "../utils/hydro_utilities.h"
 
-/*! \fn Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, Real *dev_etah,
- * int dir, int n_fields) \brief Roe Riemann solver based on the version
- * described in Stone et al, 2008. */
-__global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                          int nz, int n_ghost, Real gamma, int dir, int n_fields)
+template <int reconstruction, uint direction>
+__global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R,
+                                          Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells,
+                                          Real const gamma, int const n_fields)
 {
   // get a thread index
   int blockId = blockIdx.x + blockIdx.y * gridDim.x;
   int tid     = threadIdx.x + blockId * blockDim.x;
-  int zid     = tid / (nx * ny);
-  int yid     = (tid - zid * nx * ny) / nx;
-  int xid     = tid - zid * nx * ny - yid * nx;
-
-  int n_cells = nx * ny * nz;
+  int xid, yid, zid;
+  cuda_utilities::compute3DIndices(tid, nx, ny, xid, yid, zid);
 
   reconstruction::InterfaceState left_state, right_state;
 
@@ -51,37 +46,46 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
 #endif
 
   int o1, o2, o3;
-  if (dir == 0) {
+  if constexpr (direction == 0) {
     o1 = 1;
     o2 = 2;
     o3 = 3;
   }
-  if (dir == 1) {
+  if constexpr (direction == 1) {
     o1 = 2;
     o2 = 3;
     o3 = 1;
   }
-  if (dir == 2) {
+  if constexpr (direction == 2) {
     o1 = 3;
     o2 = 1;
     o3 = 2;
   }
 
-  // Each thread executes the solver independently
-  if (xid < nx && yid < ny && zid < nz) {
-    // retrieve conserved variables
-    left_state.density      = dev_bounds_L[tid];
-    left_state.momentum.x() = dev_bounds_L[o1 * n_cells + tid];
-    left_state.momentum.y() = dev_bounds_L[o2 * n_cells + tid];
-    left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
-    left_state.energy       = dev_bounds_L[4 * n_cells + tid];
+  // Thread guard to avoid overrun
+  if (not reconstruction::Riemann_Thread_Guard<reconstruction>(nx, ny, nz, xid, yid, zid)) {
+    // =========================
+    // Load the interface states
+    // =========================
+
+    // Check if the reconstruction chosen is implemented as a device function yet
+    if constexpr (reconstruction == reconstruction::Kind::pcm) {
+      reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
+                                                                              n_cells, gamma, left_state, right_state);
+    } else {
+      // retrieve conserved variables
+      left_state.density      = dev_bounds_L[tid];
+      left_state.momentum.x() = dev_bounds_L[o1 * n_cells + tid];
+      left_state.momentum.y() = dev_bounds_L[o2 * n_cells + tid];
+      left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
+      left_state.energy       = dev_bounds_L[4 * n_cells + tid];
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      dscalarl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        dscalarl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+      }
 #endif
 #ifdef DE
-    dgel = dev_bounds_L[(n_fields - 1) * n_cells + tid];
+      dgel = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
     right_state.density      = dev_bounds_R[tid];
@@ -90,12 +94,12 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
     right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
     right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      dscalarr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        dscalarr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
+      }
 #endif
 #ifdef DE
-    dger = dev_bounds_R[(n_fields - 1) * n_cells + tid];
+      dger = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
     // calculate primitive variables
@@ -115,14 +119,14 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
                                                     left_state.velocity.z() * left_state.velocity.z())) *
                           (gamma - 1.0);
 #endif  // PRESSURE_DE
-    left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
+      left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      left_state.scalar_specific[i] = dscalarl[i] / left_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        left_state.scalar_specific[i] = dscalarl[i] / left_state.density;
+      }
 #endif
 #ifdef DE
-    left_state.gas_energy_specific = dgel / left_state.density;
+      left_state.gas_energy_specific = dgel / left_state.density;
 #endif
     right_state.velocity.x() = right_state.momentum.x() / right_state.density;
     right_state.velocity.y() = right_state.momentum.y() / right_state.density;
@@ -140,16 +144,16 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
                                                       right_state.velocity.z() * right_state.velocity.z())) *
                            (gamma - 1.0);
 #endif  // PRESSURE_DE
-    right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
+      right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
-    for (int i = 0; i < NSCALARS; i++) {
-      right_state.scalar_specific[i] = dscalarr[i] / right_state.density;
-    }
+      for (int i = 0; i < NSCALARS; i++) {
+        right_state.scalar_specific[i] = dscalarr[i] / right_state.density;
+      }
 #endif
 #ifdef DE
-    right_state.gas_energy_specific = dger / right_state.density;
+      right_state.gas_energy_specific = dger / right_state.density;
 #endif
-
+    }
     // calculate the enthalpy in each cell
     Hl = (left_state.energy + left_state.pressure) / left_state.density;
     Hr = (right_state.energy + right_state.pressure) / right_state.density;
@@ -408,3 +412,26 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R
     }
   }
 }
+
+// Instantiate the templates we need
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::pcm, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+
+#ifndef PCM
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 0>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 1>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+template __global__ void Calculate_Roe_Fluxes_CUDA<reconstruction::Kind::chosen, 2>(
+    Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R, Real *dev_flux, int const nx,
+    int const ny, int const nz, int const n_cells, Real const gamma, int const n_fields);
+#endif  // PCM

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -86,11 +86,11 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       Real gas_energy_left = dev_bounds_L[(n_fields - 1) * n_cells + tid];
 #endif
 
-    right_state.density      = dev_bounds_R[tid];
-    right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
-    right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
-    right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
-    right_state.energy       = dev_bounds_R[4 * n_cells + tid];
+      right_state.density      = dev_bounds_R[tid];
+      right_state.momentum.x() = dev_bounds_R[o1 * n_cells + tid];
+      right_state.momentum.y() = dev_bounds_R[o2 * n_cells + tid];
+      right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
+      right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
         dscalarr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
@@ -100,22 +100,22 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       Real gas_energy_right = dev_bounds_R[(n_fields - 1) * n_cells + tid];
 #endif
 
-    // calculate primitive variables
-    left_state.velocity.x() = left_state.momentum.x() / left_state.density;
-    left_state.velocity.y() = left_state.momentum.y() / left_state.density;
-    left_state.velocity.z() = left_state.momentum.z() / left_state.density;
+      // calculate primitive variables
+      left_state.velocity.x() = left_state.momentum.x() / left_state.density;
+      left_state.velocity.y() = left_state.momentum.y() / left_state.density;
+      left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * left_state.density *
-            (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-             left_state.velocity.z() * left_state.velocity.z());
-    left_state.pressure =
-        hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
+      E_kin = 0.5 * left_state.density *
+              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+               left_state.velocity.z() * left_state.velocity.z());
+      left_state.pressure =
+          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
 #else
-    left_state.pressure = (left_state.energy - 0.5 * left_state.density *
-                                                   (left_state.velocity.x() * left_state.velocity.x() +
-                                                    left_state.velocity.y() * left_state.velocity.y() +
-                                                    left_state.velocity.z() * left_state.velocity.z())) *
-                          (gamma - 1.0);
+      left_state.pressure = (left_state.energy - 0.5 * left_state.density *
+                                                     (left_state.velocity.x() * left_state.velocity.x() +
+                                                      left_state.velocity.y() * left_state.velocity.y() +
+                                                      left_state.velocity.z() * left_state.velocity.z())) *
+                            (gamma - 1.0);
 #endif  // PRESSURE_DE
       left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR
@@ -126,21 +126,22 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
 #ifdef DE
       left_state.gas_energy_specific = gas_energy_left / left_state.density;
 #endif
-    right_state.velocity.x() = right_state.momentum.x() / right_state.density;
-    right_state.velocity.y() = right_state.momentum.y() / right_state.density;
-    right_state.velocity.z() = right_state.momentum.z() / right_state.density;
+      right_state.velocity.x() = right_state.momentum.x() / right_state.density;
+      right_state.velocity.y() = right_state.momentum.y() / right_state.density;
+      right_state.velocity.z() = right_state.momentum.z() / right_state.density;
 #ifdef DE  // PRESSURE_DE
-    E_kin = 0.5 * right_state.density *
-            (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
-             right_state.velocity.z() * right_state.velocity.z());
-    right_state.pressure =
-        hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
+      E_kin =
+          0.5 * right_state.density *
+          (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
+           right_state.velocity.z() * right_state.velocity.z());
+      right_state.pressure =
+          hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
 #else
-    right_state.pressure = (right_state.energy - 0.5 * right_state.density *
-                                                     (right_state.velocity.x() * right_state.velocity.x() +
-                                                      right_state.velocity.y() * right_state.velocity.y() +
-                                                      right_state.velocity.z() * right_state.velocity.z())) *
-                           (gamma - 1.0);
+      right_state.pressure = (right_state.energy - 0.5 * right_state.density *
+                                                       (right_state.velocity.x() * right_state.velocity.x() +
+                                                        right_state.velocity.y() * right_state.velocity.y() +
+                                                        right_state.velocity.z() * right_state.velocity.z())) *
+                             (gamma - 1.0);
 #endif  // PRESSURE_DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
 #ifdef SCALAR

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -105,11 +105,12 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       left_state.velocity.y() = left_state.momentum.y() / left_state.density;
       left_state.velocity.z() = left_state.momentum.z() / left_state.density;
 #ifdef DE  // PRESSURE_DE
-      E_kin = 0.5 * left_state.density *
-              (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
-               left_state.velocity.z() * left_state.velocity.z());
+      Real E_kin =
+          0.5 * left_state.density *
+          (left_state.velocity.x() * left_state.velocity.x() + left_state.velocity.y() * left_state.velocity.y() +
+           left_state.velocity.z() * left_state.velocity.z());
       left_state.pressure =
-          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, dgel, gamma);
+          hydro_utilities::Get_Pressure_From_DE(left_state.energy, left_state.energy - E_kin, gas_energy_left, gamma);
 #else
       left_state.pressure = (left_state.energy - 0.5 * left_state.density *
                                                      (left_state.velocity.x() * left_state.velocity.x() +
@@ -134,8 +135,8 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
           0.5 * right_state.density *
           (right_state.velocity.x() * right_state.velocity.x() + right_state.velocity.y() * right_state.velocity.y() +
            right_state.velocity.z() * right_state.velocity.z());
-      right_state.pressure =
-          hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin, dger, gamma);
+      right_state.pressure = hydro_utilities::Get_Pressure_From_DE(right_state.energy, right_state.energy - E_kin,
+                                                                   gas_energy_right, gamma);
 #else
       right_state.pressure = (right_state.energy - 0.5 * right_state.density *
                                                        (right_state.velocity.x() * right_state.velocity.x() +
@@ -185,7 +186,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
     f_mz_l = left_state.momentum.x() * left_state.velocity.z();
     f_E_l  = (left_state.energy + left_state.pressure) * left_state.velocity.x();
 #ifdef DE
-    f_ge_l = left_state.momentum.x() * left_state.gas_energy_specific;
+    Real f_ge_l = left_state.momentum.x() * left_state.gas_energy_specific;
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
@@ -199,7 +200,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
     f_mz_r = right_state.momentum.x() * right_state.velocity.z();
     f_E_r  = (right_state.energy + right_state.pressure) * right_state.velocity.x();
 #ifdef DE
-    f_ge_r = right_state.momentum.x() * right_state.gas_energy_specific;
+    Real f_ge_r = right_state.momentum.x() * right_state.gas_energy_specific;
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
@@ -354,8 +355,8 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
         f_E_r = right_state.energy * (right_state.velocity.x() - bp) + right_state.pressure * right_state.velocity.x();
 
 #ifdef DE
-        f_ge_l = dgel * (left_state.velocity.x() - bm);
-        f_ge_r = dger * (right_state.velocity.x() - bp);
+        f_ge_l = left_state.gas_energy_specific * left_state.density * (left_state.velocity.x() - bm);
+        f_ge_r = right_state.gas_energy_specific * right_state.density * (right_state.velocity.x() - bp);
 #endif
 
 #ifdef SCALAR

--- a/src/riemann_solvers/roe_cuda.h
+++ b/src/riemann_solvers/roe_cuda.h
@@ -6,11 +6,24 @@
 
 #include "../global/global.h"
 
-/*! \fn Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real
- * *dev_flux, int nx, int ny, int nz, int n_ghost, Real gamma, Real *dev_etah,
- * int dir, int n_fields) \brief Roe Riemann solver based on the version
- * described in Stone et al, 2008. */
-__global__ void Calculate_Roe_Fluxes_CUDA(Real *dev_bounds_L, Real *dev_bounds_R, Real *dev_flux, int nx, int ny,
-                                          int nz, int n_ghost, Real gamma, int dir, int n_fields);
+/*!
+ * \brief Roe Riemann solver
+ *
+ * \tparam reconstruction What kind of reconstruction to use, PCM, PLMC, etc. This argument should always be a
+ * member of the reconstruction::Kind enum, behaviour is undefined otherwise.
+ * \tparam direction The direction that the solve is taking place in. 0=X, 1=Y, 2=Z
+ * \param[in]  dev_bounds_L The interface states on the left side of the
+ * interface
+ * \param[in]  dev_bounds_R The interface states on the right side of
+ * the interface
+ * \param[out] dev_flux The output flux
+ * \param[in]  n_cells Total number of cells
+ * \param[in]  n_ghost Number of ghost cells on each side
+ * \param[in]  n_fields The total number of fields
+ */
+template <int reconstruction, uint direction>
+__global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const *dev_bounds_L, Real const *dev_bounds_R,
+                                          Real *dev_flux, int const nx, int const ny, int const nz, int const n_cells,
+                                          Real const gamma, int const n_fields);
 
 #endif  // ROE_CUDA_H

--- a/src/system_tests/mhd_system_tests.cpp
+++ b/src/system_tests/mhd_system_tests.cpp
@@ -781,7 +781,9 @@ TEST_P(tMHDSYSTEMParameterizedMpi, MhdBlastWaveCorrectInputExpectCorrectOutput)
 TEST_P(tMHDSYSTEMParameterizedMpi, OrszagTangVortexCorrectInputExpectCorrectOutput)
 {
   test_runner.numMpiRanks = GetParam();
-  test_runner.runTest();
+  // Only do the L2 Norm test. The regular cell-to-cell comparison is brittle for this test across systems and small
+  // changes
+  test_runner.runTest(true, 2.0E-4, 2.0E-3);
 }
 /// @}
 // =============================================================================

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -190,6 +190,9 @@ struct InterfaceState {
     magnetic       = in_magnetic;
     total_pressure = in_total_pressure;
 #endif  // MHD
+#ifdef DE
+    gas_energy_specific = 0.0;
+#endif  // DE
   };
 };
 }  // namespace reconstruction

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -149,3 +149,47 @@ struct Primitive {
 };
 // =====================================================================================================================
 }  // namespace hydro_utilities
+
+namespace reconstruction
+{
+struct InterfaceState {
+  // Hydro variables
+  Real density, energy;
+  /// Note that `pressure` here is the gas pressure not the total pressure which would include the magnetic component
+  Real pressure;
+  hydro_utilities::Vector velocity, momentum;
+
+#ifdef MHD
+  // These are all cell centered values
+  Real total_pressure;
+  hydro_utilities::Vector magnetic;
+#endif  // MHD
+
+#ifdef DE
+  Real gas_energy_specific;
+#endif  // DE
+
+#ifdef SCALAR
+  Real scalar_specific[grid_enum::nscalars];
+#endif  // SCALAR
+
+  // Define the constructors
+  /// Default constructor, should set everything to 0
+  InterfaceState() = default;
+  /// Initializing constructor: used to initialize to specific values, mostly used in tests. It only initializes a
+  /// subset of the member variables since that is what is used in tests at the time of writing.
+  InterfaceState(Real const in_density, hydro_utilities::Vector const in_velocity, Real const in_energy,
+                 Real const in_pressure, hydro_utilities::Vector const in_magnetic = {0, 0, 0},
+                 Real const in_total_pressure = 0.0)
+      : density(in_density), velocity(in_velocity), energy(in_energy), pressure(in_pressure)
+  {
+    momentum.x = velocity.x * density;
+    momentum.y = velocity.y * density;
+    momentum.z = velocity.z * density;
+#ifdef MHD
+    magnetic       = in_magnetic;
+    total_pressure = in_total_pressure;
+#endif  // MHD
+  };
+};
+}  // namespace reconstruction

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -112,7 +112,7 @@ struct Conserved {
  *
  */
 struct Primitive {
-  // Hydro variables
+  // Hydro variable
   Real density, pressure;
   VectorXYZ velocity;
 

--- a/src/utils/basic_structs.h
+++ b/src/utils/basic_structs.h
@@ -157,12 +157,12 @@ struct InterfaceState {
   Real density, energy;
   /// Note that `pressure` here is the gas pressure not the total pressure which would include the magnetic component
   Real pressure;
-  hydro_utilities::Vector velocity, momentum;
+  hydro_utilities::VectorXYZ velocity, momentum;
 
 #ifdef MHD
   // These are all cell centered values
   Real total_pressure;
-  hydro_utilities::Vector magnetic;
+  hydro_utilities::VectorXYZ magnetic;
 #endif  // MHD
 
 #ifdef DE
@@ -178,14 +178,14 @@ struct InterfaceState {
   InterfaceState() = default;
   /// Initializing constructor: used to initialize to specific values, mostly used in tests. It only initializes a
   /// subset of the member variables since that is what is used in tests at the time of writing.
-  InterfaceState(Real const in_density, hydro_utilities::Vector const in_velocity, Real const in_energy,
-                 Real const in_pressure, hydro_utilities::Vector const in_magnetic = {0, 0, 0},
+  InterfaceState(Real const in_density, hydro_utilities::VectorXYZ const in_velocity, Real const in_energy,
+                 Real const in_pressure, hydro_utilities::VectorXYZ const in_magnetic = {0, 0, 0},
                  Real const in_total_pressure = 0.0)
       : density(in_density), velocity(in_velocity), energy(in_energy), pressure(in_pressure)
   {
-    momentum.x = velocity.x * density;
-    momentum.y = velocity.y * density;
-    momentum.z = velocity.z * density;
+    momentum.x() = velocity.x() * density;
+    momentum.y() = velocity.y() * density;
+    momentum.z() = velocity.z() * density;
 #ifdef MHD
     magnetic       = in_magnetic;
     total_pressure = in_total_pressure;

--- a/src/utils/cuda_utilities.h
+++ b/src/utils/cuda_utilities.h
@@ -103,7 +103,12 @@ struct AutomaticLaunchParams {
    */
   AutomaticLaunchParams(T &kernel, size_t numElements = 0)
   {
-    cudaOccupancyMaxPotentialBlockSize(&numBlocks, &threadsPerBlock, kernel, 0, 0);
+    // Get the max number of threads per block allowed by this kernel
+    cudaFuncAttributes kernel_attrs{};
+    GPU_Error_Check(cudaFuncGetAttributes(&kernel_attrs, reinterpret_cast<const void *>(&kernel)));
+
+    // Determine the launch parameters
+    cudaOccupancyMaxPotentialBlockSize(&numBlocks, &threadsPerBlock, kernel, 0, kernel_attrs.maxThreadsPerBlock);
 
     if (numElements > 0) {
       // This line is needed to check that threadsPerBlock isn't zero. Somewhere inside

--- a/src/utils/error_handling.cpp
+++ b/src/utils/error_handling.cpp
@@ -69,7 +69,7 @@ void Check_Configuration(Parameters const& P)
   Check_Boundary(P.zu_bcnd, "zu_bcnd");
 
   // warn if error checking is disabled
-#ifndef DISABLE_GPU_ERROR_CHECKING
+#ifdef DISABLE_GPU_ERROR_CHECKING
   // NOLINTNEXTLINE(clang-diagnostic-#warnings)
   #warning "CUDA error checking is disabled. Enable it by compiling without the DISABLE_GPU_ERROR_CHECKING macro."
 #endif  //! DISABLE_GPU_ERROR_CHECKING

--- a/src/utils/gpu.hpp
+++ b/src/utils/gpu.hpp
@@ -67,6 +67,8 @@ static constexpr int maxWarpsPerBlock = 1024 / WARPSIZE;
   #define cudaMemGetInfo                     hipMemGetInfo
   #define cudaDeviceGetPCIBusId              hipDeviceGetPCIBusId
   #define cudaPeekAtLastError                hipPeekAtLastError
+  #define cudaFuncAttributes                 hipFuncAttributes
+  #define cudaFuncGetAttributes              hipFuncGetAttributes
 
   // Texture definitions
   #define cudaArray           hipArray

--- a/src/utils/gpu.hpp
+++ b/src/utils/gpu.hpp
@@ -124,6 +124,9 @@ static constexpr int maxWarpsPerBlock = 1024 / WARPSIZE;
   #define hipLaunchKernelGGL(F, G, B, M, S, ...) F<<<G, B, M, S>>>(__VA_ARGS__)
   #define __shfl_down(...)                       __shfl_down_sync(0xFFFFFFFF, __VA_ARGS__)
 
+  // Used to Wrap template kernels with more than one parameter in this to avoid errors. This is present in the HIP
+  // runtime but not the CUDA runtime
+  #define HIP_KERNEL_NAME(...)                   __VA_ARGS__
 #endif  // O_HIP
 
 #define GPU_MAX_THREADS 256

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -123,6 +123,11 @@ inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure, Re
 
   return fmax(pTot, TINY_NUMBER);
 }
+/// Overload for Vector objects
+inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure, hydro_utilities::Vector const &magnetic)
+{
+  return computeTotalPressure(gasPressure, magnetic.x, magnetic.y, magnetic.z);
+}
 // =========================================================================
 
 // =========================================================================

--- a/src/utils/mhd_utilities.h
+++ b/src/utils/mhd_utilities.h
@@ -124,9 +124,10 @@ inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure, Re
   return fmax(pTot, TINY_NUMBER);
 }
 /// Overload for Vector objects
-inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure, hydro_utilities::Vector const &magnetic)
+inline __host__ __device__ Real computeTotalPressure(Real const &gasPressure,
+                                                     hydro_utilities::VectorXYZ const &magnetic)
 {
-  return computeTotalPressure(gasPressure, magnetic.x, magnetic.y, magnetic.z);
+  return computeTotalPressure(gasPressure, magnetic.x(), magnetic.y(), magnetic.z());
 }
 // =========================================================================
 

--- a/src/utils/testing_utilities.h
+++ b/src/utils/testing_utilities.h
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "../system_tests/system_tester.h"  // provide systemTest class
+#include "../utils/basic_structs.h"
 
 // =============================================================================
 // NOTE: Global variables are declared as extern at the end of this file
@@ -189,6 +190,36 @@ class GlobalString
   ~GlobalString() = default;
 };
 // =========================================================================
+
+/*!
+ * \brief Function for checking if every member in a reconstruction::InterfaceState struct matches the fiducial values
+ *
+ * \param[in] test_data The data to test
+ * \param[in] fiducial_data The fiducial data
+ * \param[in] direction What direction the test was run in.
+ */
+void inline Check_Interface(reconstruction::InterfaceState const &test_data,
+                            reconstruction::InterfaceState const &fiducial_data, size_t const direction)
+{
+  std::string const message = "Direction " + std::to_string(direction);
+
+  testing_utilities::Check_Results(test_data.density, fiducial_data.density, "density " + message);
+  testing_utilities::Check_Results(test_data.energy, fiducial_data.energy, "energy " + message);
+  testing_utilities::Check_Results(test_data.pressure, fiducial_data.pressure, "pressure " + message);
+  testing_utilities::Check_Results(test_data.velocity.x, fiducial_data.velocity.x, "velocity.x " + message);
+  testing_utilities::Check_Results(test_data.velocity.y, fiducial_data.velocity.y, "velocity.y " + message);
+  testing_utilities::Check_Results(test_data.velocity.z, fiducial_data.velocity.z, "velocity.z " + message);
+  testing_utilities::Check_Results(test_data.momentum.x, fiducial_data.momentum.x, "momentum.x " + message);
+  testing_utilities::Check_Results(test_data.momentum.y, fiducial_data.momentum.y, "momentum.y " + message);
+  testing_utilities::Check_Results(test_data.momentum.z, fiducial_data.momentum.z, "momentum.z " + message);
+
+#ifdef MHD
+  testing_utilities::Check_Results(test_data.total_pressure, fiducial_data.total_pressure, "total_pressure" + message);
+  testing_utilities::Check_Results(test_data.magnetic.x, fiducial_data.magnetic.x, "magnetic.x " + message);
+  testing_utilities::Check_Results(test_data.magnetic.y, fiducial_data.magnetic.y, "magnetic.y " + message);
+  testing_utilities::Check_Results(test_data.magnetic.z, fiducial_data.magnetic.z, "magnetic.z " + message);
+#endif  // MHD
+}
 }  // namespace testing_utilities
 
 // Declare the global string variables so everything that imports this file

--- a/src/utils/testing_utilities.h
+++ b/src/utils/testing_utilities.h
@@ -206,18 +206,18 @@ void inline Check_Interface(reconstruction::InterfaceState const &test_data,
   testing_utilities::Check_Results(test_data.density, fiducial_data.density, "density " + message);
   testing_utilities::Check_Results(test_data.energy, fiducial_data.energy, "energy " + message);
   testing_utilities::Check_Results(test_data.pressure, fiducial_data.pressure, "pressure " + message);
-  testing_utilities::Check_Results(test_data.velocity.x, fiducial_data.velocity.x, "velocity.x " + message);
-  testing_utilities::Check_Results(test_data.velocity.y, fiducial_data.velocity.y, "velocity.y " + message);
-  testing_utilities::Check_Results(test_data.velocity.z, fiducial_data.velocity.z, "velocity.z " + message);
-  testing_utilities::Check_Results(test_data.momentum.x, fiducial_data.momentum.x, "momentum.x " + message);
-  testing_utilities::Check_Results(test_data.momentum.y, fiducial_data.momentum.y, "momentum.y " + message);
-  testing_utilities::Check_Results(test_data.momentum.z, fiducial_data.momentum.z, "momentum.z " + message);
+  testing_utilities::Check_Results(test_data.velocity.x(), fiducial_data.velocity.x(), "velocity.x " + message);
+  testing_utilities::Check_Results(test_data.velocity.y(), fiducial_data.velocity.y(), "velocity.y " + message);
+  testing_utilities::Check_Results(test_data.velocity.z(), fiducial_data.velocity.z(), "velocity.z " + message);
+  testing_utilities::Check_Results(test_data.momentum.x(), fiducial_data.momentum.x(), "momentum.x " + message);
+  testing_utilities::Check_Results(test_data.momentum.y(), fiducial_data.momentum.y(), "momentum.y " + message);
+  testing_utilities::Check_Results(test_data.momentum.z(), fiducial_data.momentum.z(), "momentum.z " + message);
 
 #ifdef MHD
   testing_utilities::Check_Results(test_data.total_pressure, fiducial_data.total_pressure, "total_pressure" + message);
-  testing_utilities::Check_Results(test_data.magnetic.x, fiducial_data.magnetic.x, "magnetic.x " + message);
-  testing_utilities::Check_Results(test_data.magnetic.y, fiducial_data.magnetic.y, "magnetic.y " + message);
-  testing_utilities::Check_Results(test_data.magnetic.z, fiducial_data.magnetic.z, "magnetic.z " + message);
+  testing_utilities::Check_Results(test_data.magnetic.x(), fiducial_data.magnetic.x(), "magnetic.x " + message);
+  testing_utilities::Check_Results(test_data.magnetic.y(), fiducial_data.magnetic.y(), "magnetic.y " + message);
+  testing_utilities::Check_Results(test_data.magnetic.z(), fiducial_data.magnetic.z(), "magnetic.z " + message);
 #endif  // MHD
 }
 }  // namespace testing_utilities


### PR DESCRIPTION
# Summary

The primary purpose of this PR is to remove the PCM kernel in favor of a device function called within the Riemann solver kernels. This builds off of PRs #371 and #375 and will show changes from both those PRs and this PR until those PRs are merged into dev. Most of the relevant changes in this PR are in the following files:

- pcm_cuda.cu and .h
- reconstruction.h
- All Riemann solvers

There is some extra machinery in the Riemann solvers at the moment to deal with the fact that one reconstruction is fused and the rest aren't but that will go away once all reconstructions are fused.

The performance gain from fusing the PCM kernel into the Riemann solvers is ~7% in hydro builds and ~12.6% in MHD builds compared to the version of Cholla in PR #375 [run_timing.log](https://github.com/cholla-hydro/cholla/files/14424643/run_timing.log).

## Other Changes

- Fixed a `ifndef` that should have been an `ifdef` when warning that CUDA error checking was disabled
- Added a `HIP_KERNEL_NAME` macro to CUDA builds. This macro is part of the HIP runtime but is not present in the CUDA runtime. It's used in kernel launches to wrap kernel names that have more than one template parameter since the comma in the template arguments plays havoc with some internals of the HIP runtime.
- Remove reference to deprecated `OUTPUT_ALWAYS` build macro
- Fixed a bug in `AutomaticLaunchParams` that would let it set a threads per block number higher than what `__launch_bounds__()` specified. Now it queries the kernel for that number and sets that as the maximum threads per block. This isn't causing any bugs at th moment but It did during some intermediate testing I was doing.
