### PR TITLE
Remove final parameters that were parsed with the old style of parsing

### DIFF
--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -136,36 +136,7 @@ void Warn_Unused_Params(ParameterMap &pmap) { pmap.warn_unused_parameters(option
  *
  *  \returns true if the parameter was actually used. false otherwise.
  */
-bool Old_Style_Parse_Param(const char *name, const char *value, struct Parameters *parms)
-{
-  /* Copy into correct entry in parameters struct */
-  if (strcmp(name, "output_always") == 0) {
-    int tmp = atoi(value);
-    // In this case the CHOLLA_ASSERT macro runs into issuse with the readability-simplify-boolean-expr clang-tidy check
-    // due to some weird macro expansion stuff. That check has been disabled here for now but in clang-tidy 18 the
-    // IgnoreMacro option should be used instead.
-    // NOLINTNEXTLINE(readability-simplify-boolean-expr)
-    CHOLLA_ASSERT((tmp == 0) or (tmp == 1), "output_always must be 1 or 0.");
-    parms->output_always = tmp;
-  } else if (strcmp(name, "n_steps_limit") == 0) {
-    parms->n_steps_limit = atof(value);
-#ifdef PARTICLES
-  } else if (strcmp(name, "prng_seed") == 0) {
-    parms->prng_seed = atoi(value);
-#endif  // PARTICLES
-  } else if (strcmp(name, "bc_potential_type") == 0) {
-    parms->bc_potential_type = atoi(value);
-#ifdef SCALAR
-  #ifdef DUST
-  } else if (strcmp(name, "grain_radius") == 0) {
-    parms->grain_radius = atoi(value);
-  #endif
-#endif
-  } else {
-    return false;
-  }
-  return true;
-}
+bool Old_Style_Parse_Param(const char *name, const char *value, struct Parameters *parms) { return false; }
 
 /*! \brief this would be entirely unnecessary if the Parameters struct directly stored a std::string
  */
@@ -326,6 +297,29 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
 #ifdef TILED_INITIAL_CONDITIONS
   parms->tile_length = pmap.value<double>("tile_length");
 #endif  // TILED_INITIAL_CONDITIONS
+
+  // parse some assorted values (we should parse them only where we need them)
+  {
+    int tmp = pmap.value_or("output_always", 0);
+    CHOLLA_ASSERT((tmp == 0) or (tmp == 1), "output_always must be 1 or 0.");
+    parms->output_always = tmp;
+  }
+
+  parms->n_steps_limit = pmap.value_or("n_steps_limit", -1);
+
+#ifdef PARTICLES
+  parms->prng_seed = pmap.value_or("prng_seed", 0);
+#endif  // PARTICLES
+
+#ifdef GRAVITY
+  parms->bc_potential_type = pmap.value<int>("bc_potential_type");
+#endif  // GRAVITY
+
+#if defined(SCALAR) && defined(DUST)
+  // we are assuming that this is an integer for historical consistency... But it sure
+  // seems like this should be a double
+  parms->grain_radius = pmap.value<int>("grain_radius");
+#endif  // defined(SCALAR) && defined(DUST)
 
   // in the future, the feedback module will read in its own parameters (the global Parameter struct won't
   // know anything about it)

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -300,7 +300,6 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
   parms->bc_potential_type = pmap.value_or("bc_potential_type", -1);
 
 #if defined(SCALAR) && defined(DUST)
-  // seems like this should be a double
   parms->grain_radius = pmap.value<double>("grain_radius");
 #endif  // defined(SCALAR) && defined(DUST)
 

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -108,8 +108,6 @@ const std::set<std::string> optionalParams = {"flag_delta",   "ddelta_dt",  "n_d
                                               "Omega_L",      "Omega_R",    "Omega_K", "w0",  "wa", "Init_redshift",
                                               "End_redshift", "tile_length"};  // NOLINT
 
-bool Old_Style_Parse_Param(const char *name, const char *value, struct Parameters *parms);
-
 void Init_Param_Struct_Members(ParameterMap &param, struct Parameters *parms);
 
 void Parse_Params(ParameterMap &pmap, struct Parameters *parms)
@@ -119,24 +117,11 @@ void Parse_Params(ParameterMap &pmap, struct Parameters *parms)
   parms->scale_outputs_file[0] = '\0';
 #endif
 
-  // the plan is eventually replace Old_Style_Parse_Param entirely with
-  // Init_Param_Struct_Members.
-  auto fn = [&](const char *name, const char *value) -> bool { return Old_Style_Parse_Param(name, value, parms); };
-
-  pmap.pass_entries_to_legacy_parse_param(fn);
-
   // the plan is to eventually, use the new parsing functions from Parse_Param like the following
   Init_Param_Struct_Members(pmap, parms);
 }
 
 void Warn_Unused_Params(ParameterMap &pmap) { pmap.warn_unused_parameters(optionalParams); }
-
-/*! \fn void Parse_Param(char *name,char *value, struct Parameters *parms);
- *  \brief Parses and sets a single param based on name and value.
- *
- *  \returns true if the parameter was actually used. false otherwise.
- */
-bool Old_Style_Parse_Param(const char *name, const char *value, struct Parameters *parms) { return false; }
 
 /*! \brief this would be entirely unnecessary if the Parameters struct directly stored a std::string
  */

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -296,9 +296,7 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
   parms->prng_seed = pmap.value_or("prng_seed", 0);
 #endif  // PARTICLES
 
-#ifdef GRAVITY
   parms->bc_potential_type = pmap.value<int>("bc_potential_type");
-#endif  // GRAVITY
 
 #if defined(SCALAR) && defined(DUST)
   // we are assuming that this is an integer for historical consistency... But it sure

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -301,7 +301,7 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
 
 #if defined(SCALAR) && defined(DUST)
   // seems like this should be a double
-  parms->grain_radius = pmap.value<int>("grain_radius");
+  parms->grain_radius = pmap.value<double>("grain_radius");
 #endif  // defined(SCALAR) && defined(DUST)
 
   // in the future, the feedback module will read in its own parameters (the global Parameter struct won't

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -300,7 +300,6 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
   parms->bc_potential_type = pmap.value_or("bc_potential_type", -1);
 
 #if defined(SCALAR) && defined(DUST)
-  // we are assuming that this is an integer for historical consistency... But it sure
   // seems like this should be a double
   parms->grain_radius = pmap.value<int>("grain_radius");
 #endif  // defined(SCALAR) && defined(DUST)

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -296,7 +296,8 @@ void Init_Param_Struct_Members(ParameterMap &pmap, struct Parameters *parms)
   parms->prng_seed = pmap.value_or("prng_seed", 0);
 #endif  // PARTICLES
 
-  parms->bc_potential_type = pmap.value<int>("bc_potential_type");
+  // a negative value means that the parameter wasn't set
+  parms->bc_potential_type = pmap.value_or("bc_potential_type", -1);
 
 #if defined(SCALAR) && defined(DUST)
   // we are assuming that this is an integer for historical consistency... But it sure

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -186,13 +186,6 @@ void Init_Global_Parallel_Vars_No_MPI();
  *  The existence of this type is largely a historical artifact. The plan is to
  *  gradually remove data members from this type.
  *
- *  \note
- *  Before removing a parameter from this type, check if that parameter is parsed
- *  within \ref Old_Style_Parse_Param. PR 495 seeks to remove all
- *  of the parameters from that function. Thus, you may want to merge in the work from
- *  the branch where the parameter parsing logic has been moved **BEFORE** you start to
- *  relocate logic. (Otherwise, you are going to encounter some merge conflicts)
- *
  *  Guidelines for Removing Parameters
  *  ----------------------------------
  *  In the vast majority of cases, a parameter value is temporarily stored here and

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -7,6 +7,7 @@
   #include "../io/io.h"
   #include "../model/disk_galaxy.h"
   #include "../model/potentials.h"
+  #include "../utils/error_handling.h"
 
   #if defined(GRAV_ISOLATED_BOUNDARY_X) || defined(GRAV_ISOLATED_BOUNDARY_Y) || defined(GRAV_ISOLATED_BOUNDARY_Z)
 
@@ -14,6 +15,9 @@ void Grid3D::Compute_Potential_Boundaries_Isolated(int dir, struct Parameters *P
 {
   // Set Isolated Boundaries for the ghost cells.
   int bc_potential_type = P->bc_potential_type;
+  CHOLLA_ASSERT(bc_potential_type >= 0,
+                "bc_potential_type must be set to a non-negative value when simulating "
+                "non-periodic boundaries");
   // bc_potential_type = 0 -> Point mass potential GM/r
   if (dir == 0) {
     Compute_Potential_Isolated_Boundary(0, 0, bc_potential_type);
@@ -249,9 +253,7 @@ void Grid3D::Compute_Potential_Isolated_Boundary(int direction, int side, int bc
           r       = sqrt((pos_x * pos_x) + (pos_y * pos_y));
           pot_val = approx_potential.phi_disk_D3D(r, pos_z);
         } else {
-          chprintf(
-              "ERROR: Boundary Potential not set, need to set appropriate "
-              "bc_potential_type \n");
+          CHOLLA_ERROR("Invalid bc_potential_type value: %d", bc_potential_type);
         }
 
         pot_boundary[id] = pot_val;

--- a/src/io/ParameterMap.h
+++ b/src/io/ParameterMap.h
@@ -188,20 +188,6 @@ class ParameterMap
   int warn_unused_parameters(const std::set<std::string>& ignore_params, bool abort_on_warning = false,
                              bool suppress_warning_msg = false) const;
 
-  /* This is a temporary function to help ease the transition to the new parsing approach. */
-  template <typename LegacyParseParamFn>
-  void pass_entries_to_legacy_parse_param(LegacyParseParamFn& f)
-  {
-    for (auto& kv_pair : entries_) {
-      const char* name  = kv_pair.first.c_str();
-      const char* value = (kv_pair.second).param_str.c_str();
-
-      // pass the parameter name and (unparsed) value to the legacy function. Record if used.
-      bool rslt = f(name, value);
-      if (rslt) (kv_pair.second).accessed = true;
-    }
-  }
-
   /*! Aborts with an error message if one or more of the parameters in the specified table has been used or has not
    *  been used. The precise details depend on the `expect_unused` argument.
    *

--- a/src/system_tests/input_files/tGRAVITYSYSTEMSphericalCollapse_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tGRAVITYSYSTEMSphericalCollapse_CorrectInputExpectCorrectOutput.txt
@@ -32,3 +32,4 @@ zl_bcnd=1
 zu_bcnd=1
 # path to output directory
 outdir=./
+bc_potential_type=0


### PR DESCRIPTION
To be reviewed after #494 has been merged

-------

This gets rid of the final old-style parsing logic. It does a little associated cleanup.