### PR TITLE
Fix unused variable warnings

### DIFF
--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -386,6 +386,7 @@ __global__ void Update_Conserved_Variables_3D_half(Real *dev_conserved, Real *de
   Real dtody  = dt / dy;
   Real dtodz  = dt / dz;
   int n_cells = nx * ny * nz;
+  (void)n_cells; // Suppress spurious unused variable warning
 
   // get a global thread ID
   int tid = threadIdx.x + blockIdx.x * blockDim.x;

--- a/src/integrators/VL_3D_cuda.cu
+++ b/src/integrators/VL_3D_cuda.cu
@@ -44,13 +44,14 @@ void VL_Algorithm_3D_CUDA(Real *d_conserved, Real *d_grav_potential, int nx, int
   // concatenated into a 1-d array
 
   int n_cells = nx * ny * nz;
-  int ngrid   = (n_cells + TPB - 1) / TPB;
 
-  // set values for GPU kernels
+#ifdef PCM
+  int ngrid   = (n_cells + TPB - 1) / TPB;
   // number of blocks per 1D grid
   dim3 dim1dGrid(ngrid, 1, 1);
   //  number of threads per 1D block
   dim3 dim1dBlock(TPB, 1, 1);
+#endif
 
   // host_grav_potential is NULL if not using GRAVITY
   temp_potential = host_grav_potential;


### PR DESCRIPTION
Fix build warnings due to unused variables in CUDA kernels.

- Conditionally compile PCM-related launch configuration variables
- Resolve unused variable warning for n_cells under specific build paths

No functional changes.