### PR TITLE
Introduce new organizational schema format for storing Cholla data

### DIFF
--- a/python_scripts/concat.py
+++ b/python_scripts/concat.py
@@ -7,23 +7,22 @@ At the moment, we only support fluid quantities. In the future, we could
 support other types of fields.
 """
 
-import numpy as np
-
 import argparse
 import datetime
 from functools import partial
 import os
-import pathlib
 
 import concat_internals
 from concat_2d_data import concat_2d_dataset
 from concat_3d_data import concat_3d_dataset
+from snaprepack import dset_opts_from_args
+
 
 parser = argparse.ArgumentParser(
     description = ("Concatenates HDF5 ouputs produced by Cholla")
 )
-concat_internals.add_common_cli_args(parser, num_processes_choice = 'omit',
-                                     add_concat_outputs_arg = False)
+concat_internals.add_common_cli_args(parser, num_processes_choice = 'omit')
+concat_internals.add_src_cli_args(parser, add_concat_outputs_arg=False)
 
 _2D_kinds = ("proj", "slice", "rot_proj")
 
@@ -115,14 +114,22 @@ def main(args):
         command_triples.append(
             ('3D',
              partial(temp_build_source_path, pre_extension_suffix = ''),
-             concat_3d_dataset)
+             partial(concat_3d_dataset, dset_opts=dset_opts_from_args(args)))
         )
     for kind_2D, kwargs in kindkw_2D_pairs:
         command_triples.append(
             (kind_2D,
              partial(temp_build_source_path,
                      pre_extension_suffix = f'_{kind_2D}'),
-             partial(concat_2d_dataset, dataset_kind=kind_2D, **kwargs))
+             partial(
+                 concat_2d_dataset,
+                 dataset_kind=kind_2D,
+                 destination_dtype=args.dtype,
+                 compression_type=args.compression_type,
+                 compression_options=args.compression_opts,
+                 chunking=args.chunking
+                 **kwargs)
+             )
         )
 
     #raise RuntimeError(repr(command_triples))
@@ -144,11 +151,7 @@ def main(args):
             concat_fn(output_directory=args.output_directory,
                       output_number=output,
                       build_source_path = build_source_path,
-                      skip_fields=args.skip_fields,
-                      destination_dtype=args.dtype,
-                      compression_type=args.compression_type,
-                      compression_options=args.compression_opts,
-                      chunking=args.chunking)
+                      skip_fields=args.skip_fields)
             t2 = datetime.datetime.now()
             print(f'  -> {dset_kind!r}: {(t2 - t1).total_seconds()}')
 

--- a/python_scripts/concat_3d_data.py
+++ b/python_scripts/concat_3d_data.py
@@ -39,7 +39,8 @@ def concat_3d_dataset(output_directory: pathlib.Path,
                       *,
                       num_processes: Optional[int] = None,
                       skip_fields: list = [],
-                      dset_opts: Optional[DatasetOpts] = None) -> None:
+                      dset_opts: Optional[DatasetOpts] = None,
+                      legacy_field: bool = False) -> None:
   """Concatenate a single 3D HDF5 Cholla dataset. i.e. take the single files
   generated per process and concatenate them into a single, large file.
 
@@ -60,6 +61,8 @@ def concat_3d_dataset(output_directory: pathlib.Path,
       from the hdf5 file and the parameter will be removed in the future.
   dset_opts
       Optional kwargs for ``h5py.Group.create_dataset``.
+  legacy_field
+      When True, the "field_legacy" HDF5 group will be created.
   """
 
   src_path_0 = build_source_path(proc_id=0, nfile=output_number)
@@ -88,7 +91,7 @@ def concat_3d_dataset(output_directory: pathlib.Path,
     # let's write the concatenated file
     with SnapBuilder(output_directory / f'{output_number}.h5') as builder:
       builder.set_hdr(src_f_0) \
-        .field_config(opts=dset_opts, skip=skip_fields) \
+        .field_config(opts=dset_opts, skip=skip_fields, legacy=legacy_field) \
         .field_record_itr(itr, file_paths=True) \
         .write()
 
@@ -99,6 +102,7 @@ if __name__ == '__main__':
   start = default_timer()
 
   cli = concat_internals.common_cli(num_processes_choice = 'deprecate')
+  concat_internals._add_legacyfield_arg(cli)
   args = cli.parse_args()
 
   dset_opts = dset_opts_from_args(args)
@@ -114,6 +118,7 @@ if __name__ == '__main__':
                       output_number=output,
                       build_source_path = build_source_path,
                       skip_fields=args.skip_fields,
-                      dset_opts=dset_opts)
+                      dset_opts=dset_opts,
+                      legacy_field=args.legacy_field)
 
   print(f'\nTime to execute: {round(default_timer()-start,2)} seconds')

--- a/python_scripts/concat_3d_data.py
+++ b/python_scripts/concat_3d_data.py
@@ -13,25 +13,33 @@ import concat_3d_data
 """
 
 import h5py
-import numpy as np
 
+import os
 import pathlib
 from typing import Optional
 import warnings
 
 import concat_internals
+from snaprepack import DatasetOpts, dset_opts_from_args, SnapBuilder
 
 # ==============================================================================
+def _check_num_processes_arg(path: os.PathLike, num_processes_arg: int):
+
+  with h5py.File(path, "r") as f:
+    num_files = concat_internals.infer_numfiles_from_header(f.attrs)
+    if (num_processes_arg != num_files):
+      raise RuntimeError(
+        f"header of {path!r} implies that it contains a subset of data that was split "
+        f"across {num_files} files (rather than across {num_processes_arg} files).")
+  return num_files
+
 def concat_3d_dataset(output_directory: pathlib.Path,
                       output_number: int,
                       build_source_path,
                       *,
                       num_processes: Optional[int] = None,
                       skip_fields: list = [],
-                      destination_dtype: np.dtype = None,
-                      compression_type: str = None,
-                      compression_options: str = None,
-                      chunking = None) -> None:
+                      dset_opts: Optional[DatasetOpts] = None) -> None:
   """Concatenate a single 3D HDF5 Cholla dataset. i.e. take the single files
   generated per process and concatenate them into a single, large file.
 
@@ -50,89 +58,40 @@ def concat_3d_dataset(output_directory: pathlib.Path,
   num_processes : int, optional
       The number of ranks that Cholla was run with. This information is now inferred
       from the hdf5 file and the parameter will be removed in the future.
-  destination_dtype : np.dtype
-      The data type of the output datasets. Accepts most numpy types. Defaults to the same as the input datasets.
-  compression_type : str
-      What kind of compression to use on the output data. Defaults to None.
-  compression_options : str
-      What compression settings to use if compressing. Defaults to None.
-  chunking : bool or tuple
-      Whether or not to use chunking and the chunk size. Defaults to None.
+  dset_opts
+      Optional kwargs for ``h5py.Group.create_dataset``.
   """
 
-  if num_processes is not None:
-    warnings.warn('the num_processes parameter will be removed')
+  src_path_0 = build_source_path(proc_id=0, nfile=output_number)
 
   # Error checking
   assert output_number >= 0, 'output_number must be greater than or equal to 0'
+  if num_processes is not None:
+    warnings.warn('the num_processes parameter will be removed')
+    _check_num_processes_arg(src_path_0, num_processes_arg=num_processes)
 
-  # Open the output file for writing
-  destination_file = concat_internals.destination_safe_open(output_directory / f'{output_number}.h5')
 
-  # Setup the output file
-  source_fname_0 = build_source_path(proc_id = 0, nfile = output_number)
-  with h5py.File(source_fname_0, 'r') as source_file:
-
-    # determine how many files data must be concatenated from
-    num_files = concat_internals.infer_numfiles_from_header(source_file.attrs)
-
-    if (num_processes is not None) and (num_processes != num_files):
-      raise RuntimeError(
-        f"header of {source_fname_0!r} implies that it contains data that is "
-        f"split across {num_files} files (rather than {num_processes} files).")
-    elif num_files < 2:
+  # we open up the file associated with source-file 0 to examine header details
+  with h5py.File(src_path_0, "r") as src_f_0:
+    num_files = concat_internals.infer_numfiles_from_header(src_f_0.attrs)
+    if num_files < 2:
       raise RuntimeError('it only makes sense to concatenate data split across '
                          '2 or more files')
 
-    # Copy header data
-    destination_file = concat_internals.copy_header(source_file, destination_file)
+    # create iterator over (blockid, fname) pairs. Note: the very 1st entry will
+    # correspond to src_path_0, but that's totally okay
+    itr = (
+      (blockid, build_source_path(proc_id=blockid, nfile=output_number))
+      for blockid in range(0, num_files)
+    )
 
-    # Create the datasets in the output file
-    datasets_to_copy = list(source_file.keys())
-    datasets_to_copy = [dataset for dataset in datasets_to_copy if not dataset in skip_fields]
+    # let's write the concatenated file
+    with SnapBuilder(output_directory / f'{output_number}.h5') as builder:
+      builder.set_hdr(src_f_0) \
+        .field_config(opts=dset_opts, skip=skip_fields) \
+        .field_record_itr(itr, file_paths=True) \
+        .write()
 
-    for dataset in datasets_to_copy:
-      dtype = source_file[dataset].dtype if (destination_dtype == None) else destination_dtype
-
-      data_shape = source_file.attrs['dims']
-
-      if dataset == 'magnetic_x': data_shape[0] += 1
-      if dataset == 'magnetic_y': data_shape[1] += 1
-      if dataset == 'magnetic_z': data_shape[2] += 1
-
-      destination_file.create_dataset(name=dataset,
-                                      shape=data_shape,
-                                      dtype=dtype,
-                                      chunks=chunking,
-                                      compression=compression_type,
-                                      compression_opts=compression_options)
-
-  # loop over files for a given output
-  for i in range(0, num_files):
-    # open the input file for reading
-    source_file = h5py.File(build_source_path(proc_id = i, nfile = output_number), 'r')
-
-    # Compute the offset slicing
-    nx_local, ny_local, nz_local = source_file.attrs['dims_local']
-    x_start, y_start, z_start    = source_file.attrs['offset']
-    x_end, y_end, z_end          = x_start+nx_local, y_start+ny_local, z_start+nz_local
-
-    # write data from individual processor file to correct location in concatenated file
-    for dataset in datasets_to_copy:
-      magnetic_offset = [0,0,0]
-      if dataset == 'magnetic_x': magnetic_offset[0] = 1
-      if dataset == 'magnetic_y': magnetic_offset[1] = 1
-      if dataset == 'magnetic_z': magnetic_offset[2] = 1
-
-      destination_file[dataset][x_start:x_end+magnetic_offset[0],
-                                y_start:y_end+magnetic_offset[1],
-                                z_start:z_end+magnetic_offset[2]] = source_file[dataset]
-
-    # Now that the copy is done we close the source file
-    source_file.close()
-
-  # Close destination file now that it is fully constructed
-  destination_file.close()
 # ==============================================================================
 
 if __name__ == '__main__':
@@ -142,6 +101,7 @@ if __name__ == '__main__':
   cli = concat_internals.common_cli(num_processes_choice = 'deprecate')
   args = cli.parse_args()
 
+  dset_opts = dset_opts_from_args(args)
   build_source_path = concat_internals.get_source_path_builder(
     source_directory = args.source_directory,
     pre_extension_suffix = '',
@@ -154,9 +114,6 @@ if __name__ == '__main__':
                       output_number=output,
                       build_source_path = build_source_path,
                       skip_fields=args.skip_fields,
-                      destination_dtype=args.dtype,
-                      compression_type=args.compression_type,
-                      compression_options=args.compression_opts,
-                      chunking=args.chunking)
+                      dset_opts=dset_opts)
 
   print(f'\nTime to execute: {round(default_timer()-start,2)} seconds')

