### PR TITLE
Improving thread crash logic

### DIFF
--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -9,6 +9,7 @@
 #include "../global/global.h"
 #include "../grid/grid3D.h"
 #include "../grid/grid_enum.h"    // provides grid_enum
+#include "../hydro/average_cells.h"  // provides Average_Slow_Cells and SlowCellConditionChecker
 #include "../hydro/hydro_cuda.h"  // provides Calc_dt_GPU
 #include "../integrators/VL_1D_cuda.h"
 #include "../integrators/VL_2D_cuda.h"
@@ -152,7 +153,9 @@ void Grid3D::Initialize(struct Parameters *P)
 
 #ifdef AVERAGE_SLOW_CELLS
   H.min_dt_slow = 1e-100;  // Initialize the minumum dt to a tiny number
-#endif                     // AVERAGE_SLOW_CELLS
+#else
+  H.min_dt_slow = -1.0;
+#endif  // AVERAGE_SLOW_CELLS
 
 #ifndef MPI_CHOLLA
 
@@ -578,7 +581,8 @@ Real Grid3D::Update_Hydro_Grid()
   ny_off = ny_local_start;
   nz_off = nz_local_start;
   #endif
-  Average_Slow_Cells(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_fields, H.dx, H.dy, H.dz, gama, max_dti_slow, H.xbound,
+  Average_Slow_Cells(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_fields, gama,
+                     SlowCellConditionChecker(max_dti_slow,H.dx, H.dy, H.dz), H.xbound,
                      H.ybound, H.zbound, nx_off, ny_off, nz_off);
 #endif  // AVERAGE_SLOW_CELLS
 

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -454,7 +454,7 @@ void Grid3D::Execute_Hydro_Integrator(void)
 #ifdef SIMPLE
     Simple_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,
                              H.dz, H.xbound, H.ybound, H.zbound, H.dt, H.n_fields, H.custom_grav, H.density_floor,
-                             C.Grav_potential, SlowCellConditionChecker(1.0 /H.min_dt_slow,H.dx, H.dy, H.dz));
+                             C.Grav_potential, SlowCellConditionChecker(1.0 / H.min_dt_slow, H.dx, H.dy, H.dz));
 #endif  // SIMPLE
   } else {
     chprintf("Error: Grid dimensions nx: %d  ny: %d  nz: %d  not supported.\n", H.nx, H.ny, H.nz);

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -454,7 +454,7 @@ void Grid3D::Execute_Hydro_Integrator(void)
 #ifdef SIMPLE
     Simple_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,
                              H.dz, H.xbound, H.ybound, H.zbound, H.dt, H.n_fields, H.custom_grav, H.density_floor,
-                             C.Grav_potential);
+                             C.Grav_potential, SlowCellConditionChecker(1.0 /H.min_dt_slow,H.dx, H.dy, H.dz));
 #endif  // SIMPLE
   } else {
     chprintf("Error: Grid dimensions nx: %d  ny: %d  nz: %d  not supported.\n", H.nx, H.ny, H.nz);

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -449,7 +449,7 @@ void Grid3D::Execute_Hydro_Integrator(void)
 #ifdef VL
     VL_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,
                          H.dz, H.xbound, H.ybound, H.zbound, H.dt, H.n_fields, H.custom_grav, H.density_floor,
-                         C.Grav_potential);
+                         C.Grav_potential, SlowCellConditionChecker(1.0 /H.min_dt_slow,H.dx, H.dy, H.dz));
 #endif  // VL
 #ifdef SIMPLE
     Simple_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -8,9 +8,9 @@
 #endif
 #include "../global/global.h"
 #include "../grid/grid3D.h"
-#include "../grid/grid_enum.h"    // provides grid_enum
+#include "../grid/grid_enum.h"       // provides grid_enum
 #include "../hydro/average_cells.h"  // provides Average_Slow_Cells and SlowCellConditionChecker
