### PR TITLE
fix the name of the GHA

### DIFF
--- a/.github/workflows/compilation_checks.yml
+++ b/.github/workflows/compilation_checks.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Build:
-    name: ${{ matrix.container.name }}, TYPE=${{ matrix.make-type }}
+    name: Compilation-Check for ${{ matrix.container.name }}, TYPE=${{ matrix.make-type }}
     runs-on: ubuntu-latest  # Choose OS/Runner
     container:
       image: ${{matrix.container.link}}


### PR DESCRIPTION
A followup to #431. The names of GitHub Actions appear slightly differently when (1) a PR is open and awaiting review and (2) a PR is closed (after it is merged). While crafting PR #431, I didn't realize there was a distinction and only thought about the name in the first context.

Prior to this PR:
1. an associated check in an open PR appears as `Compilation-Checks / HIP, TYPE=<type>`
2. an associated check in a closed PR (after merging) appears as `HIP, TYPE=<type>`

With the changes in this PR:
1. an associated check in an open PR appears as `Compilation-Checks / Compilation-Check for HIP, TYPE=<type>`
2. an associated check in a closed PR (after merging) appears as `Compilation-Check for HIP, TYPE=<type>`