### PR TITLE
MPI_GPU patch for hydro build

### DIFF
--- a/builds/make.type.hydro
+++ b/builds/make.type.hydro
@@ -29,3 +29,9 @@ DFLAGS    += -DTEMPERATURE_FLOOR
 # Can also add -DSLICES and -DPROJECTIONS
 OUTPUT    ?=  -DOUTPUT -DHDF5
 DFLAGS    += $(OUTPUT)
+
+#Select if the Hydro Conserved data will reside in the GPU
+#and the MPI transfers are done from the GPU
+#If not specified, MPI_GPU is off by default
+#This is set in the system make.host file
+DFLAGS    += $(MPI_GPU)


### PR DESCRIPTION
The MPI_GPU flag that should be passed from the make.host file was accidentally deleted from the make.type.hydro build. This PR returns it.