--- a/python_scripts/concat_internals.py
+++ b/python_scripts/concat_internals.py
@@ -80,26 +80,26 @@ def infer_numfiles_from_header(hdr: Mapping) -> int:
 
 
 # ==============================================================================
-def copy_header(source_file: h5py.File, destination_file: h5py.File) -> h5py.File:
+def copy_header(
+  source_file: h5py.File,
+  destination_file: h5py.File,
+  skip_keys: Optional[list] = None
+) -> h5py.File:
   """Copy the attributes of one HDF5 file to another, skipping all fields that are specific to an individual rank
 
   Parameters
   ----------
-  source_file : h5py.File
-      The source file
-  destination_file : h5py.File
-      The destination file
-  source_file: h5py.File :
-
-  destination_file: h5py.File :
-
+  source_file, destination_file : h5py.File
+      The source and destination files
+  skip_keys : list, optional
+      Keys to skip
 
   Returns
   -------
   h5py.File
       The destination file with the new header attributes
   """
-  fields_to_skip = ['dims_local', 'offset', 'n_particles_local']
+  fields_to_skip = ['dims_local', 'offset', 'n_particles_local'] + skip_keys
 
   for attr_key in source_file.attrs.keys():
     if attr_key not in fields_to_skip:
@@ -153,7 +153,8 @@ def _add_snaps_arg(cli, required: bool = False):
 
 def add_common_cli_args(cli: argparse.ArgumentParser,
                         num_processes_choice: str,
-                        add_concat_outputs_arg: bool = True):
+                        add_concat_outputs_arg: bool = True,
+                        add_src_dir_arg: bool =True):
   """Add common command-line arguments to an argparse.ArguementParser instance
   
   These arguments are shared among the various concatenation scripts.
@@ -266,7 +267,8 @@ def add_common_cli_args(cli: argparse.ArgumentParser,
     _add_snaps_arg(cli, required = True)
 
   # Other Required Arguments
-  cli.add_argument('-s', '--source-directory', type=pathlib.Path,  required=True, help='The path to the directory for the source HDF5 files.')
+  if add_src_dir_arg:
+    cli.add_argument('-s', '--source-directory', type=pathlib.Path,  required=True, help='The path to the directory for the source HDF5 files.')
   cli.add_argument('-o', '--output-directory', type=pathlib.Path,  required=True, help='The path to the directory to write out the concatenated HDF5 files.') 
     
 

--- a/python_scripts/concat_internals.py
+++ b/python_scripts/concat_internals.py
@@ -107,6 +107,20 @@ def copy_header(
 
   return destination_file
 # ==============================================================================
+def _add_legacyfield_arg(cli: argparse.ArgumentParser):
+  cli.add_argument(
+    "--legacy-field",
+    action="store_true",
+    help = (
+      "When specified, the \"field_legacy\" HDF5 group will be created. This group "
+      "contains a 'virtual dataset' for each field with a shape corresponding to the "
+      "entire domain. Accesses to these fields are automatically remapped to the "
+      "corresponding datasets in the \"field\" HDF5 group."
+    )
+  )
+
+
+# ==============================================================================
 
 def _integer_sequence(s: str):
   # converts an argument string to an integer sequence

--- a/python_scripts/concat_internals.py
+++ b/python_scripts/concat_internals.py
@@ -151,19 +151,9 @@ def _add_snaps_arg(cli, required: bool = False):
             '1,2,3)')
   )
 
-def add_common_cli_args(cli: argparse.ArgumentParser,
-                        num_processes_choice: str,
-                        add_concat_outputs_arg: bool = True,
-                        add_src_dir_arg: bool =True):
-  """Add common command-line arguments to an argparse.ArguementParser instance
-  
-  These arguments are shared among the various concatenation scripts.
-
-  Parameters
-  ----------
-  cli: argparse.ArgumentParser
-      Instance that arguments are added to
-  """
+def add_src_cli_args(cli: argparse.ArgumentParser,
+                     add_concat_outputs_arg: bool = True):
+  """Add common arguments to a parser related to specifying source files"""
 
   # ============================================================================
   def concat_output(raw_argument: str,)-> list:
@@ -208,6 +198,42 @@ def add_common_cli_args(cli: argparse.ArgumentParser,
 
     return list(iterable_argument)
   # ============================================================================
+
+  if add_concat_outputs_arg:
+    grp = cli.add_mutually_exclusive_group(required=True)
+    grp.add_argument(
+      "-c",
+      "--concat-outputs",
+      type=concat_output,
+      help=(
+        "DEPRECATED (use --snaps instead) Specify outputs to concatenate. Can "
+        "be a single number (e.g. 8), an inclusive range (e.g. 2-9), or a list "
+        "(e.g. [1,2,3])."
+      )
+    )
+    _add_snaps_arg(grp, required = False)
+  else:
+    _add_snaps_arg(cli, required = True)
+
+  cli.add_argument(
+    "-s",
+    "--source-directory",
+    type=pathlib.Path,
+    required=True,
+    help="The path to the directory for the source HDF5 files."
+  )
+
+def add_common_cli_args(cli: argparse.ArgumentParser,
+                        num_processes_choice: str):
+  """Add common command-line arguments to an argparse.ArguementParser instance
+  
+  These arguments are shared among the various concatenation scripts.
+
+  Parameters
+  ----------
+  cli: argparse.ArgumentParser
+      Instance that arguments are added to
+  """
 
   # ============================================================================
   def positive_int(raw_argument: str) -> int:
@@ -257,18 +283,6 @@ def add_common_cli_args(cli: argparse.ArgumentParser,
   elif num_processes_choice != 'omit':
     raise ValueError('invalid value passed for num_processes_choice')
 
-  if add_concat_outputs_arg:
-    grp = cli.add_mutually_exclusive_group(required=True)
-    grp.add_argument(
-      '-c', '--concat-outputs',   type=concat_output,
-      help = 'DEPRECATED (use --snaps instead) Specify outputs to concatenate. Can be a single number (e.g. 8), an inclusive range (e.g. 2-9), or a list (e.g. [1,2,3]).')
-    _add_snaps_arg(grp, required = False)
-  else:
-    _add_snaps_arg(cli, required = True)
-
-  # Other Required Arguments
-  if add_src_dir_arg:
-    cli.add_argument('-s', '--source-directory', type=pathlib.Path,  required=True, help='The path to the directory for the source HDF5 files.')
   cli.add_argument('-o', '--output-directory', type=pathlib.Path,  required=True, help='The path to the directory to write out the concatenated HDF5 files.') 
     
 
@@ -298,8 +312,8 @@ def common_cli(num_processes_choice = 'use') -> argparse.ArgumentParser:
   """
   # Initialize the CLI
   cli = argparse.ArgumentParser()
-  add_common_cli_args(cli, num_processes_choice = num_processes_choice,
-                      add_concat_outputs_arg = True)
+  add_common_cli_args(cli, num_processes_choice=num_processes_choice)
+  add_src_cli_args(cli, add_concat_outputs_arg=True)
   return cli
 
 # ==============================================================================

