### PR TITLE
Mv param-parsing to `FnameTemplate` factory method

### DIFF
--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -149,10 +149,6 @@ bool Old_Style_Parse_Param(const char *name, const char *value, struct Parameter
     // NOLINTNEXTLINE(readability-simplify-boolean-expr)
     CHOLLA_ASSERT((tmp == 0) or (tmp == 1), "output_always must be 1 or 0.");
     parms->output_always = tmp;
-  } else if (strcmp(name, "legacy_flat_outdir") == 0) {
-    int tmp = atoi(value);
-    CHOLLA_ASSERT((tmp == 0) or (tmp == 1), "legacy_flat_outdir must be 1 or 0.");
-    parms->legacy_flat_outdir = tmp;
   } else if (strcmp(name, "n_steps_limit") == 0) {
     parms->n_steps_limit = atof(value);
   } else if (strcmp(name, "xmin") == 0) {
@@ -350,7 +346,6 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
   // stored the values as std::string values)
   Load_String_Param_Into_Char_Buffer(pmap, "init", parms->init, "");
   Load_String_Param_Into_Char_Buffer(pmap, "custom_bcnd", parms->custom_bcnd, "");
-  Load_String_Param_Into_Char_Buffer(pmap, "outdir", parms->outdir, "");
   Load_String_Param_Into_Char_Buffer(pmap, "indir", parms->indir, "");
 
   // in the future, the feedback module will read in its own parameters (the global Parameter struct won't

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -188,7 +188,7 @@ void Init_Global_Parallel_Vars_No_MPI();
  *
  *  \note
  *  Before removing a parameter from this type, check if that parameter is parsed
- *  within \ref Old_Style_Parse_Param. PRs 489, 493, 494, and 495 seek to remove all
+ *  within \ref Old_Style_Parse_Param. PRs 493, 494, and 495 seek to remove all
  *  of the parameters from that function. Thus, you may want to merge in the work from
  *  the branch where the parameter parsing logic has been moved **BEFORE** you start to
  *  relocate logic. (Otherwise, you are going to encounter some merge conflicts)
@@ -224,9 +224,8 @@ struct Parameters {
   Real gamma;
   char init[MAXLEN];
   int nfile;
-  bool output_always      = false;
-  bool legacy_flat_outdir = false;
-  int n_steps_limit       = -1;  // Note that negative values indicate that there is no limit
+  bool output_always = false;
+  int n_steps_limit  = -1;  // Note that negative values indicate that there is no limit
 #ifdef STATIC_GRAV
   int custom_grav = 0;  // flag to set specific static gravity field
 #endif
@@ -251,7 +250,6 @@ struct Parameters {
   int zug_bcnd;
 #endif /*MPI_CHOLLA*/
   char custom_bcnd[MAXLEN];
-  char outdir[MAXLEN];
   char indir[MAXLEN];  // Folder to load Initial conditions from
   Real rho                 = 0;
   Real vx                  = 0;

--- a/src/io/FnameTemplate.h
+++ b/src/io/FnameTemplate.h
@@ -10,6 +10,7 @@
 #include <string_view>
 
 #include "../io/ParameterMap.h"
+#include "../utils/error_handling.h"
 
 /*! Lightweight object designed to centralize the file-naming logic (& any associated configuration).
  *
@@ -48,7 +49,19 @@ class FnameTemplate
   {
   }
 
-  explicit FnameTemplate(const Parameters& P) : FnameTemplate(not P.legacy_flat_outdir, P.outdir) {}
+  static FnameTemplate from_pmap(ParameterMap& pmap)
+  {
+    bool legacy_flat_outdir;
+    int uncoerced = pmap.value_or("legacy_flat_outdir", 0);
+    if (uncoerced == 0) {
+      legacy_flat_outdir = false;
+    } else if (uncoerced == 1) {
+      legacy_flat_outdir = true;
+    } else {
+      CHOLLA_ERROR("legacy_flat_outdir parameter must be 1 or 0.");
+    }
+    return FnameTemplate(not legacy_flat_outdir, pmap.value_or("outdir", ""));
+  }
 
   /*! Specifies whether separate cycles are written to separate directories */
   bool separate_cycle_dirs() const noexcept { return separate_cycle_dirs_; }

--- a/src/io/FnameTemplate.h
+++ b/src/io/FnameTemplate.h
@@ -60,7 +60,7 @@ class FnameTemplate
     } else {
       CHOLLA_ERROR("legacy_flat_outdir parameter must be 1 or 0.");
     }
-    return FnameTemplate(not legacy_flat_outdir, pmap.value_or("outdir", ""));
+    return {not legacy_flat_outdir, pmap.value_or("outdir", "")};
   }
 
   /*! Specifies whether separate cycles are written to separate directories */

--- a/src/io/WriterManager.cpp
+++ b/src/io/WriterManager.cpp
@@ -21,7 +21,7 @@
 #include "../utils/error_handling.h"
 
 io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const FieldInfo& field_info)
-    : fname_template_(P)
+    : fname_template_(FnameTemplate::from_pmap(pmap))
 {
   int ndim;
   if ((P.nx > 1) and (P.ny > 1) and (P.nz > 1)) {


### PR DESCRIPTION
To be reviewed after #496 is merged (I reordered commits after making 496 -- it makes more sense this way)

------

This is pretty self-explanatory. I simply moved the parsing logic for the parameters that initialize `FnameTemplate` into a new factory function