### PR TITLE
Simple housekeeping for `Parameters`

### DIFF
--- a/src/global/global.h
+++ b/src/global/global.h
@@ -181,6 +181,39 @@ extern int root;   /*rank of root process*/
  */
 void Init_Global_Parallel_Vars_No_MPI();
 
+/*! A collection of assorted parameter values.
+ *
+ *  The existence of this type is largely a historical artifact. The plan is to
+ *  gradually remove data members from this type.
+ *
+ *  \note
+ *  Before removing a parameter from this type, check if that parameter is parsed
+ *  within \ref Old_Style_Parse_Param. PRs 489, 493, 494, and 495 seek to remove all
+ *  of the parameters from that function. Thus, you may want to merge in the work from
+ *  the branch where the parameter parsing logic has been moved **BEFORE** you start to
+ *  relocate logic. (Otherwise, you are going to encounter some merge conflicts)
+ *
+ *  Guidelines for Removing Parameters
+ *  ----------------------------------
+ *  In the vast majority of cases, a parameter value is temporarily stored here and
+ *  then they are only referenced one subsequent time (while the simulation is being
+ *  initialized).
+ *   - for example, a bunch of parameters are only ever read while initializing
+ *     \ref Cosmology, \ref Gravity, \ref Header, \ref Particles, etc.
+ *   - some parameters, are only read once while setting up initial conditions.
+ *   - in all these cases, we can just read the data directly from \ref ParameterMap
+ *     rather than temporarily storing the values here.
+ *
+ *  When relocating other parameters, be mindful that a single execution of Cholla
+ *  should **NEVER** read a parameter's value from \ref ParameterMap more than once
+ *  - in this scenario, it would be extremely easy for different parts of the code
+ *    to accidentally start using different default values, which would introduce
+ *    lots of hard to debug issues
+ *  - while there are some potential workarounds to this, I think they might
+ *    produce some undesired long-term behavior (plus, they are imperfect)
+ *  - if this situation arises, it's probably a sign that you should make a new struct
+ *    (maybe a "Model" type?) where a value can be persistently stored
+ */
 struct Parameters {
   int nx;
   int ny;

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -364,12 +364,17 @@ struct Parameters {
 
 class ParameterMap;
 
-/*! \brief Reads the from the ParameterMap into the primary Parameters structure.
+/*! \brief Initializes \p parms using values from \p pmap
  *
- *  \note
- *  We opt to pass in an existing ParamterMap (by reference), rather than having this
- *  function return a ParameterMap, so that we can get away with simply forward-declaring
- *  ParameterMap (rather than including the full definition)
+ *  \param[in] pmap The map of all parsed parameters. Reminder: the only reason this
+ *      isn't marked ``const`` is to reflect the fact that the type internally tracks
+ *      each parameter that is accessed.
+ *  \param[out] parms The object being initialized
+ *
+ *  \todo
+ *  This should probably be converted so that it is a constructor of \ref Parameters
+ *  (or we should change the function name), but we are waiting until after PR #495
+ *  to actually do that
  */
 void Parse_Params(ParameterMap &pmap, struct Parameters *parms);
 

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -224,15 +224,9 @@ struct Parameters {
   Real gamma;
   char init[MAXLEN];
   int nfile;
-  int n_hydro              = 1;
-  int n_particle           = 1;
-  int n_projection         = 1;
-  int n_rotated_projection = 1;
-  int n_slice              = 1;
-  int n_out_float32        = 0;
-  bool output_always       = false;
-  bool legacy_flat_outdir  = false;
-  int n_steps_limit        = -1;  // Note that negative values indicate that there is no limit
+  bool output_always      = false;
+  bool legacy_flat_outdir = false;
+  int n_steps_limit       = -1;  // Note that negative values indicate that there is no limit
 #ifdef STATIC_GRAV
   int custom_grav = 0;  // flag to set specific static gravity field
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,6 @@ int main(int argc, char *argv[])
 
   // input parameter variables
   char *param_file;
-  struct Parameters P;
   int nfile    = 0;  // number of output files
   Real outtime = 0;  // current output time
 
@@ -81,9 +80,16 @@ int main(int argc, char *argv[])
   // read in contents from the parameter file
   ParameterMap pmap(param_file, argc, argv);
 
-  // use this parameter information to populate the Parameter object
+  // create P, a `Parameters` instance, & initialize it with information from pmap
+  // - `Parameters` is a legacy type that we're phasing out (see docstring for details)
+  // - a highlevel description of the legacy/modern control flows:
+  //   -> legacy: parameter vals are copied from pmap into P, and subsequent code
+  //              initializes the simulation using parameter values from P
+  //   -> modern: code initializes the simulation by getting values directly from pmap
+  Parameters P;
   Parse_Params(pmap, &P);
-  // and output to screen
+
+  // write a description of simulation configuration to console
   chprintf("Git Commit Hash = %s\n", GIT_HASH);
   chprintf("Macro Flags     = %s\n", MACRO_FLAGS);
   chprintf(


### PR DESCRIPTION
This does some basic house-keeping for the `Parameters` struct.

Essentially, this PR:
- adds a docstring to `Parameters` (explaining how its being phased out)
- brings the docstring up to date for `Parse_Params`
- adds an explanatory comment when we call `Parse_Params`
- deletes some unused parameters from `Parameters`
  - These include `n_hydro`, `n_particle`, `n_projection`, ...
  - essentially, I had forgotten to modify the `Parameters` struct each time I started directly reading these values from `pmap` within the constructor of `WriterManager`.