### PR TITLE
Tweak & Rename the GitHub Action testing that the code compiles with HIP

### DIFF
--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -11,56 +11,53 @@ on:
 
 jobs:
   Build:
-    name: Build & Lint = ${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
+    name: Platform=${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
     # if: ${{ false }}  # If uncommented this line will disable this job
-
-    # Choose OS/Runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest  # Choose OS/Runner
     container:
       image: ${{matrix.container.link}}
     defaults:
       run:
         shell: bash
-    # Matrix for different make types
     strategy:
       fail-fast: false
-      matrix:
+      matrix:  # Matrix for different make-types and platforms
         make-type: [hydro, gravity, disk, particles, cosmology, mhd, dust, cooling]
-        # The CUDA container can be added with {name: "CUDA", link: "docker://chollahydro/cholla:cuda_github"}
-        container: [{name: "HIP",link: "docker://chollahydro/cholla:rocm_github"}]
-
-    # Setup environment variables
-    env:
+        container:
+          #- {name: "CUDA", link: "docker://chollahydro/cholla:cuda_github"}
+          - {name: "HIP", link: "docker://chollahydro/cholla:rocm_github"}
+    env:  # Set environment variables
       CHOLLA_MAKE_TYPE: ${{ matrix.make-type }}
 
     # Run the job itself
     steps:
-
-    # Install required Tools
-    - uses: actions/checkout@v3
+    - name: Checkout Cholla
+      uses: actions/checkout@v3
 
     # Show versions
     - name: Show MPI version
       run: mpirun --version
+
     - name: Show HDF5 config
+      run: h5cc -showconfig
+
+    - name: Show CUDA/HIP version & Compiler version(s)
       run: |
-        h5cc -showconfig
+        if [[ ${{ matrix.conatainer.name }} == 'CUDA' ]]; then
+          cc --version
+          c++ --version
+          nvcc -V
+        else
+          hipcc --version
+          hipconfig --full
+        fi
+
+    # Is this really necessary?
     - name: Git Safe Directory
       run: |
         git --version
         git config --global --add safe.directory /__w/cholla/cholla
         git config --global --add safe.directory '*'
-    # - name: Show CUDA and gcc version
-    #   if: matrix.container.name == 'CUDA'
-    #   run: |
-    #     cc --version
-    #     c++ --version
-    #     nvcc -V
-    - name: Show HIP and hipcc version
-      if: matrix.container.name == 'HIP'
-      run: |
-        hipcc --version
-        hipconfig --full
 
     # Perform Build
     - name: Cholla setup

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -72,8 +72,8 @@ jobs:
         echo "CHOLLA_LAUNCH_COMMAND = ${CHOLLA_LAUNCH_COMMAND}"
         echo "CHOLLA_ROOT=${CHOLLA_ROOT}"                     >> $GITHUB_ENV
         echo "CHOLLA_LAUNCH_COMMAND=${CHOLLA_LAUNCH_COMMAND}" >> $GITHUB_ENV
-        echo "F_OFFLOAD=${F_OFFLOAD}                          >> $GITHUB_ENV
-        echo "CHOLLA_ENVSET=${CHOLLA_ENVSET}                  >> $GITHUB_ENV
+        echo "F_OFFLOAD=${F_OFFLOAD}"                         >> $GITHUB_ENV
+        echo "CHOLLA_ENVSET=${CHOLLA_ENVSET}"                 >> $GITHUB_ENV
     - name: Build Cholla
       run: |
         source builds/run_tests.sh

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -1,7 +1,9 @@
 name: Build & Lint
 
-# This runs the HIP Builds. CUDA builds can be reenabled by adding the CUDA
-# container to the matrix and uncommenting the CUDA lines
+# This runs the HIP builds
+#
+# To re-enable the CUDA build, uncomment the line mentioning CUDA under
+# jobs.Build.strategy.matrix.container
 
 on:
   pull_request:
@@ -12,7 +14,6 @@ on:
 jobs:
   Build:
     name: Platform=${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
-    # if: ${{ false }}  # If uncommented this line will disable this job
     runs-on: ubuntu-latest  # Choose OS/Runner
     container:
       image: ${{matrix.container.link}}
@@ -29,9 +30,9 @@ jobs:
     env:  # Set environment variables
       CHOLLA_MAKE_TYPE: ${{ matrix.make-type }}
 
-    # Run the job itself
-    steps:
-      - name: Checkout Cholla
+    steps:  # list steps of the job
+
+      - name: Checkout Cholla Repository
         uses: actions/checkout@v3
 
       - name: Show MPI version

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Build:
-    name: Platform=${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
+    name: ${{ matrix.container.name }}, TYPE=${{ matrix.make-type }}
     runs-on: ubuntu-latest  # Choose OS/Runner
     container:
       image: ${{matrix.container.link}}
@@ -34,6 +34,13 @@ jobs:
 
       - name: Checkout Cholla Repository
         uses: actions/checkout@v4
+        with:
+          submodules: false  # we don't want our submodule
+          # `set-safe-directory: true` is known not to work in custom docker
+          # images (like the ones that we are using)
+
+      # we can remove this step when the set-safe-directory bug is fixed
+      - run: git config --global --add safe.directory "$GITHUB_WORKSPACE" 
 
       - name: Show MPI version
         run: mpirun --version
@@ -51,13 +58,6 @@ jobs:
             hipcc --version
             hipconfig --full
           fi
-
-      # Is this really necessary?
-      #- name: Git Safe Directory
-      #  run: |
-      #    git --version
-      #    git config --global --add safe.directory /__w/cholla/cholla
-      #    git config --global --add safe.directory '*'
 
       - name: Cholla setup
         run: |

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -31,65 +31,65 @@ jobs:
 
     # Run the job itself
     steps:
-    - name: Checkout Cholla
-      uses: actions/checkout@v3
+      - name: Checkout Cholla
+        uses: actions/checkout@v3
 
-    # Show versions
-    - name: Show MPI version
-      run: mpirun --version
+      # Show versions
+      - name: Show MPI version
+        run: mpirun --version
 
-    - name: Show HDF5 config
-      run: h5cc -showconfig
+      - name: Show HDF5 config
+        run: h5cc -showconfig
 
-    - name: Show CUDA/HIP version & Compiler version(s)
-      run: |
-        if [[ ${{ matrix.conatainer.name }} == 'CUDA' ]]; then
-          cc --version
-          c++ --version
-          nvcc -V
-        else
-          hipcc --version
-          hipconfig --full
-        fi
+      - name: Show CUDA/HIP version & Compiler version(s)
+        run: |
+          if [[ ${{ matrix.conatainer.name }} == 'CUDA' ]]; then
+            cc --version
+            c++ --version
+            nvcc -V
+          else
+            hipcc --version
+            hipconfig --full
+          fi
 
-    # Is this really necessary?
-    - name: Git Safe Directory
-      run: |
-        git --version
-        git config --global --add safe.directory /__w/cholla/cholla
-        git config --global --add safe.directory '*'
+      # Is this really necessary?
+      - name: Git Safe Directory
+        run: |
+          git --version
+          git config --global --add safe.directory /__w/cholla/cholla
+          git config --global --add safe.directory '*'
 
-    # Perform Build
-    - name: Cholla setup
-      run: |
-        make clobber
-        source builds/run_tests.sh
-        setupTests -c gcc
-        echo "CHOLLA_ROOT           = ${CHOLLA_ROOT}"
-        echo "CHOLLA_LAUNCH_COMMAND = ${CHOLLA_LAUNCH_COMMAND}"
-        echo "CHOLLA_ROOT=${CHOLLA_ROOT}"                     >> $GITHUB_ENV
-        echo "CHOLLA_LAUNCH_COMMAND=${CHOLLA_LAUNCH_COMMAND}" >> $GITHUB_ENV
-        echo "F_OFFLOAD=${F_OFFLOAD}"                         >> $GITHUB_ENV
-        echo "CHOLLA_ENVSET=${CHOLLA_ENVSET}"                 >> $GITHUB_ENV
-    - name: Build Cholla
-      run: |
-        source builds/run_tests.sh
-        buildCholla OPTIMIZE
-    - name: Build Tests
-      run: |
-        source builds/run_tests.sh
-        buildChollaTests
+      # Perform Build
+      - name: Cholla setup
+        run: |
+          make clobber
+          source builds/run_tests.sh
+          setupTests -c gcc
+          echo "CHOLLA_ROOT           = ${CHOLLA_ROOT}"
+          echo "CHOLLA_LAUNCH_COMMAND = ${CHOLLA_LAUNCH_COMMAND}"
+          echo "CHOLLA_ROOT=${CHOLLA_ROOT}"                     >> $GITHUB_ENV
+          echo "CHOLLA_LAUNCH_COMMAND=${CHOLLA_LAUNCH_COMMAND}" >> $GITHUB_ENV
+          echo "F_OFFLOAD=${F_OFFLOAD}"                         >> $GITHUB_ENV
+          echo "CHOLLA_ENVSET=${CHOLLA_ENVSET}"                 >> $GITHUB_ENV
+      - name: Build Cholla
+        run: |
+          source builds/run_tests.sh
+          buildCholla OPTIMIZE
+      - name: Build Tests
+        run: |
+          source builds/run_tests.sh
+          buildChollaTests
 
-    # Run Clang-tidy
-    # - name: Run clang-tidy
-    #   if: matrix.container.name == 'CUDA'
-    #   run: make tidy TYPE=${{ matrix.make-type }} CLANG_TIDY_ARGS="--warnings-as-errors=*"
-    # - name: Display tidy_results_cpp.log
-    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-    #   run: cat tidy_results_cpp.log
-    # - name: Display tidy_results_c.log
-    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-    #   run: cat tidy_results_c.log
-    # - name: Display tidy_results_gpu.log
-    #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-    #   run: cat tidy_results_gpu.log
+      # Run Clang-tidy
+      # - name: Run clang-tidy
+      #   if: matrix.container.name == 'CUDA'
+      #   run: make tidy TYPE=${{ matrix.make-type }} CLANG_TIDY_ARGS="--warnings-as-errors=*"
+      # - name: Display tidy_results_cpp.log
+      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+      #   run: cat tidy_results_cpp.log
+      # - name: Display tidy_results_c.log
+      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+      #   run: cat tidy_results_c.log
+      # - name: Display tidy_results_gpu.log
+      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
+      #   run: cat tidy_results_gpu.log

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout Cholla
         uses: actions/checkout@v3
 
-      # Show versions
       - name: Show MPI version
         run: mpirun --version
 
@@ -59,7 +58,6 @@ jobs:
           git config --global --add safe.directory /__w/cholla/cholla
           git config --global --add safe.directory '*'
 
-      # Perform Build
       - name: Cholla setup
         run: |
           make clobber
@@ -79,17 +77,3 @@ jobs:
         run: |
           source builds/run_tests.sh
           buildChollaTests
-
-      # Run Clang-tidy
-      # - name: Run clang-tidy
-      #   if: matrix.container.name == 'CUDA'
-      #   run: make tidy TYPE=${{ matrix.make-type }} CLANG_TIDY_ARGS="--warnings-as-errors=*"
-      # - name: Display tidy_results_cpp.log
-      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-      #   run: cat tidy_results_cpp.log
-      # - name: Display tidy_results_c.log
-      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-      #   run: cat tidy_results_c.log
-      # - name: Display tidy_results_gpu.log
-      #   if: ${{ (matrix.container.name == 'CUDA') && (always()) }}
-      #   run: cat tidy_results_gpu.log

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Build:
-    name: Build & Lint: ${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
+    name: Build & Lint = ${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
     # if: ${{ false }}  # If uncommented this line will disable this job
 
     # Choose OS/Runner

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -33,7 +33,7 @@ jobs:
     steps:  # list steps of the job
 
       - name: Checkout Cholla Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Show MPI version
         run: mpirun --version

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Show CUDA/HIP version & Compiler version(s)
         run: |
-          if [[ ${{ matrix.conatainer.name }} == 'CUDA' ]]; then
+          if [[ ${{ matrix.container.name }} == 'CUDA' ]]; then
             cc --version
             c++ --version
             nvcc -V

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -53,11 +53,11 @@ jobs:
           fi
 
       # Is this really necessary?
-      - name: Git Safe Directory
-        run: |
-          git --version
-          git config --global --add safe.directory /__w/cholla/cholla
-          git config --global --add safe.directory '*'
+      #- name: Git Safe Directory
+      #  run: |
+      #    git --version
+      #    git config --global --add safe.directory /__w/cholla/cholla
+      #    git config --global --add safe.directory '*'
 
       - name: Cholla setup
         run: |

--- a/.github/workflows/build_and_lint.yml
+++ b/.github/workflows/build_and_lint.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   Build:
-    name: >
-      Build & Lint:
-      ${{ matrix.container.name }}
-      TYPE=${{ matrix.make-type }}
+    name: Build & Lint: ${{ matrix.container.name }} TYPE=${{ matrix.make-type }}
     # if: ${{ false }}  # If uncommented this line will disable this job
 
     # Choose OS/Runner

--- a/.github/workflows/compilation_checks.yml
+++ b/.github/workflows/compilation_checks.yml
@@ -1,6 +1,6 @@
-name: Build & Lint
+name: Compilation-Checks
 
-# This runs the HIP builds
+# This checks that the code successfully compiles with HIP
 #
 # To re-enable the CUDA build, uncomment the line mentioning CUDA under
 # jobs.Build.strategy.matrix.container

--- a/.github/workflows/compilation_checks.yml
+++ b/.github/workflows/compilation_checks.yml
@@ -2,7 +2,7 @@ name: Compilation-Checks
 
 # This checks that the code successfully compiles with HIP
 #
-# To re-enable the CUDA build, uncomment the line mentioning CUDA under
+# To re-enable the CUDA builds, uncomment the line mentioning CUDA under
 # jobs.Build.strategy.matrix.container
 
 on:


### PR DESCRIPTION
This PR cleans up the GitHub action that tests whether the code code can compile with HIP.
- Basically I refactored a bunch of stuff in the file without changing anything meaningful
- I also renamed the "check" from "Build and Lint" to simply "Compilation Checks" since we aren't doing any linting within this Action (we do the linting as part of the Jenkins workflow)

Aside: The motivation for making this PR was to address the fact that we would have "Build & Lint: HIP TYPE=<TYPE>" hanging around forever. I figured out how to fix this. It turns out that it is a branch-protection strategy based on the name of the action. I suspect that at some point, GitHub changed the way the GitHub actions were named (when using a "matrix of cases") and that's why things broke. I can fix this, but I figured we may want to wait if we are going to change the names of the checks