### PR TITLE
Remove line introducing a bug in cosmological cooling unit system.

### DIFF
--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -55,10 +55,10 @@ void Grid3D::Initialize_Chemistry(struct Parameters *P)
   Chem.H.time_units       = kpc_km;
   Chem.H.dens_number_conv = Chem.H.density_units / MH;
   #ifdef COSMOLOGY
-  Chem.H.a_value          = Cosmo.current_a;
-  Chem.H.density_units    = Chem.H.density_units / Chem.H.a_value / Chem.H.a_value / Chem.H.a_value;
-  Chem.H.length_units     = Chem.H.length_units / Cosmo.cosmo_h * Chem.H.a_value;
-  Chem.H.time_units       = Chem.H.time_units / Cosmo.cosmo_h;
+  Chem.H.a_value       = Cosmo.current_a;
+  Chem.H.density_units = Chem.H.density_units / Chem.H.a_value / Chem.H.a_value / Chem.H.a_value;
+  Chem.H.length_units  = Chem.H.length_units / Cosmo.cosmo_h * Chem.H.a_value;
+  Chem.H.time_units    = Chem.H.time_units / Cosmo.cosmo_h;
   #endif  // COSMOLOGY
   Chem.H.velocity_units = Chem.H.length_units / Chem.H.time_units;
 

--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -59,7 +59,6 @@ void Grid3D::Initialize_Chemistry(struct Parameters *P)
   Chem.H.density_units    = Chem.H.density_units / Chem.H.a_value / Chem.H.a_value / Chem.H.a_value;
   Chem.H.length_units     = Chem.H.length_units / Cosmo.cosmo_h * Chem.H.a_value;
   Chem.H.time_units       = Chem.H.time_units / Cosmo.cosmo_h;
-  Chem.H.dens_number_conv = Chem.H.dens_number_conv * pow(Chem.H.a_value, 3);
   #endif  // COSMOLOGY
   Chem.H.velocity_units = Chem.H.length_units / Chem.H.time_units;
 


### PR DESCRIPTION
In chemistry_functions.cpp, relative to Bruno's cosmology version, there are changes to the unit system to allow for the CHEMISTRY_GPU modules to be used without COSMOLOGY set. The changes couch scale factor scalings or little h conversions within ifdef COSMOLOGY statements.

On line 62, there is a dens_number_conv that is scaled by a^3. In Bruno's code, this undoes a a^-3 of density_units. However, in this version of the dens_number_conv is set directly by dens_CGS, not density_units, and so the additional factor of a^3 is incorrect.

I have verified that removing line 62 addresses the bug and the results show good agreement with Bruno's version* (* I have only checked with DE off to fairly high redshift, but enough to diagnose this issue).