### PR TITLE
Transfering some documentation from the Wiki

### DIFF
--- a/docs/sphinx/Development/writing-docs.md
+++ b/docs/sphinx/Development/writing-docs.md
@@ -50,9 +50,16 @@ $ firefox _build/html/index.html
 ::::
 
 ::::{tab} macOS
+:::{tab} firefox
 ```shell-session
 $ open -a firefox _build/html/index.html
 ```
+:::
+:::{tab} chrome
+```
+$ open -a "Google Chrome" _build/html/index.html
+```
+:::
 ::::
 
 ## Extensions

--- a/docs/sphinx/Physics/Dual-Energy-Formalism.md
+++ b/docs/sphinx/Physics/Dual-Energy-Formalism.md
@@ -1,0 +1,39 @@
+# Dual Energy Formalism
+
+Cholla has the capability to employ the dual-energy formalism in order to simulate high Mach number flows.
+
+## Brief Primer
+
+To ensure the conservation of mass, momentum, and energy, the hydro solvers provided in Cholla evolve the conserved quantities {math}`\rho`, {math}`\rho v_x`, {math}`\rho v_y`, {math}`\rho v_z`, {math}`E`. The bulk of the work during each timestep is to calculate the fluxes in each conserved quantites between every cell. The flux calculations require knowledge of the thermal pressure, which is given by {math}`p = (\gamma - 1) (E-E_{\rm kinetic})`. 
+
+Problems arise in simulations with large Mach numbers (such as cosmological simulations). When the Mach number is very large, then {math}`(E - E_{\rm kinetic})` is very small. Numerical issues arise, since the thermal pressure linearly scales with this small difference between two very large numbers.
+
+## About the Dual Energy Formalism
+
+The solution to this numerical problem is to use the "dual-energy formalism" (more details are provided in [Bryan+ 2014](https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B)). The core idea is to track an extra separately-advected "thermal energy" field at each cell-location, in addition to the total energy field and use this "thermal energy" field in cases where {math}`(E - E_{\rm thermal})` provides insufficient precision. 
+
+The dual-energy formalism is parameterized by two parameters, {math}`\eta_1` and {math}`\eta_2`. It's easiest to understand their meaning by discussing how they are used. The [Bryan+ 2014](https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B) paper describes two main steps:
+1. During a given timestep, when we want to compute thermal pressure, we compare quotient of the "thermal energy" field divided by {math}`E` to {math}`\eta_1`.
+    - When the ratio is smaller than {math}`\eta_1` we use the "thermal energy" field. When it exceeds {math}`\eta_1`, we use {math}`(E-E_{\rm kinetic})`.
+    - In effect, {math}`\eta_1` directly parameterizes the precision where the dual-energy formalism kicks in.
+    - It's worth mentioning that running a simulation with {math}`\eta_1=0` is equivalent to running a simulation without the dual energy formalism.
+2. Near the end of each timestep (after updating all the fields with fluxes and any source terms), the "thermal energy" energy is optionally overwritten with the value taken from {math}`(E-E_{\rm kinetic})`.
+    - To motivate this step, it's important to understand that when we separately advect the "thermal energy" and add the {math}`-p(\nabla \cdot {\bf v})\Delta t/ \rho` source term, we are effectively ignoring the effects of shock heating.
+    - Consequently, we might want to overwrite the "thermal energy" to capture the effects of shock heating. 
+    - The precise condition that dictates when we overwrite the "thermal energy" field involves a comparison of {math}`\eta_2` and the values in neighboring cells. When {math}`\eta_2` is too high, we would effectively exclude shock-heating from weaker shocks. When {math}`\eta_2` is too low we may include spurious heating that is introduced by the truncation error of {math}`(E-E_{\rm kinetic})`.
+    - **NOTE:** [Bryan+ 2014](https://ui.adsabs.harvard.edu/abs/2014ApJS..211...19B) call this step "synchronization" - we find that name somewhat confusing since it may imply a bidirectional update (updating both "thermal energy" and {math}`E`).
+
+In practice, Cholla does something slightly different:
+1. It implements step 1 exactly as described above.
+2. Step 2 is pretty much the same. However, we also overwrite the "thermal energy" field when the quotient of "thermal energy" divided by {math}`E` exceeds {math}`\eta_1`.
+3. We add an additional step after step 2, where we overwrite {math}`E` with the sum of the "thermal energy" field and {math}`E_{\rm kinetic}`.
+   - This is useful for book-keeping reasons throughout the rest of the codebase.
+   - Something like this step is commonly implemented in other simulation codes (for example, Enzo effectively does this in any configuration involving radiative cooling physics).
+
+## Configuring the Dual Energy Formalism
+
+To use the dual-energy formalism, you just need to define the `DE` macro at compile-time
+
+The `DE_ETA_1` and `DE_ETA_2` macros are automatically defined within Cholla. At the time of writing this page, Cholla sets `DE_ETA_1` to different values based on whether it is configured in cosmology. In cosmological simulations, `DE_ETA_1` is always set to 1. This means that the separately advected "thermal energy" field is **always** prioritized over {math}`E` when computing the thermal pressure.
+
+At this time, the dual-energy formalism is **NOT** compatible with MHD.

--- a/docs/sphinx/Physics/Dust.md
+++ b/docs/sphinx/Physics/Dust.md
@@ -1,0 +1,10 @@
+# Dust
+
+## Turning on `DUST`
+The `SCALAR` and `DUST` flags can be used in any build to add dust as an additional fluid component to a simulation (see also the `DUST` build type). Note that Cholla's dust model treats dust as a passive scalar, so both flags are required. The dust field in the conserved variable arrays can be accessed using `grid_enum::dust_density`.
+
+## Initializing dust distribution
+The initial distribution of dust can be set in the same manner as the other conserved variables in the initial conditions function (see, for example, the `Clouds` initial conditions function). This controls the spatial distribution and initial density of dust. The dust grain size should be set using the `grain_radius` keyword in the input file (in units of 0.1 micron). Invocations of the `DUST` macro should be wrapped in the `SCALAR` macro.
+
+## Dust model
+Currently, Cholla's dust model simulates the destruction of dust due to sputtering, which depends on the local gas density and temperature, as well as the dust grain size. The sputtering model can be found in Section 2.1 of [Richie et al. (2024)](https://ui.adsabs.harvard.edu/abs/2024ApJ...974...81R/abstract), based on the model from [Draine & Salpeter (1979)](https://ui.adsabs.harvard.edu/abs/1979ApJ...231...77D/abstract). For the dust dynamics, we assume that gas and dust are fully dynamically coupled.

--- a/docs/sphinx/Physics/MHD.md
+++ b/docs/sphinx/Physics/MHD.md
@@ -1,0 +1,25 @@
+# MHD
+
+The magnetohydrodynamics (MHD) implementation utilizes the VL+CT integrator described in [Stone & Gardiner 2009](https://ui.adsabs.harvard.edu/abs/2009NewA...14..139S/abstract) with the HLLD Riemann solver from [Miyoshi & Kusano 2005](https://ui.adsabs.harvard.edu/abs/2005JCoPh.208..315M/abstract); details of the Cholla implementation and performance can be found in Caddy & Schneider 2024. Interface reconstruction is supported in first, second, and third order with the following methods: Piecewise Constant Method (PCM), Piecewise Linear Method with limiting in the Characteristic Variables (PLMC)([Stone et al. 2005](https://ui.adsabs.harvard.edu/abs/2008ApJS..178..137S/abstract)), and Piecewise Parabolic Method in the Characteristic Variables (PPMC)([Felker & Stone 2018](https://ui.adsabs.harvard.edu/abs/2018JCoPh.375.1365F/abstract)).
+
+The VL+CT integrator utilizes a staggered grid with the magnetic fields centered at cell faces rather than cell centers. All magnetic fields are stored at the i+1/2 interface.
+
+## Turning on MHD & Supported Options
+
+To turn on MHD, build with the `MHD` flag. In addition, MHD only supports the Van Leer (`VL`) integrator and the `HLLD` Riemann solver. MHD supports all reconstruction methods (`PCM`, `PLMP`, `PLMC`, and `PPMC`) except `PPMP` (PPM with limiting in the primitive variables). If Cholla MHD is built with an unsupported configuration, then it should raise a compile time error; if it does not, please open an issue about it.
+
+### Output
+
+MHD only supports output with HDF5 files, so if output is enabled, the `HDF5` flag must also be passed. Full grid and slice outputs are fully supported. In the case of slices, the magnetic fields are converted to cell-centered values. Projections and rotated projections also supported for outputting density, temperature, and in the case of rotated projections, velocity as well.
+
+## Initializing
+
+The initial magnetic fields can be set in the same manner as the hydro fields, see the `Grid3D::Orszag_Tang_Vortex` function in [`initial_conditions.cpp`](https://github.com/cholla-hydro/cholla/blob/main/src/grid/initial_conditions.cpp) for an example. Note that the initial conditions *must* be divergence-free for the VL+CT integrator to work. The easiest way to ensure this condition for non-trivial fields is to initialize from the vector potential rather than the magnetic field directly; the `mhd::utils::Init_Magnetic_Field_With_Vector_Potential` function in [`mhd_utilities.cu`](https://github.com/cholla-hydro/cholla/blob/main/src/grid/mhd_utilities.cu) has been provided to convert a vector potential into the magnetic field.
+
+## Reconstruction Choice
+
+Piecewise Linear Method (PLM) is the default. We have found that PPMC, while giving more accurate results in problems with smooth flows, is often very oscillatory near shocks. PLMC and PLMP give similar results, PLMP is slightly more oscillatory near shocks, though this is not present in all problems and is slightly faster than PLMC (~4-5%). Either PLM method works well, though one may work better than the other for specific problems.
+
+## Caveats and Known Issues
+
+MHD support has not yet been extended to all other physics modules. Support in other modules is a work in progress but as yet is not complete.

--- a/docs/sphinx/Physics/index.md
+++ b/docs/sphinx/Physics/index.md
@@ -8,4 +8,7 @@ Port over more from the wiki
 :maxdepth: 1
 
 CoolingChemistry.md
+Dual-Energy-Formalism.md
+Dust.md
+MHD.md
 :::


### PR DESCRIPTION
Transferred the docs for the dust, MHD, and dual energy physics modules (with some small tweaks to convert Markdown syntax to MyST Markdown syntax), and added the command for viewing the local version of the documentation site in Chrome on macOS.