-#include "../hydro/hydro_cuda.h"  // provides Calc_dt_GPU
+#include "../hydro/hydro_cuda.h"     // provides Calc_dt_GPU
 #include "../integrators/VL_1D_cuda.h"
 #include "../integrators/VL_2D_cuda.h"
 #include "../integrators/VL_3D_cuda.h"
@@ -449,7 +449,7 @@ void Grid3D::Execute_Hydro_Integrator(void)
 #ifdef VL
     VL_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,
                          H.dz, H.xbound, H.ybound, H.zbound, H.dt, H.n_fields, H.custom_grav, H.density_floor,
-                         C.Grav_potential, SlowCellConditionChecker(1.0 /H.min_dt_slow,H.dx, H.dy, H.dz));
+                         C.Grav_potential, SlowCellConditionChecker(1.0 / H.min_dt_slow, H.dx, H.dy, H.dz));
 #endif  // VL
 #ifdef SIMPLE
     Simple_Algorithm_3D_CUDA(C.device, C.d_Grav_potential, H.nx, H.ny, H.nz, x_off, y_off, z_off, H.n_ghost, H.dx, H.dy,
@@ -582,8 +582,8 @@ Real Grid3D::Update_Hydro_Grid()
   nz_off = nz_local_start;
   #endif
   Average_Slow_Cells(C.device, H.nx, H.ny, H.nz, H.n_ghost, H.n_fields, gama,
-                     SlowCellConditionChecker(max_dti_slow,H.dx, H.dy, H.dz), H.xbound,
-                     H.ybound, H.zbound, nx_off, ny_off, nz_off);
+                     SlowCellConditionChecker(max_dti_slow, H.dx, H.dy, H.dz), H.xbound, H.ybound, H.zbound, nx_off,
+                     ny_off, nz_off);
 #endif  // AVERAGE_SLOW_CELLS
 
   // ==Calculate the next time step using Calc_dt_GPU from hydro/hydro_cuda.h==

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -210,9 +210,10 @@ struct Header {
    *  \brief Length of the current timestep */
   Real dt;
 
-#ifdef AVERAGE_SLOW_CELLS
+  /*! \brief Cells that introduce timesteps shorter than will be averaged with
+   *         neighboring cells. Should be a negative value when the
+   *         AVERAGE_SLOW_CELLS macro isn't defined. */
   Real min_dt_slow;
-#endif
 
   /*! \var t_wall
    *  \brief Wall time */

--- a/src/hydro/average_cells.h
+++ b/src/hydro/average_cells.h
@@ -10,26 +10,25 @@
 #include "../global/global.h"
 
 /*! \brief Object that checks whether a given cell meets the conditions for slow-cell averaging.
-*          The main motivation for creating this class is reducing ifdef statements (and allow to modify the
-*          actual slow-cell-condition. */
+ *          The main motivation for creating this class is reducing ifdef statements (and allow to modify the
+ *          actual slow-cell-condition. */
 struct SlowCellConditionChecker {
-
-  // omit data-members if they aren't used for anything
-  #ifdef AVERAGE_SLOW_CELLS
+// omit data-members if they aren't used for anything
+#ifdef AVERAGE_SLOW_CELLS
   Real max_dti_slow, dx, dy, dz;
-  #endif
+#endif
 
   /*! \brief Construct a new object. */
   __host__ __device__ SlowCellConditionChecker(Real max_dti_slow, Real dx, Real dy, Real dz)
-  #ifdef AVERAGE_SLOW_CELLS
-    : max_dti_slow{max_dti_slow}, dx{dx}, dy{dy}, dz{dz}
-  #endif
+#ifdef AVERAGE_SLOW_CELLS
+      : max_dti_slow{max_dti_slow}, dx{dx}, dy{dy}, dz{dz}
+#endif
   {
   }
 
   /*! \brief Returns whether the cell meets the condition for being considered a slow cell that must
    *  be averaged. */
-  template<bool verbose = false>
+  template <bool verbose = false>
   __device__ bool is_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
   {
     return this->max_dti_if_slow(E, d, d_inv, vx, vy, vz, gamma) >= 0.0;
@@ -39,18 +38,17 @@ struct SlowCellConditionChecker {
    *  a slow cell. If it doesn't, return a negative value instead.
    */
   __device__ Real max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const;
-
 };
 
 #ifdef AVERAGE_SLOW_CELLS
 
-void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields,
-                        Real gamma, SlowCellConditionChecker slow_check,
-                        Real xbound, Real ybound, Real zbound, int nx_offset, int ny_offset, int nz_offset);
+void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real gamma,
+                        SlowCellConditionChecker slow_check, Real xbound, Real ybound, Real zbound, int nx_offset,
+                        int ny_offset, int nz_offset);
 
 __global__ void Average_Slow_Cells_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields,
-                                      Real gamma, SlowCellConditionChecker slow_check,
-                                      Real xbound, Real ybound, Real zbound, int nx_offset, int ny_offset, int nz_offset);
+                                      Real gamma, SlowCellConditionChecker slow_check, Real xbound, Real ybound,
+                                      Real zbound, int nx_offset, int ny_offset, int nz_offset);
 #endif
 
 #endif /* AVERAGE_CELLS_H */

