### PR TITLE
Add clarifying comments and misc tweaks

### DIFF
--- a/src/io/FnameTemplate.h
+++ b/src/io/FnameTemplate.h
@@ -9,7 +9,7 @@
 
 #include "../io/ParameterMap.h"
 
-/* Lightweight object designed to centralize the file-naming logic (& any associated configuration).
+/*! Lightweight object designed to centralize the file-naming logic (& any associated configuration).
  *
  * Cholla pathnames traditionally followed the following template:
  *     "{outdir}{nfile}{pre_extension_suffix}{extension}.{proc_id}"
@@ -46,18 +46,18 @@ class FnameTemplate
   {
   }
 
-  FnameTemplate(const Parameters& P) : FnameTemplate(not P.legacy_flat_outdir, P.outdir) {}
+  explicit FnameTemplate(const Parameters& P) : FnameTemplate(not P.legacy_flat_outdir, P.outdir) {}
 
-  /* Specifies whether separate cycles are written to separate directories */
+  /*! Specifies whether separate cycles are written to separate directories */
   bool separate_cycle_dirs() const noexcept { return separate_cycle_dirs_; }
 
-  /* Returns the nominal output-directory (this value is unaffected by separate_cycle_dirs()) */
+  /*! Returns the nominal output-directory (this value is unaffected by separate_cycle_dirs()) */
   std::string nominal_output_dir_path() const noexcept { return outdir_; }
 
-  /* Returns the effective output-directory used for outputs at a given simulation-cycle */
+  /*! Returns the effective output-directory used for outputs at a given simulation-cycle */
   std::string effective_output_dir_path(int nfile) const noexcept;
 
-  /* format the file path */
+  /*! format the file path */
   std::string format_fname(int nfile, const std::string& pre_extension_suffix) const noexcept;
 
   std::string format_fname(int nfile, int file_proc_id, const std::string& pre_extension_suffix) const noexcept;

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -1,3 +1,7 @@
+/*! \file
+ *  \brief Implements logic pertaining to reading and writing data.
+ */
+
 #include <math.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -113,6 +117,11 @@ void Write_Data(Grid3D &G, struct Parameters P, int nfile, const io::WriterManag
   G.Change_Cosmological_Frame_System(false);
 #endif
 
+  // this method call does most of the heavy lifting
+  // -> recall that the writer manager was initialized at startup to manage a variable
+  //    number of output types (e.g. field-dumps, particle-dumps, slices, etc.)
+  // -> in this method call, the writer manager writes zero to all of the registered
+  //    output types based on the value of nfile.
   write_manager.Apply_Writers(G, P, nfile);
 
 #ifdef COSMOLOGY

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -1,3 +1,7 @@
+/*! \file
+ *  \brief Declares logic pertaining to reading and writing data.
+ */
+
 #pragma once
 
 #include <iomanip>
@@ -23,7 +27,13 @@ static inline bool Is_Root_Proc()
 /* Compute stats for a grid. */
 void Print_Stats(Grid3D& G);
 
-/* Write the data */
+/*! Write all data files
+ *
+ *  \param G the grid object
+ *  \param P the parameter struct
+ *  \param nfile the index corresponding to the current output
+ *  \param writer_manager Manages the data writers.
+ */
 void Write_Data(Grid3D& G, struct Parameters P, int nfile, const io::WriterManager& write_manager);
 
 /* Output the grid data to file. */

--- a/src/io/io.h
+++ b/src/io/io.h
@@ -13,16 +13,10 @@
 #include "../io/FnameTemplate.h"
 #include "../io/WriterManager.h"
 
-/* Local function that designates whether we are using a root-process. It gives
- *  * gives a sensible result regardless of whether we are using MPI */
-static inline bool Is_Root_Proc()
-{
-#ifdef MPI_CHOLLA
-  return procID == root;
-#else
-  return true;
-#endif
-}
+/*! Local function that designates whether we are using a root-process. It gives
+ *  a sensible result regardless of whether we are using MPI
+ */
+inline bool Is_Root_Proc() { return procID == root; }
 
 /* Compute stats for a grid. */
 void Print_Stats(Grid3D& G);


### PR DESCRIPTION
This adds some clarifying comments that we discussed last week.

While I was here, I also:
- simplified `Is_Root_Proc` (we don't need the ifdef statement since I introduced a PR a while back in order to define the relevant variables even if we aren't using MPI)
- I also added a few doxygen comments to encourage doxygen to star rendering docstrings for functions declared in `io.h`.
- I fixed a few doxygen comments in `FnameTemplate.h`