### PR TITLE
Fix  typo in Brio & Wu Initial Conditions

### DIFF
--- a/examples/3D/Brio_and_Wu.txt
+++ b/examples/3D/Brio_and_Wu.txt
@@ -53,7 +53,7 @@ By_l=1.0
 Bz_l=0.0
 
 # density of right state
-rho_r=0.128
+rho_r=0.125
 # velocity of right state
 vx_r=0
 vy_r=0

--- a/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_BrioAndWuShockTubeCorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tMHDSYSTEMParameterizedMpi_BrioAndWuShockTubeCorrectInputExpectCorrectOutput.txt
@@ -53,7 +53,7 @@ By_l=1.0
 Bz_l=0.0
 
 # density of right state
-rho_r=0.128
+rho_r=0.125
 # velocity of right state
 vx_r=0
 vy_r=0


### PR DESCRIPTION
The initial conditions had a typo. Bx_r should be 0.125 not 0.128. Thanks to Romain Teyssier for pointing it out to me.