--- a/src/hydro/average_cells.h
+++ b/src/hydro/average_cells.h
@@ -8,7 +8,6 @@
 #include <math.h>
 
 #include "../global/global.h"
-#include "hydro_cuda.h"
 
 /*! \brief Object that checks whether a given cell meets the conditions for slow-cell averaging.
 *          The main motivation for creating this class is reducing ifdef statements (and allow to modify the
@@ -20,6 +19,7 @@ struct SlowCellConditionChecker {
   Real max_dti_slow, dx, dy, dz;
   #endif
 
+  /*! \brief Construct a new object. */
   __host__ __device__ SlowCellConditionChecker(Real max_dti_slow, Real dx, Real dy, Real dz)
   #ifdef AVERAGE_SLOW_CELLS
     : max_dti_slow{max_dti_slow}, dx{dx}, dy{dy}, dz{dz}
@@ -28,8 +28,7 @@ struct SlowCellConditionChecker {
   }
 
   /*! \brief Returns whether the cell meets the condition for being considered a slow cell that must
-   *  be averaged.
-   */
+   *  be averaged. */
   template<bool verbose = false>
   __device__ bool is_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
   {
@@ -39,18 +38,9 @@ struct SlowCellConditionChecker {
   /*! \brief Returns the max inverse timestep of the specified cell, if it meets the criteria for being
    *  a slow cell. If it doesn't, return a negative value instead.
    */
-  __device__ Real max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
-  {
-  #ifndef AVERAGE_SLOW_CELLS
-    return -1.0;
-  #else
-    Real max_dti = hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma);
-    return (max_dti > max_dti_slow) ? max_dti : -1.0;
-  #endif
-  }
+  __device__ Real max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const;
 
 };
-
 
 #ifdef AVERAGE_SLOW_CELLS
 