--- a/python_scripts/snaprepack.py
+++ b/python_scripts/snaprepack.py
@@ -192,6 +192,74 @@ def _record_field(
     return created_grp
 
 
+def _configure_virtual_field(
+    dst_f: h5py.File,
+    blockid_location_arr: np.ndarray,
+    stored_blockid_list: Sequence[int],
+    dst_grp: str
+):
+    """Create virtual datasets for each field. The virtual dataset acts like a
+    3D array that spans the entire dataset.
+
+    Parameters
+    ----------
+    dst_f
+        Output file
+    blockid_location_arr
+        specifies the location of each block
+    stored_blockid_list
+        specifies the index of the blockid list
+    dst_grp
+        name of the group where we will write the datasets
+
+    Notes
+    -----
+    This is only intended to limit breakage in existing scripts
+    """
+    total_block_count = np.prod(blockid_location_arr.shape)
+    if len(stored_blockid_list) == total_block_count:
+        blockid_to_idx_map = {
+            blockid : idx for idx,blockid in enumerate(stored_blockid_list)
+        }
+    else:
+        raise ValueError(
+            "can't currently create virtual fields unless the file contains all blocks"
+        )
+
+    # calculate block-shape of a cell-centered field
+    _cc_block_shape, _rem = np.divmod(dst_f.attrs["dims"], blockid_location_arr.shape)
+    assert np.all(_rem == 0) # sanity check!
+    cc_block_shape = to_int_triple(_cc_block_shape)
+
+    # expected shape for dataset storing cell-centered field
+    src_dset_shape = (total_block_count,) + to_int_triple(cc_block_shape)
+    cc_domain_shape = to_int_triple(
+        np.multiply(blockid_location_arr.shape, cc_block_shape)
+    )
+    
+    grp = dst_f.create_group(dst_grp)
+
+    for field_name, field_dset in dst_f["field"].items():
+        if field_dset.shape != src_dset_shape:
+            raise ValueError(
+                f"can't make a virtual dataset for {field} since the stored data "
+                "doesn't have the expected shape for a cell-centered field"
+            )
+        vsrc = h5py.VirtualSource(field_dset)
+        layout = h5py.VirtualLayout(
+            shape=cc_domain_shape, dtype=field_dset.dtype, maxshape=cc_domain_shape
+        )
+
+        for idx3d, blockid in np.ndenumerate(blockid_location_arr):
+            layout_slc=(
+                slice(idx3d[0]*cc_block_shape[0], (idx3d[0]+1)*cc_block_shape[0]),
+                slice(idx3d[1]*cc_block_shape[1], (idx3d[1]+1)*cc_block_shape[1]),
+                slice(idx3d[2]*cc_block_shape[2], (idx3d[2]+1)*cc_block_shape[2])
+            )
+            layout[layout_slc] = vsrc[blockid_to_idx_map[blockid],:,:,:]
+        grp.create_virtual_dataset(name=field_name, layout=layout)
+
+
 class SnapBuilder:
     """A snapshot-file builder, providing fine control over the file's contents.
 
@@ -284,6 +352,7 @@ class SnapBuilder:
     _recordpack_dict: dict[str, tuple[set, RecordDataFn]]
     _stored_blockid_list: list[int]
     _blockid_location_arr_builder: Optional[BlockidLocationArrBuilder] = None
+    _write_virtual_field: Optional[bool] = None
 
     def __init__(
         self, path: os.PathLike, expected_store_block_count: Optional[int] = None
@@ -492,7 +561,11 @@ class SnapBuilder:
     field_record = functools.partialmethod(_record_data, kind="field")
     field_record_itr = functools.partialmethod(_record_data_itr, kind="field")
     def field_config(
-        self, *, opts: Optional[DatasetOpts] = None, skip: Optional[Iterable] = None
+        self,
+        *,
+        opts: Optional[DatasetOpts] = None,
+        skip: Optional[Iterable] = None,
+        legacy: bool = False
     ) -> Self:
         """Configure the builder to write field-data
 
@@ -502,12 +575,16 @@ class SnapBuilder:
             Optional kwargs for ``h5py.Group.create_dataset``.
         skip
             Fields to omit from output. Defaults to {}.
+        legacy
+            When True, the "field_legacy" HDF5 group will be created
         """
         opts = dict() if opts is None else opts
         skip = set() if skip is None else set(skip)
         self._setup_recorder(
             name="field", fn=_record_field, dset_opts=opts, skip_fields=skip
         )
+
+        self._write_virtual_field = legacy
         return self
 
     particle_record = functools.partialmethod(_record_data, kind="particle")
@@ -546,13 +623,16 @@ class SnapBuilder:
                 raise RuntimeError(f"{kind}_record wasn't called enough times")
 
         # write the domain group of the file
+        blockid_location_arr = self._blockid_location_arr_builder.final_arr()
+        stored_blockid_list = np.array(self._stored_blockid_list)
         domain_grp = self._f.create_group("domain")
-        domain_grp.create_dataset(
-            "blockid_location_arr", data=self._blockid_location_arr_builder.final_arr()
-        )
-        domain_grp.create_dataset(
-            "stored_blockid_list", data=np.array(self._stored_blockid_list)
-        )
+        domain_grp.create_dataset("blockid_location_arr", data=blockid_location_arr)
+        domain_grp.create_dataset("stored_blockid_list", data=stored_blockid_list)
+
+        if self._write_virtual_field:
+            _configure_virtual_field(
+                self._f, blockid_location_arr, stored_blockid_list, "field_legacy"
+            )
 
         # save and close!
         self._f.close()
@@ -676,6 +756,7 @@ def repack_snapshot(
     missing_nprocs_triple: Optional[Sequence] = None,
     skip_fields: Optional[Sequence] = None,
     dset_opts: Optional[DatasetOpts] = None,
+    legacy_field: bool = False
 ):
     """This repacks an already concatenated snapshot
 
@@ -691,6 +772,8 @@ def repack_snapshot(
         Optional list of fields to skip concatenating.
     dset_opts
         Optional kwargs for ``h5py.Group.create_dataset``.
+    legacy_field
+        When True, the "field_legacy" HDF5 group will be created.
     """
 
     # coerce arguments
@@ -718,7 +801,7 @@ def repack_snapshot(
 
         with SnapBuilder(out_path) as builder:  # open the snapshot-builder
             builder.set_hdr(src_f, missing_nprocs_triple) \
-                .field_config(opts=dset_opts, skip=skip_fields) \
+                .field_config(opts=dset_opts, skip=skip_fields, legacy=legacy_field) \
                 .field_record_itr(itr) \
                 .write()
 
@@ -748,6 +831,9 @@ parser.add_argument(
     ),
 )
 
+concat_internals._add_legacyfield_arg(parser)
+
+
 if __name__ == "__main__":
     args = parser.parse_args()
 
@@ -757,4 +843,5 @@ if __name__ == "__main__":
         missing_nprocs_triple=args.missing_nprocs_triple,
         skip_fields=args.skip_fields,
         dset_opts=dset_opts_from_args(args),
+        legacy_field=args.legacy_field
     )

--- a/python_scripts/snaprepack.py
+++ b/python_scripts/snaprepack.py
@@ -1,0 +1,566 @@
+#!/usr/bin/env python3
+"""
+This file provides machinery to help build Cholla snapshots in postprocess-v2
+format. A snapshot is any dataset that is a snapshot of the simulation state
+(and is required for restarts). For example: fields, particles, gravity. This
+does NOT include slices/projections
+"""
+import argparse
+from collections import UserDict
+from collections.abc import Mapping, Sequence
+from contextlib import nullcontext
+import itertools
+import os
+import shutil
+import sys
+from typing import Any, Callable, Iterable, Optional, TypedDict, Union
+
+import numpy as np
+from numpy.typing import NDArray
+import h5py
+
+import concat_internals
+
+if sys.version_info >= (3, 11, 0):
+    from typing import Self
+else:
+    Self = Any
+
+int3 = tuple[int,int,int]
+
+
+class DatasetOpts(TypedDict, total=False):
+    # tracks kwargs for h5py.Group.create_dataset
+
+    # The data type of the output datasets. Accepts most numpy types.
+    dtype: np.dtype
+    # kind of compression to use on the output data (if any)
+    compression: str
+    # Denotes compression settings (if any)
+    compression_opts: str
+    # Whether to use chunking and the chunk size
+    chunks: Any
+
+
+def _get_global_dims(f: h5py.File, f_is_concatenated:Optional[bool] = None):
+    if "dims" in f.attrs:
+        tmp = f.attrs["dims"]
+        assert all(int(e) == e for e in tmp)
+        return tuple(int(e) for e in tmp)
+    elif f_is_concatenated and "density" in f:
+        return f["density"].shape
+    raise RuntimeError("can't infer global dims")
+
+
+def _get_nprocs(f:h5py.File, nprocs: Optional[int3]=None) -> int3:
+    f_has_nprocs = "nprocs" in f.attrs
+    if nprocs is None and not f_has_nprocs:
+        if "domain/blockid_location_arr" in f:
+            return f["domain/blockid_location_arr"].shape
+        raise ValueError("nprocs kwarg is required; it isn't an attr of f")
+    elif nprocs is None:
+        _nprocs = np.asarray(f.attrs["nprocs"])
+    else:
+        _nprocs = np.asarray(nprocs)
+        if f_has_nprocs and np.any(_nprocs != np.asarray(f.attrs["nprocs"])):
+            raise ValueError("nprocs kw inconsistent with f.attrs['nprocs']")
+
+    # sanity checks
+    assert np.all(_nprocs > 0) and len(_nprocs) == 3
+    dims_local, remainders = np.divmod(f.attrs["dims"], _nprocs)
+    if np.any(dims_local == 0) or np.any(remainders != 0):
+        raise ValueError("global dims and nprocs are inconsistent")
+    return tuple(_nprocs)
+
+
+def _make_blockid_location_arr(
+    f:h5py.File, *, nprocs: Optional[int3]=None
+) -> NDArray[np.int64]:
+    """Create a blockid_location_arr instance.
+
+    As we note in the description of the file format, the blockid_location_arr
+    is an array specifying the locations of each block. Negative value in the
+    output denote missing values
+    
+    Parameters
+    ----------
+    f
+        source file to try to read values from
+    nprocs
+        must be provided if the information isn't part source_file
+    """
+
+    nprocs = _get_nprocs(f=f, nprocs=nprocs)
+    if "domain/blockid_location_arr" in f:
+        assert f["domain/blockid_location_arr"].shape == nprocs
+        return f["domain/blockid_location_arr"][...]
+    else:
+        shape = tuple(int(e) for e in nprocs)
+        return np.full(shape=shape, fill_value=-1, dtype='i8')
+
+def _calc_block_location(global_cell_offset:int3, block_cell_shape:int3) -> int3:
+    """Compute the block's location in the blockid_location_arr
+
+    Parameters
+    ----------
+    global_cell_offset
+        In the conceptual global grid of cell-centered field-values, this
+        denotes the 3D index of the leftmost cell in the considered block.
+    block_cell_shape
+        The shape of the array for storing a cell-centered field in each block
+    Returns
+    -------
+    tuple
+        An index of blockid_location_arr
+    """
+    out, remainders = np.divmod(global_cell_offset, block_cell_shape)
+    assert np.all(out >= 0) and np.all(remainders==0)
+    return tuple(out)
+
+
+def _record_field_data(
+    dst_f: h5py.File,
+    expected_store_block_count: int,
+    dest_idx: Any,
+    data: Mapping,
+    skip_fields: list,
+    dset_opts: Mapping
+) -> bool:
+    # get the field names to be copied
+    names = [name for name in data.keys() if name not in skip_fields]
+
+    # get the "field" group (create it if it doesn't exist yet)
+    if "field" not in dst_f:
+        field_grp = dst_f.create_group("field")
+        for field_name, dset in data.items():
+            assert len(dset.shape) == 3 # sanity check!
+            shape = (expected_store_block_count,) + dset.shape
+            field_grp.create_dataset(name=field_name, shape=shape, **dset_opts)
+        created_grp = True
+    else:
+        field_grp = dst_f["field"]
+        created_grp = False
+
+    # now, store the field data
+    assert len(names) == len(field_grp) # sanity check!
+    dest_sel = np.s_[dest_idx]
+    for name in names:
+        field_grp[name].write_direct(data[name], dest_sel=dest_sel)
+
+    return created_grp
+
+class SnapBuilder:
+    """
+    A snapshot-file builder, provideing fine-grained control over what is
+    included in the file.
+
+    This can be used as a context manager, (i.e. in a ``with``-statement), to
+    help with proper cleanup if any errors occur
+
+        
+    Examples
+    --------
+    The public methods all return ``self`` to allow chaining.
+    >>> with SnapBuilder(path, *args) as builder:
+    ...     builder.set_hdr(src_f) \
+    ...         .record_field_data_itr(itr) \
+    ...         .write()
+    """
+
+    # note: the presence of type annotations means these are instance variables
+    #       (not class variables)
+
+    # attributes tracking global-file props
+    _path: str         # path of file that we will create
+    _tmp_path: str     # path to temporary file
+    _f: h5py.File      # File object that represents the file @ _tmp_path
+    _all_blocks: bool  # store all or 1 block in the file?
+
+    _field_dset_opts: DatasetOpts  # kwargs for h5py.Group.create_dataset
+    _skip_fields: set[str]         # fields that should be skipped
+
+    # properties related to the domain group
+    _stored_blockid_list: list[int]
+    _blockid_location_arr: Optional[np.ndarray] = None
+    _block_cell_shape: Optional[int3]  # used to compute block-locations
+
+    def __init__(
+        self,
+        path: os.PathLike,
+        all_blocks: bool,
+        *,
+        dset_opts: Optional[DatasetOpts]=None,
+        skip_fields: Optional[list]=None
+    ):
+        self._path = os.fsdecode(path)
+        self._tmp_path = f"{self._path}-tmp"
+        assert not os.path.exists(self._path)
+        assert not os.path.exists(self._tmp_path)
+        self._f = h5py.File(self._tmp_path, "w")
+        self._all_blocks = all_blocks
+
+        self._field_dset_opts = dict() if dset_opts is None else dset_opts
+        self._skip_fields = set() if skip_fields is None else set(skip_fields)
+
+        self._stored_blockid_list = []
+        self._blockid_location_arr = None
+        self._block_cell_shape = None
+
+    def _get_expected_local_block_count(self) -> int:
+        if self._blockid_location_arr is None:
+            raise RuntimeError("set_hdr method was never called")
+        return self._blockid_location_arr.size if self._all_blocks else 1
+
+    def set_hdr(
+        self,
+        source_file: Union[os.PathLike,h5py.File],
+        *,
+        nprocs: Optional[int3] = None
+    ) -> Self:
+        """Copy the header-attributes from source_file
+
+        Kwargs
+        ------
+        nprocs
+            This must be provided if the information isn't part source_file
+        """
+        if len(self._f.attrs) != 0:
+            raise RuntimeError("It's an error to call set_hdr more than once")
+
+        if isinstance(source_file, h5py.File):
+            cm = nullcontext(source_file)
+        else:
+            cm = h5py.File(source_file, "r")
+
+        with cm as src_f:
+            # copy most of the header
+            concat_internals.copy_header(src_f, self._f, skip_keys = ["nprocs"])
+
+            # construct the array
+            self._blockid_location_arr = _make_blockid_location_arr(
+                f=src_f, nprocs=nprocs
+            )
+
+        nprocs = np.array(self._blockid_location_arr.shape)
+        self._f.attrs["nprocs"] = nprocs
+
+        global_dims = _get_global_dims(src_f)
+        self._block_cell_shape, _remainder = np.divmod(global_dims, nprocs)
+        assert np.all(self._block_cell_shape > 0) and np.all(_remainder==0)
+        assert len(self._block_cell_shape) == 3 and len(nprocs) == 3
+
+        return self
+
+    def record_blockid_loc(self, blockid:int, global_cell_offset: int3) -> Self:
+        """record the specified block's location
+
+        Parameters
+        ----------
+        blockid
+            The block's id
+        global_cell_offset
+            Location of the leftmost cell of the block in the conceptual grid
+            spanning the entire domain
+        """
+        if self._block_cell_shape is None:
+            raise RuntimeError("set_hdr method was never called")
+
+        index = _calc_block_location(global_cell_offset, self._block_cell_shape)
+        if self._blockid_location_arr[index] < 0:
+            assert blockid not in self._stored_blockid_list  # sanity check
+            assert blockid not in self._blockid_location_arr  # sanity check
+            self._blockid_location_arr[index] = blockid
+        else:
+            assert self._blockid_location_arr[index] == blockid
+        return Self
+
+    def record_field_data(
+        self,
+        blockid: int,
+        data: Mapping,
+        *,
+        global_cell_offset: Optional[int3] = None
+    ) -> Self:
+        """Record the specified block's field info
+
+        Parameters
+        ----------
+        blockid
+            The block's id
+        data
+            A dict-like object mapping field names to field data
+        global_cell_offset
+            Optionally specifies the location of the leftmost cell of the block
+            in the conceptual grid spanning the entire domain. An error will be
+            raised if this isn't specified & the block's location isn't known.
+        """
+
+        assert blockid >= 0
+        if blockid in self._stored_blockid_list:
+            raise RuntimeError("record_field_data already called for blockid")
+        if global_cell_offset is not None:
+            self.record_blockid_loc(blockid, global_cell_offset)
+
+        # handles case where `data` is a h5py.File for existing snapshot file
+        data = data["field"] if "field" in data else data
+
+        newly_created = _record_field_data(
+            dst_f=self._f,
+            expected_store_block_count=self._get_expected_local_block_count(),
+            dest_idx=(len(self._stored_blockid_list), ...),
+            data=data,
+            skip_fields=self._skip_fields,
+            dset_opts=self._field_dset_opts
+        )
+
+        self._stored_blockid_list.append(blockid)
+
+        if newly_created:
+            assert self._block_cell_shape is not None  # sanity check!
+            self._f["field"].attrs["block_cell_shape"] = self._block_cell_shape
+
+        return self
+
+    def record_field_data_itr(self, itr: Iterable) -> Self:
+        """Calls self.record_field_data for each entry in itr"""
+
+        for pack in itr:
+            global_cell_offset = None
+            if len(pack) == 2:
+                blockid, data = pack
+            elif len(pack) == 3:
+                blockid, data, global_cell_offset = pack
+            else:
+                raise ValueError("each element of itr must be 2 or 3 elements")
+            self.record_field_data(
+                blockid=blockid, data=data, global_cell_offset=global_cell_offset
+            )
+        return self
+
+    def write(self):
+        # set require_all_blocks to False to write file with a subset of blocks
+        if self._f is None:
+            raise RuntimeError("already cleaned up the builder")
+
+        # more sanity checks
+        total_block_count = self._blockid_location_arr.size
+        local_block_count = len(self._stored_blockid_list)
+        if self._blockid_location_arr is None or len(self._f.attrs) == 0:
+            raise RuntimeError("set_hdr was never called")
+        elif np.any(self._blockid_location_arr < 0):
+            raise RuntimeError("block location info is missing")
+        elif local_block_count == 0:
+            raise RuntimeError("no snapshot-data is stored for any block")
+        elif self._all_blocks and total_block_count != local_block_count:
+            raise RuntimeError("snapshot-data is missing for some blocks")
+
+        # write the domain group of the file
+        domain_grp = self._f.create_group("domain")
+        domain_grp.create_dataset(
+            "blockid_location_arr", data=self._blockid_location_arr
+        )
+        domain_grp.create_dataset(
+            "stored_blockid_list", data=np.array(self._stored_blockid_list)
+        )
+
+        # save and close!
+        self._f.close()
+        self._f = None
+        shutil.move(self._tmp_path, self._path)
+
+    def cleanup(self):
+        if self._f is not None:
+            self._f.close()
+            self._f = None
+            os.remove(self._tmp_path)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.cleanup()
+
+##########################################
+class _MockBlockFieldGroup(UserDict):
+    # acts like a h5py.Group instance for a selected region. This is better
+    # than using a dict of loaded fields since that uses a lot more memory
+
+    def __init__(self, grp: Mapping, idx_map: Mapping):
+        super().__init__(dict(grp.items()))
+        self._idx_map = idx_map
+
+    def __getitem__(self, key:str):
+        return self.data[key][self._idx_map.get(key,...)]
+
+    def __repr__(self): return "<_MockBlockFieldGroup>"
+
+def _iter_block_from_concat(
+    src_f: h5py.File, missing_nprocs_triple: Optional[Sequence] = None,
+)-> Iterable[tuple[int, _MockBlockFieldGroup, int3]]:
+    """
+    Iterates over blocks from a previously concatenated field
+
+    Yields
+    ------
+    blockid: int
+        The blockid
+    data: _MockBlockFieldGroup
+        maps field names to associated data
+    global_cell_offset: tuple
+        Location of the leftmost cell of the block in the conceptual grid
+        spanning the entire domain
+    """
+
+    if "field" in src_f: # we dealing with file put into the new format
+        assert missing_nprocs_triple is None
+
+        blockid_list = src_f["domain/stored_blockid_list"][...]
+        blockid_location_arr = src_f["domain/blockid_location_arr"][...]
+        assert blockid_location_arr.size == blockid_list.size  # sanity check
+        mapping = dict(zip(blockid_list, range(blockid_list.size)))
+
+        grp = src_f["field"]
+        stacked_field_shape = grp["density"].shape
+        assert len(stacked_field_shape) == 4  # check invariant
+        assert stacked_field_shape[0] == blockid_list.size  # check invariant
+        block_cell_shape = stacked_field_shape[1:]
+
+        for block_loc_idx, blockid in np.ndenumerate(blockid_location_arr):
+            stack_idx = mapping[blockid]
+            idx_map = {name: (stack_idx, ...) for name in grp}
+            data = _MockBlockFieldGroup(grp, idx_map)
+
+            global_cell_offset = tuple(
+                block_loc_idx[i] * block_cell_shape[i] for i in range(3)
+            )
+            yield blockid, data, global_cell_offset
+
+    else:
+        nprocs = _get_nprocs(f=src_f, nprocs=missing_nprocs_triple)
+        global_dims = _get_global_dims(src_f, True)
+        block_cell_shape, _remainder = np.divmod(global_dims, nprocs)
+        assert np.all(block_cell_shape > 0) and np.all(_remainder==0)
+        assert len(block_cell_shape) == 3 and len(nprocs) == 3
+
+        offset_itr = itertools.product(
+            range(0, global_dims[0], block_cell_shape[0]),
+            range(0, global_dims[1], block_cell_shape[1]),
+            range(0, global_dims[2], block_cell_shape[2])    
+        )
+
+        def _mk_idx(name, start):
+            shape = [e for e in block_cell_shape]
+            if name == "magnetic_x":
+                shape[0]+=1
+            elif name == "magnetic_y":
+                shape[1]+=1
+            elif name == "magnetic_z":
+                shape[2]+=1
+            return tuple(slice(start[i], start[i]+shape[i], 1) for i in range(3))
+
+        for blockid, global_cell_offset in enumerate(offset_itr):
+            idx_map = {name: _mk_idx(name, global_cell_offset) for name in src_f}
+            data = _MockBlockFieldGroup(src_f, idx_map)
+            yield blockid, data, global_cell_offset
+
+def repack_snapshot(
+    out_dir: os.PathLike,
+    src_path: os.PathLike,
+    *,
+    missing_nprocs_triple: Optional[Sequence] = None,
+    skip_fields: Optional[Sequence] = None,
+    dset_opts: Optional[DatasetOpts] = None,
+):
+    """This repacks an already concatenated snapshot
+
+    Parameters
+    ----------
+    out_dir
+        Path to directory where output files are written
+    src_path
+        Path to the input file
+    missing_nprocs_triple
+        Must be provided when the input file is missing the "nprocs" attr
+    skip_fields
+        Optional list of fields to skip concatenating.
+    dset_opts
+        Optional kwargs for ``h5py.Group.create_dataset``.
+    """
+
+    # coerce arguments
+    if isinstance(skip_fields, str):
+        raise TypeError("skip_fields can't be a string")
+    elif missing_nprocs_triple is None or len(missing_nprocs_triple) == 0:
+        missing_nprocs_triple = None
+    else:
+        assert len(missing_nprocs_triple) == 3
+        assert all(elem > 0 for elem in missing_nprocs_triple)
+
+    dset_opts = dict() if dset_opts is None else dset_opts
+
+    out_path = os.path.join(out_dir, os.path.basename(src_path))
+    if not os.path.isfile(src_path):
+        raise ValueError(f"{src_path} doesn't exist")
+    elif not os.path.isdir(out_dir):
+        raise ValueError(f"{out_dir=} isn't a directory")
+    elif os.path.exists(out_path):
+        raise ValueError(f"{out_path} already exists")
+
+    with h5py.File(src_path, "r") as src_f: # open the source file
+        # do some basic setup
+        itr = _iter_block_from_concat(src_f, missing_nprocs_triple)
+
+        with SnapBuilder(
+            out_path, True, dset_opts=dset_opts, skip_fields=skip_fields
+        ) as builder: # open the snapshot-builder 
+            builder.set_hdr(src_f, nprocs=missing_nprocs_triple) \
+                .record_field_data_itr(itr) \
+                .write()
+
+parser = argparse.ArgumentParser(
+    description = "Repacks (previously concatenated) HDF5 snapshots for Cholla"
+)
+concat_internals.add_common_cli_args(
+    parser,
+    num_processes_choice = 'omit',
+    add_concat_outputs_arg = False,
+    add_src_dir_arg=False
+)
+parser.add_argument(
+    "--missing-nprocs-triple",
+    nargs=3,
+    default=None,
+    type=int,
+    help=(
+        "This must be supplied when the 'nproc' attribute is missing from the "
+        "input file. This specifies the number of processes along each axis."
+    )
+)
+
+parser.add_argument(
+    "--input-path-template",
+    required=True,
+    help=(
+        "template-path for the input file. This path should generally include "
+        "{snap}, which will be replaced by the snapshot numbers"
+    )
+)
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+
+    dset_opts = {
+        "dtype" : args.dtype,
+        "compression" : args.compression_type,
+        "compression_opts" : args.compression_opts,
+        "chunks" : args.chunking
+    }
+
+    for snap_number in args.concat_outputs:
+        repack_snapshot(
+            out_dir=args.output_directory,
+            src_path=args.input_path_template.format(snap=snap_number),
+            missing_nprocs_triple=args.missing_nprocs_triple,
+            skip_fields=args.skip_fields,
+            dset_opts=dset_opts
+        )

--- a/python_scripts/snaprepack.py
+++ b/python_scripts/snaprepack.py
@@ -1,22 +1,24 @@
 #!/usr/bin/env python3
 """
-This file provides machinery to help build Cholla snapshots in postprocess-v2
-format. A snapshot is any dataset that is a snapshot of the simulation state
-(and is required for restarts). For example: fields, particles, gravity. This
-does NOT include slices/projections
+This file provides machinery to help build Cholla snapshots in the hierarichal
+format. Specifically, this file can be invoked from the command line to repack
+an existing file
 """
+
 import argparse
 from collections import UserDict
-from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
+import errno
+import functools
 import itertools
 import os
 import shutil
 import sys
-from typing import Any, Callable, Iterable, Optional, TypedDict, Union
+from typing import (
+    Any, Callable, Iterable, Iterator, Mapping, Optional, Sequence, TypedDict, Union
+)
 
 import numpy as np
-from numpy.typing import NDArray
 import h5py
 
 import concat_internals
@@ -26,11 +28,13 @@ if sys.version_info >= (3, 11, 0):
 else:
     Self = Any
 
-int3 = tuple[int,int,int]
+int3 = tuple[int, int, int]
+RecordDataFn = Callable[[h5py.File, int, int, Mapping], bool]
 
 
 class DatasetOpts(TypedDict, total=False):
     # tracks kwargs for h5py.Group.create_dataset
+    # -> keep in mind, TypedDict subclasses are only used to annotate regular dicts
 
     # The data type of the output datasets. Accepts most numpy types.
     dtype: np.dtype
@@ -42,90 +46,128 @@ class DatasetOpts(TypedDict, total=False):
     chunks: Any
 
 
-def _get_global_dims(f: h5py.File, f_is_concatenated:Optional[bool] = None):
-    if "dims" in f.attrs:
-        tmp = f.attrs["dims"]
-        assert all(int(e) == e for e in tmp)
-        return tuple(int(e) for e in tmp)
-    elif f_is_concatenated and "density" in f:
-        return f["density"].shape
-    raise RuntimeError("can't infer global dims")
+def dset_opts_from_args(args: argparse.Namespace) -> DatasetOpts:
+    return {
+        "dtype": args.dtype,
+        "compression": args.compression_type,
+        "compression_opts": args.compression_opts,
+        "chunks": args.chunking,
+    }
 
 
-def _get_nprocs(f:h5py.File, nprocs: Optional[int3]=None) -> int3:
+def to_int_triple(iterable: Iterable, *, min_val: Optional[int] = None) -> int3:
+    # coerce the specified sequence to a 3 element tuple
+    coerced_l = []
+    for i, elem in enumerate(iterable):
+        if i > 3:
+            raise ValueError("invalid iterable for to_int_triple: more than 3 items")
+        coerced = int(elem)
+        if elem != coerced:
+            raise ValueError(f"converting {elem} to 'int' changes the value")
+        elif (min_val is not None) and (coerced < min_val):
+            raise ValueError(f"min_val, {min_val}, exceeds int({elem})")
+        coerced_l.append(coerced)
+    if len(coerced_l) < 3:
+        raise ValueError("invalid iterable for to_int_triple: less than 3 items")
+    return tuple(coerced_l)
+
+
+def _nprocs_and_blockcellshape(
+    f: h5py.File,
+    missing_nprocs_triple: Optional[int3] = None,
+    f_is_concatenated: bool = False,
+) -> tuple[int3, int3]:
+    # first, infer nprocs
     f_has_nprocs = "nprocs" in f.attrs
-    if nprocs is None and not f_has_nprocs:
+    if missing_nprocs_triple is None and not f_has_nprocs:
         if "domain/blockid_location_arr" in f:
             return f["domain/blockid_location_arr"].shape
         raise ValueError("nprocs kwarg is required; it isn't an attr of f")
-    elif nprocs is None:
+    elif missing_nprocs_triple is None:
         _nprocs = np.asarray(f.attrs["nprocs"])
     else:
-        _nprocs = np.asarray(nprocs)
+        _nprocs = np.asarray(missing_nprocs_triple)
         if f_has_nprocs and np.any(_nprocs != np.asarray(f.attrs["nprocs"])):
-            raise ValueError("nprocs kw inconsistent with f.attrs['nprocs']")
+            raise ValueError(
+                "missing_nprocs_triple inconsistent with f.attrs['nprocs']"
+            )
+    nprocs = to_int_triple(_nprocs, min_val=1)
 
-    # sanity checks
-    assert np.all(_nprocs > 0) and len(_nprocs) == 3
-    dims_local, remainders = np.divmod(f.attrs["dims"], _nprocs)
-    if np.any(dims_local == 0) or np.any(remainders != 0):
-        raise ValueError("global dims and nprocs are inconsistent")
-    return tuple(_nprocs)
+    # next, infer global dims
+    if "dims" in f.attrs:
+        global_dims = np.asarray(f.attrs["dims"])
+    elif f_is_concatenated and "density" in f:
+        global_dims = f["density"].shape
+    else:
+        RuntimeError("can't infer global dims")
+    assert np.shape(global_dims) == (3,)
+
+    # determine block_cell_shape
+    _block_cell_shape, _remainder = np.divmod(global_dims, nprocs)
+    assert np.all(_remainder == 0)
+
+    return nprocs, to_int_triple(_block_cell_shape, min_val=1)
 
 
-def _make_blockid_location_arr(
-    f:h5py.File, *, nprocs: Optional[int3]=None
-) -> NDArray[np.int64]:
-    """Create a blockid_location_arr instance.
+class BlockidLocationArrBuilder:
+    """A blockid_location_arr builer. The array specifies each block's location
 
-    As we note in the description of the file format, the blockid_location_arr
-    is an array specifying the locations of each block. Negative value in the
-    output denote missing values
-    
     Parameters
     ----------
     f
         source file to try to read values from
     nprocs
-        must be provided if the information isn't part source_file
+        must be provided if source file is missing the "nprocs" attribute
     """
 
-    nprocs = _get_nprocs(f=f, nprocs=nprocs)
-    if "domain/blockid_location_arr" in f:
-        assert f["domain/blockid_location_arr"].shape == nprocs
-        return f["domain/blockid_location_arr"][...]
-    else:
-        shape = tuple(int(e) for e in nprocs)
-        return np.full(shape=shape, fill_value=-1, dtype='i8')
+    _arr: np.ndarray # 3D array of i64
+    block_cell_shape: int3
 
-def _calc_block_location(global_cell_offset:int3, block_cell_shape:int3) -> int3:
-    """Compute the block's location in the blockid_location_arr
+    def __init__(self, f: h5py.File, *, missing_nprocs_triple: Optional[int3] = None):
+        nprocs, self.block_cell_shape = _nprocs_and_blockcellshape(
+            f, missing_nprocs_triple=missing_nprocs_triple
+        )
+        try:
+            self._arr = f["domain/blockid_location_arr"][...]
+            assert nprocs == self._arr
+        except KeyError:
+            # Negative values denote unknown blockids
+            self._arr = np.full(shape=nprocs, fill_value=-1, dtype="i8")
 
-    Parameters
-    ----------
-    global_cell_offset
-        In the conceptual global grid of cell-centered field-values, this
-        denotes the 3D index of the leftmost cell in the considered block.
-    block_cell_shape
-        The shape of the array for storing a cell-centered field in each block
-    Returns
-    -------
-    tuple
-        An index of blockid_location_arr
-    """
-    out, remainders = np.divmod(global_cell_offset, block_cell_shape)
-    assert np.all(out >= 0) and np.all(remainders==0)
-    return tuple(out)
+    @property
+    def nprocs(self) -> int3:
+        return self._arr.shape
+
+    def final_arr(self) -> np.ndarray:  # return fully build array
+        missing = np.sum(self._arr < 0)
+        if missing > 0:
+            raise RuntimeError(
+                f"blockid_location_arr missing location info for {missing} blocks"
+            )
+        return self._arr
+
+    def store_location(self, blockid: int, global_cell_offset: int3) -> Self:
+        _idx, remainders = np.divmod(global_cell_offset, self.block_cell_shape)
+        assert np.all(_idx >= 0) and np.all(remainders == 0)  # sanity-check
+        idx = tuple(int(i) for i in _idx)
+
+        if self._arr[idx] < 0:
+            assert blockid not in self._arr  # sanity-check
+            self._arr[idx] = blockid
+        assert self._arr[idx] == blockid
+        return self
 
 
-def _record_field_data(
+def _record_field(
     dst_f: h5py.File,
     expected_store_block_count: int,
-    dest_idx: Any,
+    stored_block_idx: int,
     data: Mapping,
-    skip_fields: list,
-    dset_opts: Mapping
+    *,
+    skip_fields: set,
+    dset_opts: DatasetOpts,
 ) -> bool:
+    """The core logic for recording fields to a file"""
     # get the field names to be copied
     names = [name for name in data.keys() if name not in skip_fields]
 
@@ -133,7 +175,7 @@ def _record_field_data(
     if "field" not in dst_f:
         field_grp = dst_f.create_group("field")
         for field_name, dset in data.items():
-            assert len(dset.shape) == 3 # sanity check!
+            assert len(dset.shape) == 3  # sanity check!
             shape = (expected_store_block_count,) + dset.shape
             field_grp.create_dataset(name=field_name, shape=shape, **dset_opts)
         created_grp = True
@@ -142,117 +184,178 @@ def _record_field_data(
         created_grp = False
 
     # now, store the field data
-    assert len(names) == len(field_grp) # sanity check!
-    dest_sel = np.s_[dest_idx]
+    assert len(names) == len(field_grp)  # sanity check!
+    dest_sel = np.s_[stored_block_idx, ...]
     for name in names:
-        field_grp[name].write_direct(data[name], dest_sel=dest_sel)
+        field_grp[name].write_direct(data[name][...], dest_sel=dest_sel)
 
     return created_grp
 
+
 class SnapBuilder:
-    """
-    A snapshot-file builder, provideing fine-grained control over what is
-    included in the file.
+    """A snapshot-file builder, providing fine control over the file's contents.
 
-    This can be used as a context manager, (i.e. in a ``with``-statement), to
-    help with proper cleanup if any errors occur
+    The output file is organized according to the Hierarichal Schema. Users
+    call builder methods to configure the output before using the `write`
+    to produce the output. Logic is in place to ensure that the result isn't
+    missing crucial information.
 
-        
+    Parameters
+    ----------
+    path
+        Path to the output file.
+    expected_store_block_count
+        Specifies the number of blocks stored in the file. A value of ``None``
+        (the default) indicates that all blocks will be stored.
+
+    Notes
+    -----
+    We suggest using this type as a context manager, (i.e. in a ``with``
+    statement), to help with proper cleanup if any errors occur.
+
+    The various builder-methods are associated with the following aspects of the
+    output file:
+
+    - header-attribute-data: this must always be configured with `set_hdr`.
+    - block-location-data: specifies the block location. This information is
+      required by the builder. The info can be manually specified for a given
+      block with `record_block_loc`. In practice, other methods can be used to
+      implicitly specify this information
+    - snapshot-data: this is the real core of the output. There are a few of
+      "kinds" of snapshot data. Currently, we support the "field" kind. We plan
+      to add support for "gravity" and "particle".
+
+      - to configure the builder to record data of the specified "kind", call
+        the ``{kind}_config``.
+      - to actually record data for a given block, call ``{kind}_record``. The
+        builder will report an error if you call this before ``{kind}_config``
+        or before `set_hdr`.
+
+    Methods
+    -------
+    write
+        Write the output file
+    cleanup
+        Cleanup the builder (unnecessary if you call `write`)
+    set_hdr
+        Copy the header of an existing source file (must be called)
+    record_block_loc
+        Manually record a block's location
+    field_config, particle_config
+        Configure builder for recording field-data or particle-data
+    field_record, particle_record
+        Record the field-data or particle-data from a single block
+    field_record_itr, particle_record_itr
+        Record the field-data or particle-data from multiple blocks
+
     Examples
     --------
     The public methods all return ``self`` to allow chaining.
-    >>> with SnapBuilder(path, *args) as builder:
+
+    Here's an example where we build a file with field data from entire domain
+    >>> with SnapBuilder(out_path) as builder:  # open the snapshot-builder
     ...     builder.set_hdr(src_f) \
-    ...         .record_field_data_itr(itr) \
+    ...         .field_config(opts=dset_opts, skip=skip_fields) \
+    ...         .field_record_itr(itr) \
+    ...         .write()
+
+    In the near future, we plan to support code like the following snippets:
+    >>> with SnapBuilder(out_path) as builder:  # open the snapshot-builder
+    ...     builder.set_hdr(src_f) \
+    ...         .particle_config(...) \
+    ...         .particle_record_itr(itr) \
+    ...         .write()
+    
+    or like:
+    >>> with SnapBuilder(out_path) as builder:  # open the snapshot-builder
+    ...     builder.set_hdr(src_f) \
+    ...         .field_config(opts=dset_opts, skip=skip_fields) \
+    ...         .field_record_itr(itr_field) \
+    ...         .particle_config(...) \
+    ...         .particle_record_itr(itr_particle) \
     ...         .write()
     """
 
     # note: the presence of type annotations means these are instance variables
-    #       (not class variables)
 
-    # attributes tracking global-file props
-    _path: str         # path of file that we will create
-    _tmp_path: str     # path to temporary file
-    _f: h5py.File      # File object that represents the file @ _tmp_path
-    _all_blocks: bool  # store all or 1 block in the file?
-
-    _field_dset_opts: DatasetOpts  # kwargs for h5py.Group.create_dataset
-    _skip_fields: set[str]         # fields that should be skipped
-
-    # properties related to the domain group
+    _tmp_final_path_pair: tuple[str, str]  # temporary and final paths
+    _f: h5py.File  # File object that represents the file @ _tmp_final_path_pair[0]
+    _expected_store_block_count: Optional[int]
+    _recordpack_dict: dict[str, tuple[set, RecordDataFn]]
     _stored_blockid_list: list[int]
-    _blockid_location_arr: Optional[np.ndarray] = None
-    _block_cell_shape: Optional[int3]  # used to compute block-locations
+    _blockid_location_arr_builder: Optional[BlockidLocationArrBuilder] = None
 
     def __init__(
-        self,
-        path: os.PathLike,
-        all_blocks: bool,
-        *,
-        dset_opts: Optional[DatasetOpts]=None,
-        skip_fields: Optional[list]=None
+        self, path: os.PathLike, expected_store_block_count: Optional[int] = None
     ):
-        self._path = os.fsdecode(path)
-        self._tmp_path = f"{self._path}-tmp"
-        assert not os.path.exists(self._path)
-        assert not os.path.exists(self._tmp_path)
-        self._f = h5py.File(self._tmp_path, "w")
-        self._all_blocks = all_blocks
-
-        self._field_dset_opts = dict() if dset_opts is None else dset_opts
-        self._skip_fields = set() if skip_fields is None else set(skip_fields)
-
+        if os.path.exists(path):
+            raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), path)
+        self._tmp_final_path_pair = (f"{os.fsdecode(path)}-tmp", path)
+        self._f = h5py.File(self._tmp_final_path_pair[0], "w-")
+        self._expected_store_block_count = expected_store_block_count
+        self._recordpack_dict = {}
         self._stored_blockid_list = []
-        self._blockid_location_arr = None
-        self._block_cell_shape = None
 
-    def _get_expected_local_block_count(self) -> int:
-        if self._blockid_location_arr is None:
-            raise RuntimeError("set_hdr method was never called")
-        return self._blockid_location_arr.size if self._all_blocks else 1
+    def _require(self, *attrs: str): # common requirement-checking
+        for a in attrs:
+            if getattr(self, a) is not None:
+                continue
+            elif a == "_f":
+                raise RuntimeError("already cleaned up the builder")
+            elif a in ["_blockid_location_arr_builder", "_expected_store_block_count"]:
+                raise RuntimeError("set_hdr method was never called")
+            raise RuntimeError(f"{a} is invalid")
 
     def set_hdr(
         self,
-        source_file: Union[os.PathLike,h5py.File],
-        *,
-        nprocs: Optional[int3] = None
+        source_file: Union[os.PathLike, h5py.File],
+        missing_nprocs_triple: Optional[int3] = None,
     ) -> Self:
         """Copy the header-attributes from source_file
 
-        Kwargs
-        ------
-        nprocs
+        Parameters
+        ----------
+        source_file
+            Used to set the header
+        missing_nprocs_triple
             This must be provided if the information isn't part source_file
+
+        Notes
+        -----
+        If source_file has the hierarichal-schema, all block location data will
+        be read from source_file.
         """
+        self._require("_f")
         if len(self._f.attrs) != 0:
             raise RuntimeError("It's an error to call set_hdr more than once")
+        cm = nullcontext if isinstance(source_file, h5py.File) else h5py.File
 
-        if isinstance(source_file, h5py.File):
-            cm = nullcontext(source_file)
-        else:
-            cm = h5py.File(source_file, "r")
-
-        with cm as src_f:
+        with cm(source_file) as src_f:
             # copy most of the header
-            concat_internals.copy_header(src_f, self._f, skip_keys = ["nprocs"])
+            concat_internals.copy_header(src_f, self._f, skip_keys=["nprocs"])
 
-            # construct the array
-            self._blockid_location_arr = _make_blockid_location_arr(
-                f=src_f, nprocs=nprocs
+            # construct the location-array-builder
+            self._blockid_location_arr_builder = BlockidLocationArrBuilder(
+                f=src_f, missing_nprocs_triple=missing_nprocs_triple
             )
 
-        nprocs = np.array(self._blockid_location_arr.shape)
+        nprocs = np.array(self._blockid_location_arr_builder.nprocs)
         self._f.attrs["nprocs"] = nprocs
+        assert "dims" in self._f.attrs  # this is a hard requirement
 
-        global_dims = _get_global_dims(src_f)
-        self._block_cell_shape, _remainder = np.divmod(global_dims, nprocs)
-        assert np.all(self._block_cell_shape > 0) and np.all(_remainder==0)
-        assert len(self._block_cell_shape) == 3 and len(nprocs) == 3
-
+        tot_block_count = np.prod(nprocs)
+        if self._expected_store_block_count is None:
+            self._expected_store_block_count = tot_block_count
+        elif self._expected_store_block_count > tot_block_count:
+            raise RuntimeError(
+                "builder is configured to store more blocks than actually exist"
+            )
         return self
 
-    def record_blockid_loc(self, blockid:int, global_cell_offset: int3) -> Self:
-        """record the specified block's location
+    def record_block_loc(self, blockid: int, global_cell_offset: int3) -> Self:
+        """Manually record the specified block's location
+
+        You usually don't need to manually call this method.
 
         Parameters
         ----------
@@ -262,26 +365,25 @@ class SnapBuilder:
             Location of the leftmost cell of the block in the conceptual grid
             spanning the entire domain
         """
-        if self._block_cell_shape is None:
-            raise RuntimeError("set_hdr method was never called")
+        self._require("_f", "_blockid_location_arr_builder")
+        self._blockid_location_arr_builder.store_location(blockid, global_cell_offset)
+        return self
 
-        index = _calc_block_location(global_cell_offset, self._block_cell_shape)
-        if self._blockid_location_arr[index] < 0:
-            assert blockid not in self._stored_blockid_list  # sanity check
-            assert blockid not in self._blockid_location_arr  # sanity check
-            self._blockid_location_arr[index] = blockid
-        else:
-            assert self._blockid_location_arr[index] == blockid
-        return Self
+    def _setup_recorder(self, name: str, fn: Callable, **kwargs: Any):
+        self._require("_f")
+        if name in self._recordpack_dict:
+            raise RuntimeError("the {name!r} recorder is already configured")
+        self._recordpack_dict[name] = (set(), functools.partial(fn, **kwargs))
 
-    def record_field_data(
+    def _record_data(
         self,
         blockid: int,
         data: Mapping,
         *,
-        global_cell_offset: Optional[int3] = None
+        global_cell_offset: Optional[int3] = None,
+        kind=None,
     ) -> Self:
-        """Record the specified block's field info
+        """Record the specified block's data of the specified kind
 
         Parameters
         ----------
@@ -292,72 +394,161 @@ class SnapBuilder:
         global_cell_offset
             Optionally specifies the location of the leftmost cell of the block
             in the conceptual grid spanning the entire domain. An error will be
-            raised if this isn't specified & the block's location isn't known.
-        """
+            raised during the final ``write`` command if the locations are
+            never specified.
+        kind
+            The data kind
 
-        assert blockid >= 0
-        if blockid in self._stored_blockid_list:
-            raise RuntimeError("record_field_data already called for blockid")
-        if global_cell_offset is not None:
-            self.record_blockid_loc(blockid, global_cell_offset)
+        Notes
+        -----
+        This function is not intended to be called directly. Instead you should
+        call methods like field_record or particle_record. (In these scenarios,
+        you shouldn't specify the ``kind`` kwarg)
+        """
+        self._require("_f", "_expected_store_block_count")
+        if kind not in self._recordpack_dict:
+            raise RuntimeError(f"{kind}_config was never called")
+        already_recorded_blockids, record_fn = self._recordpack_dict[kind]
+
+        if blockid < 0:
+            raise ValueError("blockid must not be nonnegative")
+        elif blockid in already_recorded_blockids:
+            raise RuntimeError(f"{kind}_record already called for blockid")
+
+        # deal with the block's spatial location
+        if hasattr(data, "attrs") and "offset" in data.attrs:
+            _offset = to_int_triple(data.attrs["offset"])
+            if global_cell_offset is not None:
+                assert _offset == to_int_triple(global_cell_offset)
+            self.record_block_loc(blockid, _offset)
+        elif global_cell_offset is not None:
+            self.record_block_loc(blockid, global_cell_offset)
 
         # handles case where `data` is a h5py.File for existing snapshot file
-        data = data["field"] if "field" in data else data
+        data = data[kind] if kind in data else data
 
-        newly_created = _record_field_data(
-            dst_f=self._f,
-            expected_store_block_count=self._get_expected_local_block_count(),
-            dest_idx=(len(self._stored_blockid_list), ...),
-            data=data,
-            skip_fields=self._skip_fields,
-            dset_opts=self._field_dset_opts
-        )
+        # get the index in the file associated with blockid
+        try:
+            stored_block_idx = self._stored_blockid_list.index(blockid)
+        except ValueError:
+            stored_block_idx = len(self._stored_blockid_list)
 
-        self._stored_blockid_list.append(blockid)
+        # store the data to the file
+        record_fn(self._f, self._expected_store_block_count, stored_block_idx, data)
 
-        if newly_created:
-            assert self._block_cell_shape is not None  # sanity check!
-            self._f["field"].attrs["block_cell_shape"] = self._block_cell_shape
+        # record that we've stored data for blockid
+        already_recorded_blockids.add(blockid)
+        if len(self._stored_blockid_list) == stored_block_idx:
+            self._stored_blockid_list.append(blockid)
 
         return self
 
-    def record_field_data_itr(self, itr: Iterable) -> Self:
-        """Calls self.record_field_data for each entry in itr"""
+    def _record_data_itr(
+        self, itr: Iterable, *, kind: str, file_paths: bool = False
+    ) -> Self:
+        """Records data (of the specified ``kind``) for multiple blocks
 
+        iterable over blocks to write information of a given kind.
+
+        Parameters
+        ----------
+        itr
+            Iterable that returns ``(blockid, data)`` **OR**
+            ``(blockid, data, global_cell_offset)``. When `file_paths`` is
+            ``True``, ``data`` is treated as a file path.
+        kind
+            The data kind
+        file_paths
+            Controls the interpretation of ``itr``.
+
+        Notes
+        -----
+        This function is not intended to be called directly. Instead you should
+        call methods like field_record_itr or particle_record_itr. (In these
+        scenarios, you shouldn't specify the ``kind`` kwarg)
+        """
+
+        cm = h5py.File if file_paths else nullcontext
+        _packlen = None
         for pack in itr:
-            global_cell_offset = None
-            if len(pack) == 2:
-                blockid, data = pack
-            elif len(pack) == 3:
-                blockid, data, global_cell_offset = pack
-            else:
-                raise ValueError("each element of itr must be 2 or 3 elements")
-            self.record_field_data(
-                blockid=blockid, data=data, global_cell_offset=global_cell_offset
-            )
+            if len(pack) != _packlen:
+                if _packlen is not None:
+                    raise ValueError("members of itr have inconsistent lengths")
+                _packlen = len(pack)
+                if _packlen < 2 or _packlen > 3:
+                    raise ValueError("members of itr must hold 2 or 3 elements")
+            blockid,data = pack[:2]
+            global_cell_offset = pack[2] if _packlen == 3 else None
+
+            with cm(data) as _data:
+                self._record_data(
+                    blockid=blockid,
+                    data=_data,
+                    global_cell_offset=global_cell_offset,
+                    kind=kind
+                )
         return self
+
+    field_record = functools.partialmethod(_record_data, kind="field")
+    field_record_itr = functools.partialmethod(_record_data_itr, kind="field")
+    def field_config(
+        self, *, opts: Optional[DatasetOpts] = None, skip: Optional[Iterable] = None
+    ) -> Self:
+        """Configure the builder to write field-data
+
+        Parameters
+        ----------
+        opts
+            Optional kwargs for ``h5py.Group.create_dataset``.
+        skip
+            Fields to omit from output. Defaults to {}.
+        """
+        opts = dict() if opts is None else opts
+        skip = set() if skip is None else set(skip)
+        self._setup_recorder(
+            name="field", fn=_record_field, dset_opts=opts, skip_fields=skip
+        )
+        return self
+
+    particle_record = functools.partialmethod(_record_data, kind="particle")
+    particle_record_itr = functools.partialmethod(_record_data_itr, kind="particle")
+    def particle_config(
+        self, store_particle_count:int, tot_particle_count:int, # *, kwargs...
+    ) -> Self:
+        raise NotImplementedError("we need to implement this")
+        # will look something like:
+        # > self._setup_recorder(
+        # >     name="particle",
+        # >     fn=_record_particle,
+        # >     store_particle_count=store_particle_count,
+        # >     tot_particle_count=tot_particle_count,
+        # >     kwargs...
+        # > )
+        # > return self
 
     def write(self):
-        # set require_all_blocks to False to write file with a subset of blocks
-        if self._f is None:
-            raise RuntimeError("already cleaned up the builder")
+        """finish writing the output file"""
+        self._require(
+            "_f", "_expected_store_block_count", "_blockid_location_arr_builder"
+        )
 
-        # more sanity checks
-        total_block_count = self._blockid_location_arr.size
-        local_block_count = len(self._stored_blockid_list)
-        if self._blockid_location_arr is None or len(self._f.attrs) == 0:
-            raise RuntimeError("set_hdr was never called")
-        elif np.any(self._blockid_location_arr < 0):
-            raise RuntimeError("block location info is missing")
-        elif local_block_count == 0:
+        # generic sanity checks
+        if "dims" not in self._f.attrs:
+            raise RuntimeError("'dims' is missing from header")
+        stored_block_count = len(self._stored_blockid_list)
+        if stored_block_count == 0:
             raise RuntimeError("no snapshot-data is stored for any block")
-        elif self._all_blocks and total_block_count != local_block_count:
+        elif self._expected_store_block_count != stored_block_count:
             raise RuntimeError("snapshot-data is missing for some blocks")
+
+        for kind, (recorded_set, _) in self._recordpack_dict.items():
+            if len(recorded_set) != self._expected_store_block_count:
+                raise RuntimeError(f"{kind}_record wasn't called enough times")
 
         # write the domain group of the file
         domain_grp = self._f.create_group("domain")
         domain_grp.create_dataset(
-            "blockid_location_arr", data=self._blockid_location_arr
+            "blockid_location_arr", data=self._blockid_location_arr_builder.final_arr()
         )
         domain_grp.create_dataset(
             "stored_blockid_list", data=np.array(self._stored_blockid_list)
@@ -366,19 +557,23 @@ class SnapBuilder:
         # save and close!
         self._f.close()
         self._f = None
-        shutil.move(self._tmp_path, self._path)
+        shutil.move(*self._tmp_final_path_pair)
 
     def cleanup(self):
         if self._f is not None:
             self._f.close()
             self._f = None
-            os.remove(self._tmp_path)
+            os.remove(self._tmp_final_path_pair[0])
 
     def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *args, **kwargs):
         self.cleanup()
+
+    def __deepcopy__(self, memo):
+        raise RuntimeError(f"can't deepcopy {self.__class__.__name__}")
+
 
 ##########################################
 class _MockBlockFieldGroup(UserDict):
@@ -389,14 +584,23 @@ class _MockBlockFieldGroup(UserDict):
         super().__init__(dict(grp.items()))
         self._idx_map = idx_map
 
-    def __getitem__(self, key:str):
-        return self.data[key][self._idx_map.get(key,...)]
+    def __getitem__(self, key: str):
+        return self.data[key][self._idx_map.get(key, ...)]
 
-    def __repr__(self): return "<_MockBlockFieldGroup>"
+    def __repr__(self):
+        return "<_MockBlockFieldGroup>"
+
+
+def _product(*iterables: Iterable, advance_right: bool = True) -> Iterator:
+    if advance_right:
+        return itertools.product(*iterables)
+    return map(lambda seq: seq[::-1], itertools.product(*iterables[::-1]))
+
 
 def _iter_block_from_concat(
-    src_f: h5py.File, missing_nprocs_triple: Optional[Sequence] = None,
-)-> Iterable[tuple[int, _MockBlockFieldGroup, int3]]:
+    src_f: h5py.File,
+    missing_nprocs_triple: Optional[Sequence] = None,
+) -> Iterable[tuple[int, _MockBlockFieldGroup, int3]]:
     """
     Iterates over blocks from a previously concatenated field
 
@@ -411,7 +615,7 @@ def _iter_block_from_concat(
         spanning the entire domain
     """
 
-    if "field" in src_f: # we dealing with file put into the new format
+    if "field" in src_f:  # we dealing with file put into the new format
         assert missing_nprocs_triple is None
 
         blockid_list = src_f["domain/stored_blockid_list"][...]
@@ -436,32 +640,34 @@ def _iter_block_from_concat(
             yield blockid, data, global_cell_offset
 
     else:
-        nprocs = _get_nprocs(f=src_f, nprocs=missing_nprocs_triple)
-        global_dims = _get_global_dims(src_f, True)
-        block_cell_shape, _remainder = np.divmod(global_dims, nprocs)
-        assert np.all(block_cell_shape > 0) and np.all(_remainder==0)
-        assert len(block_cell_shape) == 3 and len(nprocs) == 3
-
-        offset_itr = itertools.product(
-            range(0, global_dims[0], block_cell_shape[0]),
-            range(0, global_dims[1], block_cell_shape[1]),
-            range(0, global_dims[2], block_cell_shape[2])    
+        nprocs, block_cell_shape = _nprocs_and_blockcellshape(
+            f=src_f, missing_nprocs_triple=missing_nprocs_triple, f_is_concatenated=True
         )
+
+        # At the time of writing, I'm pretty sure that advance_right=False should assign
+        # blockids in a consistent manner to cholla
+        blockid_offset_pairs = enumerate(_product(
+            range(0, nprocs[0] * block_cell_shape[0], block_cell_shape[0]),
+            range(0, nprocs[1] * block_cell_shape[1], block_cell_shape[1]),
+            range(0, nprocs[2] * block_cell_shape[2], block_cell_shape[2]),
+            advance_right = False
+        ))
 
         def _mk_idx(name, start):
             shape = [e for e in block_cell_shape]
             if name == "magnetic_x":
-                shape[0]+=1
+                shape[0] += 1
             elif name == "magnetic_y":
-                shape[1]+=1
+                shape[1] += 1
             elif name == "magnetic_z":
-                shape[2]+=1
-            return tuple(slice(start[i], start[i]+shape[i], 1) for i in range(3))
+                shape[2] += 1
+            return tuple(slice(start[i], start[i] + shape[i], 1) for i in range(3))
 
-        for blockid, global_cell_offset in enumerate(offset_itr):
+        for blockid, global_cell_offset in blockid_offset_pairs:
             idx_map = {name: _mk_idx(name, global_cell_offset) for name in src_f}
             data = _MockBlockFieldGroup(src_f, idx_map)
             yield blockid, data, global_cell_offset
+
 
 def repack_snapshot(
     out_dir: os.PathLike,
@@ -500,32 +706,27 @@ def repack_snapshot(
 
     out_path = os.path.join(out_dir, os.path.basename(src_path))
     if not os.path.isfile(src_path):
-        raise ValueError(f"{src_path} doesn't exist")
+        raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), src_path)
     elif not os.path.isdir(out_dir):
-        raise ValueError(f"{out_dir=} isn't a directory")
+        raise OSError(errno.ENOTDIR, os.strerror(errno.ENOTDIR), out_dir)
     elif os.path.exists(out_path):
-        raise ValueError(f"{out_path} already exists")
+        raise OSError(errno.EEXIST, os.strerror(errno.EEXIST), out_path)
 
-    with h5py.File(src_path, "r") as src_f: # open the source file
+    with h5py.File(src_path, "r") as src_f:  # open the source file
         # do some basic setup
         itr = _iter_block_from_concat(src_f, missing_nprocs_triple)
 
-        with SnapBuilder(
-            out_path, True, dset_opts=dset_opts, skip_fields=skip_fields
-        ) as builder: # open the snapshot-builder 
-            builder.set_hdr(src_f, nprocs=missing_nprocs_triple) \
-                .record_field_data_itr(itr) \
+        with SnapBuilder(out_path) as builder:  # open the snapshot-builder
+            builder.set_hdr(src_f, missing_nprocs_triple) \
+                .field_config(opts=dset_opts, skip=skip_fields) \
+                .field_record_itr(itr) \
                 .write()
 
+
 parser = argparse.ArgumentParser(
-    description = "Repacks (previously concatenated) HDF5 snapshots for Cholla"
+    description="Repacks (previously concatenated) HDF5 snapshots for Cholla"
 )
-concat_internals.add_common_cli_args(
-    parser,
-    num_processes_choice = 'omit',
-    add_concat_outputs_arg = False,
-    add_src_dir_arg=False
-)
+concat_internals.add_common_cli_args(parser, num_processes_choice="omit")
 parser.add_argument(
     "--missing-nprocs-triple",
     nargs=3,
@@ -534,33 +735,26 @@ parser.add_argument(
     help=(
         "This must be supplied when the 'nproc' attribute is missing from the "
         "input file. This specifies the number of processes along each axis."
-    )
+    ),
 )
 
 parser.add_argument(
-    "--input-path-template",
+    "-s",
+    "--src-path",
     required=True,
     help=(
         "template-path for the input file. This path should generally include "
         "{snap}, which will be replaced by the snapshot numbers"
-    )
+    ),
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()
 
-    dset_opts = {
-        "dtype" : args.dtype,
-        "compression" : args.compression_type,
-        "compression_opts" : args.compression_opts,
-        "chunks" : args.chunking
-    }
-
-    for snap_number in args.concat_outputs:
-        repack_snapshot(
-            out_dir=args.output_directory,
-            src_path=args.input_path_template.format(snap=snap_number),
-            missing_nprocs_triple=args.missing_nprocs_triple,
-            skip_fields=args.skip_fields,
-            dset_opts=dset_opts
-        )
+    repack_snapshot(
+        out_dir=args.output_directory,
+        src_path=args.src_path,
+        missing_nprocs_triple=args.missing_nprocs_triple,
+        skip_fields=args.skip_fields,
+        dset_opts=dset_opts_from_args(args),
+    )


### PR DESCRIPTION
## Overview

This Pull Request introduces a new data format for storing Cholla's concatenated field data in snapshots. We introduce 3 changes: specify a new format, modifying python scripts, and [changing documentation](#change-3-proposed-changes-to-the-documentation)

## Background

As we all know, a Cholla simulation partitions spatial data into blocks.
- each MPI-process evolves a separate block
- The blocks are conceptually organized on a 3D "block-location" grid of shape `(BLx, BLy, BLz)`. When a simulation starts, this shape is always chosen to match `(n_proc_x, n_proc_y, n_proc_z)`.
- Conceptually, all fields live on a global Domain-grid composed of `(nDx,nDy,nDz)` cells. In practice, the underlying field data is partitioned among the blocks. A given block is responsible for tracking data on `(nBx,nBy,nBz)` cells, where `(nDx,nDy,nDz) = (BLx*nBx, BLy*nBy, BLz*nBz)`.

When Cholla writes a snapshot of the field data, each block is written to a distinct file.

By default, Cholla uses HDF5 files. Cholla's standard "schema" (strategy for organizing data) is "flat" (i.e. there is no hierarchy). We represent this schema down below:
```
/                                      # root group
 ├── HEADER-ATTRS  (REQUIRED)
 ├── <dataset-0>
 ├── <dataset-1>
 └── ...
```

For convenience, we typically concatenate files as a post-processing step. Historically, this procedure always produces an HDF5 file with the "Flat Format," where the data is stitched together in a way that roughly approximates the file that would be produced by a simulation run with a single block that spanned the entire domain.

## Motivation for a new schema

The classic organizational schema works quite well. The simplicity is extremely useful! However, we start to encounter issues when we get to really large data files

The main impetus for making this PR is relates to issues with existing strategy and yt[^1] for large datasets:
1. specifically, yt is designed to break calculations up block-by-block. When we have a single monolithic block:
   - we can't leverage yt's ability to operate on large datasets where the size of the dataset exceeds the available ram.
   - we can't make use of yt's parallelism
2. **Most importantly**, yt starts to break for simulations of size ~2048^3 (presumably due to 32-bit index overflows)

Theoretically, we can configure yt to operate on distributed files (see yt-project/yt#4702). But, this is not an optimal general solution for a few reasons:
- file-system accesses are slow on parallel file systems (it becomes especially noticeable when you thousands of blocks or are using LUSTRE file systems)
- the previous point is compounded by the fact that to infer the relative spatial locations of every block logic in the above link requires that you open every single file. This is solvable by including more information within the files. But, this effectively changes the structure of the files (and if we are going to change it, we might as well make a bigger change)
- Frankly, it seems a little silly that the standard post-processing step would make data-analysis less efficient

More generally (whether you use yt or not), the current approach is sub-optimal for any sort of analysis of a spatial sub-region. At the moment, the fastest way to access all of the data in simulation, you need to iterate over all values along the z-axis. This is pretty inefficient if you want to access just a spatial subregion (say you just want to consider the region around a galactic disk).

## Change 1: Description of New Format:

**NOTE:** it may be helpful to look at the newly proposed documentation (linked down below).

The proposed schema looks like the following:

```
/                                  # root group
 ├── HEADER-ATTRS  (REQUIRED)
 ├── domain/       (REQUIRED)
 │    ├── blockid_location_arr     # shape: (BLx,BLy,BLz)
 │    └── stored_blockid_list      # shape: (nBStored,)
 └── field/
      ├── <field-0>     # 4D shape: (nBStored,nBx,nBy,nBz) or (nBStored, ...)
      ├── <field-1>
      └── ...
```

In the above diagram:
- we follow numpy conventions for describing arrays with C-contiguous layouts.
  In other words, the fastest index is last axis
- `BLx`,`BLy`,`BLz` refer to the number of blocks per axis.
- `nBx`,`nBy`,`nBz` refer to the number of cells per block. This is the shape of a cell-centered field.
- `nBStored` is the number of blocks in the file. It should nominally be `1` or
  `nBx*nBy*nBz`
- `"domain/blockid_location_arr"` specifies the relative locations of the
  blocks
- the data at `{field/<field-0>}[i, ...]` corresponds to the data of the
  block with blockid specified by `{domain/stored_blockid_list}[i]`

> [!NOTE]
> Files in this format **ALWAYS** provide the `"dims"` attribute (in HEADER-ATTRS) and the ``"domain"`` group. Importantly, `"dims"` specifies `(nDx,nDy,nDz)`, the number of cells on the conceptual global Domain-grid, and the shape of "domain/blockid_location_arr" is `(BLx,BLy,BLz)`. Thus, you always can infer `(nBx,nBy,nBz) = (nDx/BLx, nDy/BLy, nDz/BLz)`. Consequently, you can determine whether a `field/<field-0>` is cell-centered, face-centered, etc. by looking at the field's shape.

The above format is intended to be forward-compatible with a schema that also stores particle-data and gravity-data in the same file. We illustrate what this could look like down below (in the collapsible section)


<details>

<summary>ASIDE: Preview of more general schema</summary>

Here we sketch a more-general hypothetical schema that can also include particle and gravity data:

```
/                                      # root group
 ├── HEADER-ATTRS  (REQUIRED)
 ├── domain/       (REQUIRED)
 │    ├── blockid_location_arr        # shape: (BLx,BLy,BLz)
 │    └── stored_blockid_list         # shape: (nBStored,)
 ├── field/
 │    ├── <field-0>        # 4D shape: (nBStored,nBx,nBy,nBz) or (nBStored, ...)
 │    ├── <field-1>        # 4D shape: (nBStored,nBx,nBy,nBz) or (nBStored, ...)
 │    └── ...              # 4D shape: (nBStored,nBx,nBy,nBz) or (nBStored, ...)
 ├── particle/
 │    ├── ATTR:total_particle_count    # i64
 │    ├── stop_particle_idx            # 1D shape: (nBStored,)
 │    ├── <particle-prop-0>            # 1D shape: (stop_particle_idx[-1],)
 │    ├── <particle-prop-1>            # 1D shape: (stop_particle_idx[-1],)
 │    └── ...                          # 1D shape: (stop_particle_idx[-1],)
 └── gravity/
      └── gravity          # 4D shape: (nBStored,nBx,nBy,nBz)
```


A few notes about particle group in this hypothetical extension:

- `particle/ATTR:total_particle_count` specifies the total number of particles in the ENTIRE simulation.
- `particle/stop_particle_idx` holds monotonically non-decreasing values. 
  - when `nBStored == nBx*nBy*nBz`, then `{particle/stop_particle_idx}[-1] =={particle/ATTR:total_particle_count}`
  - in other cases, `{particle/stop_particle_idx}[-1] <={particle/ATTR:total_particle_count}`
- The values of <particle-prop-0> that describe particles for the blockid specified by `{domain/stored_blockid_list}[i]` are given by `{particle/<particle-prop-0>}[slc]`, where `slc` is:
  - `0:{particle/stop_particle_idx}[0]`, when `i` is 0
  - `{particle/stop_particle_idx}[i-1]:{particle/stop_particle_idx}[i]`, in all other cases


</details>

## Change 2: Modifications to the Python Scripts:

This is the only set of changes that concretely correspond to modifications in the repository.

1. The largest change is that we introduce `snaprepack.py` to create new files with the hierarchical schema based on previously concatenated files.
   - invoking this tool from the command line looks something like:
     ```sh
     ./snaprepack.py -s PATH/TO/SOURCE/FILE.h5 -o PATH/TO/OUTPUT/DIRECTORY
     ```
   - if the input file is missing the `"nprocs"` header attribute, you would specify it with the `--missing-nprocs-triple` flag. For example, if "nprocs" should hold (4,2,2), then you could invoke
     ```sh
     ./snaprepack.py -s PATH/TO/SOURCE/FILE.h5 -o PATH/TO/OUTPUT/DIRECTORY --missing-nprocs-triple 4 2 2
     ```
2. I modified the contents of ``concat_3d_data.py`` such that resulting files now have the hierarchical format. 

> [!IMPORTANT]
> This PR has no impact on the concatenation of particles or 2D datasets (e.g. slices, projections)

While ``snaprepack.py`` is a little long, a lot of the contents are related to documenting the code. The code is written in a way that it will be easy to extend to also handle particle-data as well as gravity-data. Once we finish that, I think I could probably simplify the logic a little more. But, for now I think the code is "good enough."

## Change 3: Proposed Changes to the documentation:

If/When this PR is merged, we will need to modify the [Outputs page of the Wiki.](https://github.com/cholla-hydro/cholla/wiki/Output). I have already drafted the changes to this page, while I was trying to figure out how to best describe the file format.
- You can find the draft of the changes [here](https://github.com/cholla-hydro/cholla/wiki/RevisedOutputPage), in a free-floating wiki page
- When this PR is merged, we will obviously need to copy the changes from the free-floating wiki page to the Output page (and delete the free-floating page).
- You can use [this page](https://github.com/cholla-hydro/cholla/wiki/RevisedOutputPage/_history) to highlight all of my proposed changes.

## Other thoughts

Potential improvements to the proposed scheme:
- When using the hierarchical format for files that only store data for a single block, it's worth considering whether we want the domain group to only be present in the files for block 0, or in all files (we can't currently make these files, but it would be worth deciding this sooner or later).
- Theoretically, we could reduce the number of datasets in the "field" group by using 5D datasets instead of 4D datasets. In this picture, we would have a separate dataset for all cell-centered fields, all fields on x-faces (namely `"magnetic_x"`, all fields on y-faces (namely `"magnetic_y"`, etc.). Theoretically, this would give us the flexibility opportunity to store the fields for a given block in closer proximity to each other (which could be useful for analysis). In practice, I skeptical that this additional complexity is warranted.

In the future:
- As already noted, it would be useful to start putting gravity-data and particle-data into this format.
- It would be straight-forward to let cholla start reading from files in the hierarchical format
- It would be useful (and straight-forward) to have Cholla start writing snapshot data in hierarchical format
- we might consider storing derived data in hierarchical format. This could theoretically let us speed up slice-concatenation (by letting us skip unneeded files). It could also let us store multiple kinds of derived data in a single file. In practice, it may not be worth the effort.


[^1]: As we're all aware, yt is not necessarily the most efficient tool in the world (i.e. it isn't hard to write a script/python module to perform a particular task more efficiently than yt), but it is a useful "toolbox" for data exploration and basic analysis.