### PR TITLE
Introduce simple sphinx extension to let us easily document scripts

### DIFF
--- a/docs/sphinx/OutputFmtAndRepack.md
+++ b/docs/sphinx/OutputFmtAndRepack.md
@@ -329,10 +329,6 @@ At the time of writing, this is just used for restarts
 
 We provide a variety of scripts for modifying outputs in the directory called {repository-file}`python/scripts`.
 
-:::{todo}
-We may want to directly embed the result of each script's help command within the documentation.
-:::
-
 ### Concatenation scripts
 
 The following scripts are provided (for use as command-line tools or as python modules) to help with concatenation:

--- a/docs/sphinx/OutputFmtAndRepack.md
+++ b/docs/sphinx/OutputFmtAndRepack.md
@@ -357,6 +357,30 @@ The CLI for all the scripts is similar and details can be found when passing the
 In general you need to tell the script which directory to read files from (the `-s`/`--source-directory` flag), where to write the concatenated files (the `-o`/`--output-directory` flag), and which outputs to concatenate (the `--snaps` flag).
 The `--snaps` flag accepts a couple of different input formats, it can be a single number (e.g. 8), a range (e.g. 2-9), or a list (e.g. [1,2,3]); ranges are inclusive.
 
+We show the detailed help messages down below
+
+::::{tab} concat\_2d\_data.py
+
+:::{include-cli-help} ../../python/scripts/concat_2d_data.py
+:::
+
+::::
+
+::::{tab} concat\_3d\_data.py
+
+:::{include-cli-help} ../../python/scripts/concat_3d_data.py
+:::
+
+::::
+
+
+::::{tab} concat\_particles.py
+
+:::{include-cli-help} ../../python/scripts/concat_particles.py
+:::
+
+::::
+
 **Example**
 ```bash
 ./concat_3d_data.py -s /PATH/TO/SOURCE/DIRECTORY/ -o /PATH/TO/DESTINATION/DIRECTORY/ -n 8  --snaps 0-10

--- a/docs/sphinx/_ext/cli_help.py
+++ b/docs/sphinx/_ext/cli_help.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import sys
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+class IncludeCliHelp(SphinxDirective):
+    """
+    Implements ``.. include-cli-help:: <path/to/prog>``
+    """
+
+    has_content = False
+    required_arguments = 1
+
+    def run(self) -> list[nodes.Node]:
+        document = self.state.document
+        rel_path, path = self.env.relfn2path(self.arguments[0].strip())
+        if os.path.isfile(path):
+            self.state.document.settings.record_dependencies.add(path)
+        else:
+            self.severe(f"can't locate ``{path}``")
+
+        if path.endswith(".py"):
+            cmd = [sys.executable]
+        else:
+            cmd = []
+        cmd.extend([str(path), "--help"])
+        rslt = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        if rslt.returncode == 0:
+            content = rslt.stdout.decode()
+        else:
+            msg = f"there was a problem executing ``{' '.join(cmd)}``"
+            document.reporter.warning(msg, line=self.lineno)
+            content = f"<{msg}>"
+        content = content.strip()
+        literal = nodes.literal_block(content, content)
+        return [literal]
+
+
+def setup(app):
+    app.add_directive("include-cli-help", IncludeCliHelp)
+
+    return {"version": "0.1"}  # identifies the version of our extension

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -54,7 +54,8 @@ extensions = [
 
     # Custom Extensions
     # -----------------
-    "par"
+    "par",
+    "cli_help",
 ]
 
 source_suffix = [".rst", ".md"]


### PR DESCRIPTION
To be reviewed after #461 is merged

------

This is a short PR that introduces a very simple sphinx extension to let us easily document scripts. Essentially, the extension invokes the script with the ``--help`` option and then displays the output in the documentation