--- a/src/hydro/average_cells.h
+++ b/src/hydro/average_cells.h
@@ -1,0 +1,66 @@
+/*! \file average_cells.h
+ *  \brief Definitions of functions and classes that implement logic related to averaging cells with
+ *         neighbors. */
+
+#ifndef AVERAGE_CELLS_H
+#define AVERAGE_CELLS_H
+
+#include <math.h>
+
+#include "../global/global.h"
+#include "hydro_cuda.h"
+
+/*! \brief Object that checks whether a given cell meets the conditions for slow-cell averaging.
+*          The main motivation for creating this class is reducing ifdef statements (and allow to modify the
+*          actual slow-cell-condition. */
+struct SlowCellConditionChecker {
+
+  // omit data-members if they aren't used for anything
+  #ifdef AVERAGE_SLOW_CELLS
+  Real max_dti_slow, dx, dy, dz;
+  #endif
+
+  __host__ __device__ SlowCellConditionChecker(Real max_dti_slow, Real dx, Real dy, Real dz)
+  #ifdef AVERAGE_SLOW_CELLS
+    : max_dti_slow{max_dti_slow}, dx{dx}, dy{dy}, dz{dz}
+  #endif
+  {
+  }
+
+  /*! \brief Returns whether the cell meets the condition for being considered a slow cell that must
+   *  be averaged.
+   */
+  template<bool verbose = false>
+  __device__ bool is_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
+  {
+    return this->max_dti_if_slow(E, d, d_inv, vx, vy, vz, gamma) >= 0.0;
+  }
+
+  /*! \brief Returns the max inverse timestep of the specified cell, if it meets the criteria for being
+   *  a slow cell. If it doesn't, return a negative value instead.
+   */
+  __device__ Real max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
+  {
+  #ifndef AVERAGE_SLOW_CELLS
+    return -1.0;
+  #else
+    Real max_dti = hydroInverseCrossingTime(E, d, d_inv, vx, vy, vz, dx, dy, dz, gamma);
+    return (max_dti > max_dti_slow) ? max_dti : -1.0;
+  #endif
+  }
+
+};
+
+
+#ifdef AVERAGE_SLOW_CELLS
+
+void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields,
+                        Real gamma, SlowCellConditionChecker slow_check,
+                        Real xbound, Real ybound, Real zbound, int nx_offset, int ny_offset, int nz_offset);
+
+__global__ void Average_Slow_Cells_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields,
+                                      Real gamma, SlowCellConditionChecker slow_check,
+                                      Real xbound, Real ybound, Real zbound, int nx_offset, int ny_offset, int nz_offset);
+#endif
+
+#endif /* AVERAGE_CELLS_H */

--- a/src/hydro/hydro_cuda.cu
+++ b/src/hydro/hydro_cuda.cu
@@ -381,10 +381,11 @@ __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, R
   }
 }
 
