### PR TITLE
Introducing pre-commit configuration to call clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+ci:
+    autofix_prs: false
+
+
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    # unlike most pre-commit tools, the version of this repository exactly
+    # matches the version of clang-format
+    rev: v17.0.1
+    hooks:
+    -   id: clang-format
+        verbose: true
+        types_or: [c++, c, cuda]
+        args: ["-style=file", "--verbose"]
+

--- a/src/utils/gpu.hpp
+++ b/src/utils/gpu.hpp
@@ -126,8 +126,8 @@ static constexpr int maxWarpsPerBlock = 1024 / WARPSIZE;
   #define hipLaunchKernelGGL(F, G, B, M, S, ...) F<<<G, B, M, S>>>(__VA_ARGS__)
   #define __shfl_down(...)                       __shfl_down_sync(0xFFFFFFFF, __VA_ARGS__)
 
-  // Used to Wrap template kernels with more than one parameter in this to avoid errors. This is present in the HIP
-  // runtime but not the CUDA runtime
+// Used to Wrap template kernels with more than one parameter in this to avoid errors. This is present in the HIP
+// runtime but not the CUDA runtime
   #define HIP_KERNEL_NAME(...)                   __VA_ARGS__
 #endif  // O_HIP
 


### PR DESCRIPTION
### Overview

This introduced a basic configuration file for the [pre-commit](https://pre-commit.com/) software that calls clang-format.

In general, pre-commit is a tool written in python that was originally designed to be use locally (any user of cholla is free to do that). In the original design, it was intended to be used to easily attach varying "lints" to git's "commit-hooks". More recently, pre-commit has become popular for continuous integration. In principle, pre-commit can be used with any arbitrary continuous integration provider (whether it's Jenkins, GitHub Actions, CircleCI, etc.).

We are interested in using [pre-commit.ci](https://pre-commit.ci/), which is a continuous integration system designed around pre-commit. 
- After we set up pre-commit.ci, a check will appear at the bottom of every PR that specifies whether the configured lints (namely just clang-format) passed or failed. 
- pre-commit.ci is free for all open-source software. It also has the nifty feature, where adding a comment that says "pre-commit.ci autofix" to a PR (where the pre-commit.ci check has failed), will trigger pre-commit.ci to add a commit to that PR that fixes the formatting.

``yt`` actually makes use of pre-commit.ci

### What does this PR do?

Specifically, this PR adds the configuration file for pre-commit. I have configured that pre-commit file to use clang-format (with the precise version that matches the wiki -- 17.0.1).

I also made a tweak to a file flagged by a run of pre-commit. ~~I'm a little worried about that... But, if the existing CI test suite succeeds, then I think we are probably fine. (Clang-format will continue to run as part of Jenkins, so will know if any disagreements arise -- there really isn't any risk for Cholla).~~ **EDIT:** I'm no longer worried -- the GitHub action seems to be totally fine with this change in file formatting. Plus, it looks like Jenkins was successful at applying clang-format

### What we need to do after this PR is merged

We will need to go to the [pre-commit.ci](https://pre-commit.ci/) and enable it for the Cholla repository. (I'm happy to try to do that, but I may not have appropriate permissions -- so Evan may need to do that)

