### PR TITLE
Ruff check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,13 @@ repos:
         types_or: [c++, c, cuda]
         args: ["-style=file", "--verbose"]
 
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.4
+  hooks:
+  # enable the linter:
+  - id: ruff
+    args: ["--fix", "--show-fixes"]
+  # we currently do **NOT** enable the formatter (while I generally think it's a good
+  # idea, we definitely need buy-in)
+  #-  id: ruff-format
+

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,28 @@
+# this is useful with pre-commit (when we want to exclude files)
+force-exclude = true
+
+# do not add any files to this list. We are only introducing this parameter so that
+# we can start using ruff as soon as possible. We plan to gradually remove all files
+# from this list
+extend-exclude = [
+    "./tools/analyze_tidy_checks.py",
+    "./python_scripts/dask_single_machine_template.py",
+    "./python_scripts/combine_test_files.py",
+    "./python_scripts/concat.py",
+    "./python_scripts/concat_particles.py",
+    "./python_scripts/h5AttrsFuncs.py",
+    "./python_scripts/tools.py",
+    "./python_scripts/concat_3d_data.py",
+    "./python_scripts/concat_2d_data.py",
+    "./python_scripts/compress_snapshots.py",
+    "./python_scripts/data_compress_particles.py",
+    "./python_scripts/load_cholla_snapshot.py",
+    "./python_scripts/move_files.py",
+    "./python_scripts/dask_distributed_template.py",
+    "./python_scripts/plot_sod.py",
+    "./python_scripts/concat_internals.py",
+    "./python_scripts/numdiff.py",
+    "./python_scripts/Projection_Slice_Tutorial.ipynb",
+    "./python_scripts/data_compress_grid.py",
+    "./docs/sphinx/source/conf.py",
+]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -5,10 +5,8 @@ force-exclude = true
 # we can start using ruff as soon as possible. We plan to gradually remove all files
 # from this list
 extend-exclude = [
-    "./tools/analyze_tidy_checks.py",
     "./python_scripts/dask_single_machine_template.py",
     "./python_scripts/combine_test_files.py",
-    "./python_scripts/concat.py",
     "./python_scripts/concat_particles.py",
     "./python_scripts/h5AttrsFuncs.py",
     "./python_scripts/tools.py",

--- a/python_scripts/concat.py
+++ b/python_scripts/concat.py
@@ -7,13 +7,11 @@ At the moment, we only support fluid quantities. In the future, we could
 support other types of fields.
 """
 
-import numpy as np
 
 import argparse
 import datetime
 from functools import partial
 import os
-import pathlib
 
 import concat_internals
 from concat_2d_data import concat_2d_dataset

--- a/tools/analyze_tidy_checks.py
+++ b/tools/analyze_tidy_checks.py
@@ -12,7 +12,6 @@
 """
 
 import numpy as np
-import pandas as pd
 import pathlib
 import subprocess
 


### PR DESCRIPTION
EDIT: the contributions of this PR are now a part of #434. We can close this PR if we want

--------------

## Overview

This adds the [ruff linter](https://docs.astral.sh/ruff/linter/) to pre-commit.

## Motivation

In more detail, the [ruff linter](https://docs.astral.sh/ruff/linter/) performs similar actions to ``clang-tidy``, but applies to python.

> [!IMPORTANT]
> Ruff also provides a code-formatter (e.g. like clang-format for python). This PR does **NOT** enable the formatter. While I think it would be useful to enable the code formatter, that's beyond the scope of this PR (it would produce a bunch of churn in the existing scripts and it provides less value)

It's useful to draw comparisons to ``clang-tidy``:
- I think most of us share the sentiment that clang-tidy provides us with only limited benefit. In practice, it mostly just enforces coding conventions and infrequently catches bugs[^1]
- while the ruff linter also enforces coding-conventions, it serves some additional purposes. To illustrate this, consider the following (contrived) code block:
   ```python
   a = 3
   if cond:
       a = a + 2
   else:
       a = a + myvar
   ```
   Now that this is part of a larger function where I forgot to define the variable `myvar` (or I defined it as `my_var`). Python won't identify the error unless we run the code and `cond` has a value of `False`. The ruff linter provides a lot of additional value[^2] by identifying these cases for us!

The second bullet point covers the majority of python bugs that I personally produce (and that I see). And for that reason I think the linter is extremely useful (I found it useful while writing #427)

## Details

Currently the ruff linter identifies lots of "problems" with our existing scripts. While many of these problems are about coding-style, some of them are real issues. To avoid making this a large PR, I configured the ruff linter to exclude all existing files and only apply to newly introduced files. But, we can fix that going forward.

As a proof of concept, I did address the "problems" in 2 existing files -- pertaining to unused import-statements

[^1]: I suspect that this has a lot to do with the kind of logic within Cholla. I suspect that in more-general codebases (not just a numerical simulation code) it's probably a more useful tool.
[^2]: If this logic were in C/C++, clang-tidy could probably also identify this case for us. But this isn't as useful since any modern C/C++ compiler should also identify the error. 