### PR TITLE
WIP: Dumping hdf5 parameters

### DIFF
--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -813,8 +813,7 @@ class Grid3D
   void Transfer_Particles_Density_Boundaries(struct Parameters P);
   void Copy_Particles_Density_Buffer_Device_to_Host(int direction, int side, Real *buffer_d, Real *buffer_h);
   // void Transfer_Particles_Boundaries( struct Parameters P );
-  void WriteData_Particles(struct Parameters P, int nfile);
-  void OutputData_Particles(struct Parameters P, int nfile);
+  void OutputData_Particles(struct Parameters P, const ParameterMap& pmap, int nfile);
   void Load_Particles_Data(struct Parameters P);
   #ifdef HDF5
   void Write_Particles_Header_HDF5(hid_t file_id);

--- a/src/io/ParameterMap.h
+++ b/src/io/ParameterMap.h
@@ -101,6 +101,27 @@ class ParameterMap
   /* queries the number of parameters (mostly for testing purposes) */
   std::size_t size() { return entries_.size(); }
 
+  /*! \brief Applies the given function object ``f`` on each parameter, parameter-value pair
+   *
+   *  Since the parameter file-format doesn't have syntactic typing, the value is always
+   *  provided as a string. The function object should have accept 2 arguments of type
+   * ``const std::string&``.
+   *
+   *  \note
+   *  This method has no impact on whether a value has been "accessed"
+   *
+   *  \note
+   *  In the future, it may be better to provide an iterator rather than this function.
+   */
+  template<typename Fn>
+  void for_each(Fn f) const {
+    for (const auto& kv_pair : entries_) {
+      const std::string& key = kv_pair.first;
+      const std::string& val = kv_pair.second.param_str;
+      f(key, val);
+    }
+  }
+
   /* queries whether the parameter exists. */
   bool has_param(const std::string& param) { return entries_.find(param) != entries_.end(); }
 

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -127,14 +127,14 @@ void Write_Data(Grid3D &G, struct Parameters P, const ParameterMap& pmap, int nf
 #ifndef ONLY_PARTICLES
   /*call the data output routine for Hydro data*/
   if (nfile % P.n_hydro == 0) {
-    Output_Data(G, P, nfile);
+    Output_Data(G, P, pmap, nfile);
   }
 #endif
 
 // This function does other checks to make sure it is valid (3D only)
 #ifdef HDF5
   if (P.n_out_float32 && nfile % P.n_out_float32 == 0) {
-    Output_Float32(G, P, nfile);
+    Output_Float32(G, P, pmap, nfile);
   }
 #endif
 
@@ -158,7 +158,7 @@ void Write_Data(Grid3D &G, struct Parameters P, const ParameterMap& pmap, int nf
 
 #ifdef PARTICLES
   if (nfile % P.n_particle == 0) {
-    G.WriteData_Particles(P, nfile);
+    G.OutputData_Particles(P, pmap, nfile);
   }
 #endif
 
@@ -196,7 +196,7 @@ void Write_Data(Grid3D &G, struct Parameters P, const ParameterMap& pmap, int nf
 }
 
 /* Output the grid data to file. */
-void Output_Data(Grid3D &G, struct Parameters P, int nfile)
+void Output_Data(Grid3D &G, struct Parameters P, const ParameterMap& pmap, int nfile)
 {
   // create the filename
   std::string filename = FnameTemplate(P).format_fname(nfile, "");
@@ -234,6 +234,9 @@ void Output_Data(Grid3D &G, struct Parameters P, int nfile)
   // Write the header (file attributes)
   G.Write_Header_HDF5(file_id);
 
+  // Record a copy of the parameter values
+  Write_HDF5_pmap(file_id, pmap);
+
   // write the conserved variables to the output file
   G.Write_Grid_HDF5(file_id);
 
@@ -265,7 +268,7 @@ void Output_Data(Grid3D &G, struct Parameters P, int nfile)
 #endif
 }
 
-void Output_Float32(Grid3D &G, struct Parameters P, int nfile)
+void Output_Float32(Grid3D &G, struct Parameters P, const ParameterMap& pmap, int nfile)
 {
 #ifdef HDF5
   Header H = G.H;
@@ -293,6 +296,9 @@ void Output_Float32(Grid3D &G, struct Parameters P, int nfile)
 
   // Write the header (file attributes)
   G.Write_Header_HDF5(file_id);
+
+  // Record a copy of the parameter values
+  Write_HDF5_pmap(file_id, pmap);
 
   // write the conserved variables to the output file
 

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -6,9 +6,10 @@
 
 #include "../global/global.h"
 #include "../grid/grid3D.h"
+#include "../io/ParameterMap.h"
 
 /* Write the data */
-void Write_Data(Grid3D& G, struct Parameters P, int nfile);
+void Write_Data(Grid3D& G, struct Parameters P, const ParameterMap& pmap, int nfile);
 
 /* Output the grid data to file. */
 void Output_Data(Grid3D& G, struct Parameters P, int nfile);
@@ -123,6 +124,8 @@ herr_t Read_HDF5_Dataset(hid_t file_id, float* dataset_buffer, const char* name)
 
 herr_t Write_HDF5_Dataset(hid_t file_id, hid_t dataspace_id, double* dataset_buffer, const char* name);
 herr_t Write_HDF5_Dataset(hid_t file_id, hid_t dataspace_id, float* dataset_buffer, const char* name);
+
+bool Write_HDF5_pmap(hid_t file_id, const ParameterMap& pmap);
 
 /* \brief After HDF5 reads data into a buffer, remap and write to grid buffer. */
 void Fill_Grid_From_HDF5_Buffer(int nx, int ny, int nz, int nx_real, int ny_real, int nz_real, int n_ghost,

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -12,10 +12,10 @@
 void Write_Data(Grid3D& G, struct Parameters P, const ParameterMap& pmap, int nfile);
 
 /* Output the grid data to file. */
-void Output_Data(Grid3D& G, struct Parameters P, int nfile);
+void Output_Data(Grid3D& G, struct Parameters P, const ParameterMap& pmap, int nfile);
 
 /* Output the grid data to file as 32-bit floats. */
-void Output_Float32(Grid3D& G, struct Parameters P, int nfile);
+void Output_Float32(Grid3D& G, struct Parameters P, const ParameterMap& pmap, int nfile);
 
 /* Output a projection of the grid data to file. */
 void Output_Projected_Data(Grid3D& G, struct Parameters P, int nfile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
   if (!is_restart || G.H.Output_Now) {
     // write the initial conditions to file
     chprintf("Writing initial conditions to file...\n");
-    Write_Data(G, P, nfile);
+    Write_Data(G, P, pmap, nfile);
   }
   // add one to the output file count
   nfile++;
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
     if (G.H.t == outtime || G.H.Output_Now) {
 #ifdef OUTPUT
       /*output the grid data*/
-      Write_Data(G, P, nfile);
+      Write_Data(G, P, pmap, nfile);
       // add one to the output file count
       nfile++;
 #endif  // OUTPUT
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
     // Exit the loop when reached the limit number of steps (optional)
     if (G.H.n_step >= P.n_steps_limit and P.n_steps_limit > 0) {
 #ifdef OUTPUT
-      Write_Data(G, P, nfile);
+      Write_Data(G, P, pmap, nfile);
 #endif  // OUTPUT
       break;
     }

--- a/src/particles/io_particles.cpp
+++ b/src/particles/io_particles.cpp
@@ -61,12 +61,6 @@ void Particles3D::Load_Particles_Data(struct Parameters *P)
   #endif
 }
 
-void Grid3D::WriteData_Particles(struct Parameters P, int nfile)
-{
-  // Write the particles data to file
-  OutputData_Particles(P, nfile);
-}
-
   #ifdef HDF5
 
 void Particles3D::Load_Particles_Data_HDF5(hid_t file_id, int nfile, struct Parameters *P)
@@ -754,7 +748,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
 }
   #endif  // HDF5
 
-void Grid3D::OutputData_Particles(struct Parameters P, int nfile)
+void Grid3D::OutputData_Particles(struct Parameters P, const ParameterMap& pmap, int nfile)
 {
   FILE *out;
   std::string filename = FnameTemplate(P).format_fname(nfile, "_particles");
@@ -773,6 +767,7 @@ void Grid3D::OutputData_Particles(struct Parameters P, int nfile)
 
   // Write header (file attributes)
   Write_Header_HDF5(file_id);
+  Write_HDF5_pmap(file_id, pmap);
   Write_Particles_Header_HDF5(file_id);
   Write_Particles_Data_HDF5(file_id);
 


### PR DESCRIPTION
This is a work-in-progress PR to add the ability to dump entries in a parameter-map.

Things to do:
- figure out why we are crashing
- probably need to update the concatenation scripts
- do we only want to write out the parameter files to a single file?