-__global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off, int y_off, int z_off, 
-                                                        int n_ghost, Real gamma, int n_fields, SlowCellConditionChecker slow_check)
+__global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off,
+                                                        int y_off, int z_off, int n_ghost, Real gamma, int n_fields,
+                                                        SlowCellConditionChecker slow_check)
 {
-  int n_cells    = nx * ny * nz;
+  int n_cells = nx * ny * nz;
 
   // get a global thread ID
   int id  = threadIdx.x + blockIdx.x * blockDim.x;
@@ -394,9 +395,8 @@ __global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int
 
   if (xid > n_ghost - 1 && xid < nx - n_ghost && yid > n_ghost - 1 && yid < ny - n_ghost && zid > n_ghost - 1 &&
       zid < nz - n_ghost) {
-
 #if !(defined(DENSITY_FLOOR) && defined(TEMPERATURE_FLOOR))
-  // threads corresponding to real cells do the calculation
+    // threads corresponding to real cells do the calculation
     if (dev_conserved[id] < 0.0 || dev_conserved[id] != dev_conserved[id] || dev_conserved[4 * n_cells + id] < 0.0 ||
         dev_conserved[4 * n_cells + id] != dev_conserved[4 * n_cells + id]) {
       printf("%3d %3d %3d Thread crashed in final update. %e - - - %e\n", xid + x_off, yid + y_off, zid + z_off,
@@ -683,7 +683,8 @@ void Temperature_Ceiling(Real *dev_conserved, int nx, int ny, int nz, int n_ghos
   }
 }
 
-__device__ Real SlowCellConditionChecker::max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz, Real gamma) const
+__device__ Real SlowCellConditionChecker::max_dti_if_slow(Real E, Real d, Real d_inv, Real vx, Real vy, Real vz,
+                                                          Real gamma) const
 {
 #ifndef AVERAGE_SLOW_CELLS
   return -1.0;
@@ -695,9 +696,9 @@ __device__ Real SlowCellConditionChecker::max_dti_if_slow(Real E, Real d, Real d
 
 #ifdef AVERAGE_SLOW_CELLS
 
-void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields,
-                        Real gamma, SlowCellConditionChecker slow_check,
-                        Real xbound, Real ybound, Real zbound, int nx_offset, int ny_offset, int nz_offset)
+void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real gamma,
+                        SlowCellConditionChecker slow_check, Real xbound, Real ybound, Real zbound, int nx_offset,
+                        int ny_offset, int nz_offset)
 {
   // set values for GPU kernels
   int n_cells = nx * ny * nz;
@@ -1309,9 +1310,7 @@ __device__ void Average_Cell_All_Fields(int i, int j, int k, int nx, int ny, int
   for (int kk = k - 1; kk <= k + 1; kk++) {
     for (int jj = j - 1; jj <= j + 1; jj++) {
       for (int ii = i - 1; ii <= i + 1; ii++) {
-
-        if (ii <= stale_depth - 1 || ii >= nx - stale_depth ||
-            jj <= stale_depth - 1 || jj >= ny - stale_depth ||
+        if (ii <= stale_depth - 1 || ii >= nx - stale_depth || jj <= stale_depth - 1 || jj >= ny - stale_depth ||
             kk <= stale_depth - 1 || kk >= nz - stale_depth) {
           continue;
         }

--- a/src/hydro/hydro_cuda.cu
+++ b/src/hydro/hydro_cuda.cu
@@ -757,7 +757,7 @@ __global__ void Average_Slow_Cells_3D(Real *dev_conserved, int nx, int ny, int n
           x, y, z, 1. / max_dti, 1. / slow_check.max_dti_slow, dev_conserved[id] * DENSITY_UNIT / 0.6 / MP, temp,
           speed * VELOCITY_UNIT * 1e-5, vx * VELOCITY_UNIT * 1e-5, vy * VELOCITY_UNIT * 1e-5, vz * VELOCITY_UNIT * 1e-5,
           cs);
-      Average_Cell_All_Fields(xid, yid, zid, nx, ny, nz, n_cells, n_fields, gamma, dev_conserved, 0, slow_check);
+      Average_Cell_All_Fields(xid, yid, zid, nx, ny, nz, n_cells, n_fields, gamma, dev_conserved, n_ghost, slow_check);
     }
   }
 }

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -83,16 +83,7 @@ void Temperature_Ceiling(Real *dev_conserved, int nx, int ny, int nz, int n_ghos
                          Real T_ceiling);
 #endif  // TEMPERATURE CEILING
 
-#ifdef AVERAGE_SLOW_CELLS
 
-void Average_Slow_Cells(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx, Real dy,
-                        Real dz, Real gamma, Real max_dti_slow, Real xbound, Real ybound, Real zbound, int nx_offset,
-                        int ny_offset, int nz_offset);
-
-__global__ void Average_Slow_Cells_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real dx,
-                                      Real dy, Real dz, Real gamma, Real max_dti_slow, Real xbound, Real ybound,
-                                      Real zbound, int nx_offset, int ny_offset, int nz_offset);
-#endif
 
 void Apply_Temperature_Floor(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real U_floor);
 

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -22,8 +22,9 @@ __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, R
                                               Real gamma, int n_fields, int custom_grav, Real density_floor,
                                               Real *dev_potential);
 
-__global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off, int y_off, int z_off, 
-                                                        int n_ghost, Real gamma, int n_fields, SlowCellConditionChecker slow_check);
+__global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off,
+                                                        int y_off, int z_off, int n_ghost, Real gamma, int n_fields,
+                                                        SlowCellConditionChecker slow_check);
 
 /*!
  * \brief Determine the maximum inverse crossing time in a specific cell
@@ -83,8 +84,6 @@ __global__ void Sync_Energies_3D(Real *dev_conserved, int nx, int ny, int nz, in
 void Temperature_Ceiling(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real gamma,
                          Real T_ceiling);
 #endif  // TEMPERATURE CEILING
-
-
 
 void Apply_Temperature_Floor(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields, Real U_floor);
 

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -123,7 +123,7 @@ __global__ void Select_Internal_Energy_2D(Real *dev_conserved, int nx, int ny, i
 __global__ void Select_Internal_Energy_3D(Real *dev_conserved, int nx, int ny, int nz, int n_ghost, int n_fields);
 
 __device__ void Average_Cell_All_Fields(int i, int j, int k, int nx, int ny, int nz, int ncells, int n_fields,
-                                        Real gamma, Real *conserved);
+                                        Real gamma, Real *conserved, int stale_depth);
 
 __device__ Real Average_Cell_Single_Field(int field_indx, int i, int j, int k, int nx, int ny, int nz, int ncells,
                                           Real *conserved);

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -5,6 +5,7 @@
 #define HYDRO_CUDA_H
 
 #include "../global/global.h"
+#include "../hydro/average_cells.h"
 #include "../utils/mhd_utilities.h"
 
 __global__ void Update_Conserved_Variables_1D(Real *dev_conserved, Real *dev_F, int n_cells, int x_off, int n_ghost,
@@ -22,7 +23,7 @@ __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, R
                                               Real *dev_potential);
 
 __global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off, int y_off, int z_off, 
-                                                        int n_ghost, Real gamma, int n_fields);
+                                                        int n_ghost, Real gamma, int n_fields, SlowCellConditionChecker slow_check);
 
 /*!
  * \brief Determine the maximum inverse crossing time in a specific cell
@@ -143,7 +144,8 @@ __global__ void Select_Internal_Energy_3D(Real *dev_conserved, int nx, int ny, i
  *    * Aside: a similar argument could be made for the energy-synchronization step of the dual-energy formalism.
  */
 __device__ void Average_Cell_All_Fields(int i, int j, int k, int nx, int ny, int nz, int ncells, int n_fields,
-                                        Real gamma, Real *conserved, int stale_depth);
+                                        Real gamma, Real *conserved, int stale_depth,
+                                        SlowCellConditionChecker slow_check);
 
 __device__ Real Average_Cell_Single_Field(int field_indx, int i, int j, int k, int nx, int ny, int nz, int ncells,
                                           Real *conserved);

--- a/src/hydro/hydro_cuda.h
+++ b/src/hydro/hydro_cuda.h
@@ -21,6 +21,9 @@ __global__ void Update_Conserved_Variables_3D(Real *dev_conserved, Real *Q_Lx, R
                                               Real gamma, int n_fields, int custom_grav, Real density_floor,
                                               Real *dev_potential);
 
+__global__ void PostUpdate_Conserved_Correct_Crashed_3D(Real *dev_conserved, int nx, int ny, int nz, int x_off, int y_off, int z_off, 
+                                                        int n_ghost, Real gamma, int n_fields);
+
 /*!
  * \brief Determine the maximum inverse crossing time in a specific cell
  *

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -35,7 +35,8 @@ __global__ void Update_Conserved_Variables_3D_half(Real *dev_conserved, Real *de
 
 void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                           int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
-                          Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential)
+                          Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
+                          const SlowCellConditionChecker& slow_check)
 {
   // Here, *dev_conserved contains the entire
   // set of conserved variables on the grid
@@ -376,7 +377,7 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   // Step 6b: Address any crashed threads
   hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, update_full_launch_params.get_numBlocks(),
                      update_full_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, nx, ny, nz, x_off, y_off, z_off, 
-                     n_ghost, gama, n_fields);
+                     n_ghost, gama, n_fields, slow_check);
 
   #ifdef MHD
   // Update the magnetic fields

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -373,6 +373,11 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
                      dt, gama, n_fields, custom_grav, density_floor, dev_grav_potential);
   GPU_Error_Check();
 
+  // Step 6b: Address any crashed threads
+  hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, update_full_launch_params.get_numBlocks(),
+                     update_full_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, nx, ny, nz, x_off, y_off, z_off, 
+                     n_ghost, gama, n_fields);
+
   #ifdef MHD
   // Update the magnetic fields
   hipLaunchKernelGGL(mhd::Update_Magnetic_Field_3D, update_magnetic_launch_params.get_numBlocks(),

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -36,7 +36,7 @@ __global__ void Update_Conserved_Variables_3D_half(Real *dev_conserved, Real *de
 void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                           int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
                           Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
-                          const SlowCellConditionChecker& slow_check)
+                          const SlowCellConditionChecker &slow_check)
 {
   // Here, *dev_conserved contains the entire
   // set of conserved variables on the grid
@@ -376,8 +376,8 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
 
   // Step 6b: Address any crashed threads
   hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, update_full_launch_params.get_numBlocks(),
-                     update_full_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, nx, ny, nz, x_off, y_off, z_off, 
-                     n_ghost, gama, n_fields, slow_check);
+                     update_full_launch_params.get_threadsPerBlock(), 0, 0, dev_conserved, nx, ny, nz, x_off, y_off,
+                     z_off, n_ghost, gama, n_fields, slow_check);
 
   #ifdef MHD
   // Update the magnetic fields

--- a/src/integrators/VL_3D_cuda.h
+++ b/src/integrators/VL_3D_cuda.h
@@ -10,7 +10,7 @@
 void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                           int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
                           Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
-                          const SlowCellConditionChecker& slow_check);
+                          const SlowCellConditionChecker &slow_check);
 
 void Free_Memory_VL_3D();
 

--- a/src/integrators/VL_3D_cuda.h
+++ b/src/integrators/VL_3D_cuda.h
@@ -5,10 +5,12 @@
 #define VL_3D_CUDA_H
 
 #include "../global/global.h"
+#include "../hydro/average_cells.h"
 
 void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                           int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
-                          Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential);
+                          Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
+                          const SlowCellConditionChecker& slow_check);
 
 void Free_Memory_VL_3D();
 

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -25,7 +25,7 @@
 void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                               int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
                               Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
-                              const SlowCellConditionChecker& slow_check)
+                              const SlowCellConditionChecker &slow_check)
 {
   // Here, *dev_conserved contains the entire
   // set of conserved variables on the grid
@@ -156,8 +156,8 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
   GPU_Error_Check();
 
   // Step 3b: Address any crashed threads
-  hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, dim1dGrid, dim1dBlock, 0, 0,
-                     dev_conserved, nx, ny, nz, x_off, y_off, z_off, n_ghost, gama, n_fields, slow_check);
+  hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, nx, ny, nz,
+                     x_off, y_off, z_off, n_ghost, gama, n_fields, slow_check);
   GPU_Error_Check();
 
   #ifdef DE

--- a/src/integrators/simple_3D_cuda.cu
+++ b/src/integrators/simple_3D_cuda.cu
@@ -24,7 +24,8 @@
 
 void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                               int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
-                              Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential)
+                              Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
+                              const SlowCellConditionChecker& slow_check)
 {
   // Here, *dev_conserved contains the entire
   // set of conserved variables on the grid
@@ -152,6 +153,11 @@ void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx,
   hipLaunchKernelGGL(Update_Conserved_Variables_3D, dim1dGrid, dim1dBlock, 0, 0, dev_conserved, Q_Lx, Q_Rx, Q_Ly, Q_Ry,
                      Q_Lz, Q_Rz, F_x, F_y, F_z, nx, ny, nz, x_off, y_off, z_off, n_ghost, dx, dy, dz, xbound, ybound,
                      zbound, dt, gama, n_fields, custom_grav, density_floor, dev_grav_potential);
+  GPU_Error_Check();
+
+  // Step 3b: Address any crashed threads
+  hipLaunchKernelGGL(PostUpdate_Conserved_Correct_Crashed_3D, dim1dGrid, dim1dBlock, 0, 0,
+                     dev_conserved, nx, ny, nz, x_off, y_off, z_off, n_ghost, gama, n_fields, slow_check);
   GPU_Error_Check();
 
   #ifdef DE

--- a/src/integrators/simple_3D_cuda.h
+++ b/src/integrators/simple_3D_cuda.h
@@ -10,7 +10,7 @@
 void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                               int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
                               Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
-                              const SlowCellConditionChecker& slow_check);
+                              const SlowCellConditionChecker &slow_check);
 
 void Free_Memory_Simple_3D();
 

--- a/src/integrators/simple_3D_cuda.h
+++ b/src/integrators/simple_3D_cuda.h
@@ -9,7 +9,8 @@
 
 void Simple_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int ny, int nz, int x_off, int y_off,
                               int z_off, int n_ghost, Real dx, Real dy, Real dz, Real xbound, Real ybound, Real zbound,
-                              Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential);
+                              Real dt, int n_fields, int custom_grav, Real density_floor, Real *host_grav_potential,
+                              const SlowCellConditionChecker& slow_check);
 
 void Free_Memory_Simple_3D();
 


### PR DESCRIPTION
This introduces 3 changes to the behavior revolving around fixing thread-crashes (i.e. density or energy drops to a negative value). For the uninitiated, the default behavior in a thread-crash, when `DENSITY_FLOOR` isn't defined, is to call `Average_Cell_All_Fields`, which overrides the values in the crashed cell with the values from the neighboring cells.

The 3 changes include:

1. **A major synchronization bugfix:**
   - we moved the call to `Average_Cell_All_Fields` from the `Update_Conserved_Variables_3D` kernel to the newly created `PostUpdate_Conserved_Correct_Crashed_3D` kernel. We always launch `PostUpdate_Conserved_Correct_Crashed_3D` after `Update_Conserved_Variables_3D`
   - Previously, we could be averaging the values of neighboring cells while they were in the middle of an update. 
   - This was producing large spikes in Energy (1000 times larger than a supernova) in our simulations. This fix seemed to fix a little more than I was expecting (I still need to finish examining that).
2. A minor bugfix:
   - Previously `Average_Cell_All_Fields` always looked for neighbors, regardless of where the central cell was located on a grid. So if you were at the edge of the active zone, you might include the values of cells in the ghost-zone. This was problematic when dealing with a crashed-cell at the hydro update when the ghost zones had not been updated yet (it's unclear if this commonly happened).
   - Care was taken to maintain existing behavior in `Average_Slow_Cells`, which could apply `Average_Cell_All_Fields` to a slow-cell at identified at any location on the grid (in the ghost zone or active zone).[^1] My change also happens
3. A minor improvement:
   - Previously the `Average_Cell_All_Fields` would ignore any neighboring cells with a non-positive density or pressure. 
   - This PR extends the behavior to also ignore any cells that would be considered a "slow" cell and will need to be separately averaged. (When the `AVERAGE_SLOW_CELLS` macro isn't defined, no cell is considered a "slow" cell)


The implementation of the third change got a little hairy. In principle I think it's a good design choice (especially for reducing ifdef statements). But, with the benefit of hindsight, maybe I should have done something simpler. Definitely open to feedback on this point!

[^1]: In this case we continue for a cell on the edge of the active zone, we will include cells in the ghost zone in the average. As I write this out, I'm not totally sure the ghost zones are refreshed between the invocation of the Hydro-Solver and the call to `Average_Slow_Cells`. **That is something to followup on!**