### PR TITLE
`Grav3D` use `SpatialDomainProps`

### DIFF
--- a/src/cooling_grackle/cool_grackle.cpp
+++ b/src/cooling_grackle/cool_grackle.cpp
@@ -113,9 +113,9 @@ void Cool_GK::Initialize(struct Parameters *P, Cosmology &Cosmo)
 void Grid3D::Allocate_Memory_Grackle()
 {
   int n_cells = H.nx * H.ny * H.nz;
-  int nx      = Grav.nx_local;
-  int ny      = Grav.ny_local;
-  int nz      = Grav.nz_local;
+  int nx      = Grav.spatial_props.nx_local;
+  int ny      = Grav.spatial_props.ny_local;
+  int nz      = Grav.spatial_props.nz_local;
   // Set grid dimension and size.
   Cool.field_size               = n_cells;
   Cool.fields.grid_rank         = 3;

--- a/src/gravity/grav3D.cpp
+++ b/src/gravity/grav3D.cpp
@@ -16,23 +16,16 @@
 
 Grav3D::Grav3D(void) {}
 
-void Grav3D::Initialize(const SpatialDomainProps &spatial_props, Real Lx, Real Ly, Real Lz, int n_ghost_pot_offset,
-                        Parameters *P)
+void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real Lx, Real Ly, Real Lz,
+                        int n_ghost_pot_offset, Parameters *P)
 {
   // Set Box Size
   Lbox_x = Lx;
   Lbox_y = Ly;
   Lbox_z = Lz;
 
-  // Set Box Left boundary positions
-  xMin = spatial_props.xMin;
-  yMin = spatial_props.yMin;
-  zMin = spatial_props.zMin;
-
-  // Set Box Right boundary positions
-  xMax = spatial_props.xMax;
-  yMax = spatial_props.yMax;
-  zMax = spatial_props.zMax;
+  // store a copy of the spatial properties
+  spatial_props = external_spatial_props;
 
   // Set uniform ( dx, dy, dz )
   dx = spatial_props.dx;
@@ -107,11 +100,11 @@ void Grav3D::Initialize(const SpatialDomainProps &spatial_props, Real Lx, Real L
   chprintf("  N OMP Threads per MPI process: %d\n", N_OMP_THREADS);
   #endif
 
-  Poisson_solver.Initialize(Lbox_x, Lbox_y, Lbox_z, xMin, yMin, zMin, nx_total, ny_total, nz_total, nx_local, ny_local,
-                            nz_local, dx, dy, dz);
+  Poisson_solver.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
+                            nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, dx, dy, dz);
   #if defined(PARIS_TEST) || defined(PARIS_GALACTIC_TEST)
-  Poisson_solver_test.Initialize(Lbox_x, Lbox_y, Lbox_z, xMin, yMin, zMin, nx_total, ny_total, nz_total, nx_local,
-                                 ny_local, nz_local, dx, dy, dz);
+  Poisson_solver_test.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
+                                 nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, dx, dy, dz);
   #endif
 
   // At the end of initializing, set restart state if needed

--- a/src/gravity/grav3D.cpp
+++ b/src/gravity/grav3D.cpp
@@ -27,11 +27,6 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   // store a copy of the spatial properties
   spatial_props = external_spatial_props;
 
-  // Set Box Total number of cells
-  nx_total = spatial_props.nx_total;
-  ny_total = spatial_props.ny_total;
-  nz_total = spatial_props.nz_total;
-
   // Set Box local domain number of cells
   nx_local = spatial_props.nx_local;
   ny_local = spatial_props.ny_local;
@@ -82,7 +77,8 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   chprintf(
       "Gravity Initialized: \n Lbox: %0.2f %0.2f %0.2f \n Local: %d %d %d \n "
       "Global: %d %d %d \n",
-      Lbox_x, Lbox_y, Lbox_z, nx_local, ny_local, nz_local, nx_total, ny_total, nz_total);
+      Lbox_x, Lbox_y, Lbox_z, nx_local, ny_local, nz_local, spatial_props.nx_total, spatial_props.ny_total,
+      spatial_props.nz_total);
 
   chprintf(" dx:%f  dy:%f  dz:%f\n", spatial_props.dx, spatial_props.dy, spatial_props.dz);
   chprintf(" N ghost potential: %d\n", N_GHOST_POTENTIAL);
@@ -96,12 +92,12 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   #endif
 
   Poisson_solver.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                            nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, spatial_props.dx,
-                            spatial_props.dy, spatial_props.dz);
+                            spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total, nx_local, ny_local,
+                            nz_local, spatial_props.dx, spatial_props.dy, spatial_props.dz);
   #if defined(PARIS_TEST) || defined(PARIS_GALACTIC_TEST)
   Poisson_solver_test.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                                 nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, spatial_props.dx,
-                                 spatial_props.dy, spatial_props.dz);
+                                 spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total, nx_local,
+                                 ny_local, nz_local, spatial_props.dx, spatial_props.dy, spatial_props.dz);
   #endif
 
   // At the end of initializing, set restart state if needed

--- a/src/gravity/grav3D.cpp
+++ b/src/gravity/grav3D.cpp
@@ -27,16 +27,12 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   // store a copy of the spatial properties
   spatial_props = external_spatial_props;
 
-  // Set Box local domain number of cells
-  nx_local = spatial_props.nx_local;
-  ny_local = spatial_props.ny_local;
-  nz_local = spatial_props.nz_local;
-
   // Local n_cells without ghost cells
-  n_cells = nx_local * ny_local * nz_local;
+  n_cells = spatial_props.nx_local * spatial_props.ny_local * spatial_props.nz_local;
   // Local n_cells including ghost cells for the potential array
-  n_cells_potential =
-      (nx_local + 2 * N_GHOST_POTENTIAL) * (ny_local + 2 * N_GHOST_POTENTIAL) * (nz_local + 2 * N_GHOST_POTENTIAL);
+  n_cells_potential = (spatial_props.nx_local + 2 * N_GHOST_POTENTIAL) *
+                      (spatial_props.ny_local + 2 * N_GHOST_POTENTIAL) *
+                      (spatial_props.nz_local + 2 * N_GHOST_POTENTIAL);
 
   // Set Initial and dt used for the extrapolation of the potential;
   // The first timestep the potential in not extrapolated ( INITIAL = TRUE )
@@ -77,8 +73,8 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   chprintf(
       "Gravity Initialized: \n Lbox: %0.2f %0.2f %0.2f \n Local: %d %d %d \n "
       "Global: %d %d %d \n",
-      Lbox_x, Lbox_y, Lbox_z, nx_local, ny_local, nz_local, spatial_props.nx_total, spatial_props.ny_total,
-      spatial_props.nz_total);
+      Lbox_x, Lbox_y, Lbox_z, spatial_props.nx_local, spatial_props.ny_local, spatial_props.nz_local,
+      spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total);
 
   chprintf(" dx:%f  dy:%f  dz:%f\n", spatial_props.dx, spatial_props.dy, spatial_props.dz);
   chprintf(" N ghost potential: %d\n", N_GHOST_POTENTIAL);
@@ -92,12 +88,14 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   #endif
 
   Poisson_solver.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                            spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total, nx_local, ny_local,
-                            nz_local, spatial_props.dx, spatial_props.dy, spatial_props.dz);
+                            spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total,
+                            spatial_props.nx_local, spatial_props.ny_local, spatial_props.nz_local, spatial_props.dx,
+                            spatial_props.dy, spatial_props.dz);
   #if defined(PARIS_TEST) || defined(PARIS_GALACTIC_TEST)
   Poisson_solver_test.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                                 spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total, nx_local,
-                                 ny_local, nz_local, spatial_props.dx, spatial_props.dy, spatial_props.dz);
+                                 spatial_props.nx_total, spatial_props.ny_total, spatial_props.nz_total,
+                                 spatial_props.nx_local, spatial_props.ny_local, spatial_props.nz_local,
+                                 spatial_props.dx, spatial_props.dy, spatial_props.dz);
   #endif
 
   // At the end of initializing, set restart state if needed
@@ -118,19 +116,22 @@ void Grav3D::AllocateMemory_CPU(void)
   boundary_flags = (int *)malloc(6 * sizeof(int));       // array for the gravity boundary flags
 
   #ifdef GRAV_ISOLATED_BOUNDARY_X
-  F.pot_boundary_x0 = (Real *)malloc(N_GHOST_POTENTIAL * ny_local * nz_local *
+  F.pot_boundary_x0 = (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.ny_local * spatial_props.nz_local *
                                      sizeof(Real));  // array for the potential isolated boundary
-  F.pot_boundary_x1 = (Real *)malloc(N_GHOST_POTENTIAL * ny_local * nz_local * sizeof(Real));
+  F.pot_boundary_x1 =
+      (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.ny_local * spatial_props.nz_local * sizeof(Real));
   #endif
   #ifdef GRAV_ISOLATED_BOUNDARY_Y
-  F.pot_boundary_y0 = (Real *)malloc(N_GHOST_POTENTIAL * nx_local * nz_local *
+  F.pot_boundary_y0 = (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.nx_local * spatial_props.nz_local *
                                      sizeof(Real));  // array for the potential isolated boundary
-  F.pot_boundary_y1 = (Real *)malloc(N_GHOST_POTENTIAL * nx_local * nz_local * sizeof(Real));
+  F.pot_boundary_y1 =
+      (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.nx_local * spatial_props.nz_local * sizeof(Real));
   #endif
   #ifdef GRAV_ISOLATED_BOUNDARY_Z
-  F.pot_boundary_z0 = (Real *)malloc(N_GHOST_POTENTIAL * nx_local * ny_local *
+  F.pot_boundary_z0 = (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.nx_local * spatial_props.ny_local *
                                      sizeof(Real));  // array for the potential isolated boundary
-  F.pot_boundary_z1 = (Real *)malloc(N_GHOST_POTENTIAL * nx_local * ny_local * sizeof(Real));
+  F.pot_boundary_z1 =
+      (Real *)malloc(N_GHOST_POTENTIAL * spatial_props.nx_local * spatial_props.ny_local * sizeof(Real));
   #endif
 
   #ifdef GRAVITY_ANALYTIC_COMP

--- a/src/gravity/grav3D.cpp
+++ b/src/gravity/grav3D.cpp
@@ -27,11 +27,6 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   // store a copy of the spatial properties
   spatial_props = external_spatial_props;
 
-  // Set uniform ( dx, dy, dz )
-  dx = spatial_props.dx;
-  dy = spatial_props.dy;
-  dz = spatial_props.dz;
-
   // Set Box Total number of cells
   nx_total = spatial_props.nx_total;
   ny_total = spatial_props.ny_total;
@@ -89,7 +84,7 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
       "Global: %d %d %d \n",
       Lbox_x, Lbox_y, Lbox_z, nx_local, ny_local, nz_local, nx_total, ny_total, nz_total);
 
-  chprintf(" dx:%f  dy:%f  dz:%f\n", dx, dy, dz);
+  chprintf(" dx:%f  dy:%f  dz:%f\n", spatial_props.dx, spatial_props.dy, spatial_props.dz);
   chprintf(" N ghost potential: %d\n", N_GHOST_POTENTIAL);
   chprintf(" N ghost offset: %d\n", n_ghost_pot_offset);
 
@@ -101,10 +96,12 @@ void Grav3D::Initialize(const SpatialDomainProps &external_spatial_props, Real L
   #endif
 
   Poisson_solver.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                            nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, dx, dy, dz);
+                            nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, spatial_props.dx,
+                            spatial_props.dy, spatial_props.dz);
   #if defined(PARIS_TEST) || defined(PARIS_GALACTIC_TEST)
   Poisson_solver_test.Initialize(Lbox_x, Lbox_y, Lbox_z, spatial_props.xMin, spatial_props.yMin, spatial_props.zMin,
-                                 nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, dx, dy, dz);
+                                 nx_total, ny_total, nz_total, nx_local, ny_local, nz_local, spatial_props.dx,
+                                 spatial_props.dy, spatial_props.dz);
   #endif
 
   // At the end of initializing, set restart state if needed

--- a/src/gravity/grav3D.h
+++ b/src/gravity/grav3D.h
@@ -44,16 +44,6 @@ class Grav3D
   /// Aggregates spatial properties
   SpatialDomainProps spatial_props;
 
-  /*! \var nx_local
-   *  \brief Local number of cells in the x-dimension */
-  int nx_local;
-  /*! \var ny_local
-   *  \brief Local number of cells in the y-dimension */
-  int ny_local;
-  /*! \var nz_local
-   *  \brief Local number of cells in the z-dimension */
-  int nz_local;
-
 #ifdef COSMOLOGY
   Real current_a;
 #endif

--- a/src/gravity/grav3D.h
+++ b/src/gravity/grav3D.h
@@ -41,12 +41,9 @@ class Grav3D
   Real Lbox_y;
   Real Lbox_z;
 
-  Real xMin;
-  Real yMin;
-  Real zMin;
-  Real xMax;
-  Real yMax;
-  Real zMax;
+  /// Aggregates spatial properties
+  SpatialDomainProps spatial_props;
+
   /*! \var nx
    *  \brief Total number of cells in the x-dimension */
   int nx_total;
@@ -189,13 +186,15 @@ class Grav3D
 
   } F;
 
-  /*! \fn Grav3D(void)
-   *  \brief Constructor for the gravity class */
+  /*! \brief Constructor for the gravity class
+   *
+   *  The constructed object is **NOT** in a valid state. You must call @ref Initialize
+   *  before you try to use it. (Ideally, we will fix this in the future).
+   */
   Grav3D(void);
 
-  /*! \fn void Initialize(int nx_in, int ny_in, int nz_in)
-   *  \brief Initialize the grid. */
-  void Initialize(const SpatialDomainProps &spatial_props, Real Lx, Real Ly, Real Lz, int n_ghost_pot_offset,
+  /*! \brief Initialize the gravity object. */
+  void Initialize(const SpatialDomainProps &external_spatial_props, Real Lx, Real Ly, Real Lz, int n_ghost_pot_offset,
                   Parameters *P);
 
   void AllocateMemory_CPU(void);

--- a/src/gravity/grav3D.h
+++ b/src/gravity/grav3D.h
@@ -44,16 +44,6 @@ class Grav3D
   /// Aggregates spatial properties
   SpatialDomainProps spatial_props;
 
-  /*! \var nx
-   *  \brief Total number of cells in the x-dimension */
-  int nx_total;
-  /*! \var ny
-   *  \brief Total number of cells in the y-dimension */
-  int ny_total;
-  /*! \var nz
-   *  \brief Total number of cells in the z-dimension */
-  int nz_total;
-
   /*! \var nx_local
    *  \brief Local number of cells in the x-dimension */
   int nx_local;

--- a/src/gravity/grav3D.h
+++ b/src/gravity/grav3D.h
@@ -64,16 +64,6 @@ class Grav3D
    *  \brief Local number of cells in the z-dimension */
   int nz_local;
 
-  /*! \var dx
-   *  \brief x-width of cells */
-  Real dx;
-  /*! \var dy
-   *  \brief y-width of cells */
-  Real dy;
-  /*! \var dz
-   *  \brief z-width of cells */
-  Real dz;
-
 #ifdef COSMOLOGY
   Real current_a;
 #endif

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -1,15 +1,16 @@
+#include <cmath>
+#include <utility>
+
+#include "../gravity/grav3D.h"
+#include "../grid/grid3D.h"
+#include "../io/io.h"
+#include "../model/galaxy/disk_galaxy.h"
+#include "../model/galaxy/potentials.h"
+#include "../model/model_collection.h"
+#include "../utils/error_handling.h"
+#include "cholla_config.h"
+
 #ifdef GRAVITY
-
-  #include <cmath>
-  #include <utility>
-
-  #include "../gravity/grav3D.h"
-  #include "../grid/grid3D.h"
-  #include "../io/io.h"
-  #include "../model/galaxy/disk_galaxy.h"
-  #include "../model/galaxy/potentials.h"
-  #include "../model/model_collection.h"
-  #include "../utils/error_handling.h"
 
 /*! \brief aggregates properties of the buffer for boundary vals of the potential
  *

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -177,29 +177,29 @@ static void Compute_Potential_Isolated_Boundary_Helper(Real *pot_boundary, const
         // calculate the position
         Real pos_x, pos_y, pos_z;
         if (direction == 0) {
-          // pos_x = Grav.xMin - ( nGHST + k + 0.5 ) * Grav.dx;
-          pos_x = Grav.xMin + (k + 0.5 - nGHST) * Grav.dx;
+          // pos_x = Grav.spatial_props.xMin - ( nGHST + k + 0.5 ) * Grav.dx;
+          pos_x = Grav.spatial_props.xMin + (k + 0.5 - nGHST) * Grav.dx;
           if (side == 1) {
             pos_x += Lx_local + nGHST * Grav.dx;
           }
-          pos_y = Grav.yMin + (i + 0.5) * Grav.dy;
-          pos_z = Grav.zMin + (j + 0.5) * Grav.dz;
+          pos_y = Grav.spatial_props.yMin + (i + 0.5) * Grav.dy;
+          pos_z = Grav.spatial_props.zMin + (j + 0.5) * Grav.dz;
         } else if (direction == 1) {
-          // pos_y = Grav.yMin - ( nGHST + k + 0.5 ) * Grav.dy;
-          pos_y = Grav.yMin + (k + 0.5 - nGHST) * Grav.dy;
+          // pos_y = Grav.spatial_props.yMin - ( nGHST + k + 0.5 ) * Grav.dy;
+          pos_y = Grav.spatial_props.yMin + (k + 0.5 - nGHST) * Grav.dy;
           if (side == 1) {
             pos_y += Ly_local + nGHST * Grav.dy;
           }
-          pos_x = Grav.xMin + (i + 0.5) * Grav.dx;
-          pos_z = Grav.zMin + (j + 0.5) * Grav.dz;
+          pos_x = Grav.spatial_props.xMin + (i + 0.5) * Grav.dx;
+          pos_z = Grav.spatial_props.zMin + (j + 0.5) * Grav.dz;
         } else {  // (direction == 2)
-          // pos_z = Grav.zMin - ( nGHST + k + 0.5 ) * Grav.dz;
-          pos_z = Grav.zMin + (k + 0.5 - nGHST) * Grav.dz;
+          // pos_z = Grav.spatial_props.zMin - ( nGHST + k + 0.5 ) * Grav.dz;
+          pos_z = Grav.spatial_props.zMin + (k + 0.5 - nGHST) * Grav.dz;
           if (side == 1) {
             pos_z += Lz_local + nGHST * Grav.dz;
           }
-          pos_x = Grav.xMin + (i + 0.5) * Grav.dx;
-          pos_y = Grav.yMin + (j + 0.5) * Grav.dy;
+          pos_x = Grav.spatial_props.xMin + (i + 0.5) * Grav.dx;
+          pos_y = Grav.spatial_props.yMin + (j + 0.5) * Grav.dy;
         }
         pot_boundary[id] = fn(pos_x, pos_y, pos_z);
       }

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -26,23 +26,25 @@ struct BoundaryBufProps {
   CHOLLA_ASSERT(0 <= direction and direction <= 2, "sanity check failed");
   CHOLLA_ASSERT(side == 0 or side == 1, "sanity check failed");
 
+  const SpatialDomainProps &spatial_props = Grav.spatial_props;
+
   int n_i, n_j;
   Real *pot_boundary = nullptr;
   if (direction == 0) {
-    n_i = Grav.ny_local;
-    n_j = Grav.nz_local;
+    n_i = spatial_props.ny_local;
+    n_j = spatial_props.nz_local;
   #ifdef GRAV_ISOLATED_BOUNDARY_X
     pot_boundary = (side == 0) ? Grav.F.pot_boundary_x0 : Grav.F.pot_boundary_x1;
   #endif
   } else if (direction == 1) {
-    n_i = Grav.nx_local;
-    n_j = Grav.nz_local;
+    n_i = spatial_props.nx_local;
+    n_j = spatial_props.nz_local;
   #ifdef GRAV_ISOLATED_BOUNDARY_Y
     pot_boundary = (side == 0) ? Grav.F.pot_boundary_y0 : Grav.F.pot_boundary_y1;
   #endif
   } else {  // direction == 2
-    n_i = Grav.nx_local;
-    n_j = Grav.ny_local;
+    n_i = spatial_props.nx_local;
+    n_j = spatial_props.ny_local;
   #ifdef GRAV_ISOLATED_BOUNDARY_Z
     pot_boundary = (side == 0) ? Grav.F.pot_boundary_z0 : Grav.F.pot_boundary_z1;
   #endif
@@ -89,14 +91,12 @@ void Grid3D::Set_Potential_Boundaries_Isolated(int direction, int side, int *fla
   int n_j                                 = tmp.second.n_j;
   int nGHST                               = tmp.second.nGHST;
 
-  int nx_g, ny_g, nz_g;
-  int nx_local, ny_local, nz_local;
-  nx_g     = Grav.nx_local + 2 * nGHST;
-  ny_g     = Grav.ny_local + 2 * nGHST;
-  nz_g     = Grav.nz_local + 2 * nGHST;
-  nx_local = Grav.nx_local;
-  ny_local = Grav.ny_local;
-  nz_local = Grav.nz_local;
+  int nx_g     = Grav.spatial_props.nx_local + 2 * nGHST;
+  int ny_g     = Grav.spatial_props.ny_local + 2 * nGHST;
+  int nz_g     = Grav.spatial_props.nz_local + 2 * nGHST;
+  int nx_local = Grav.spatial_props.nx_local;
+  int ny_local = Grav.spatial_props.ny_local;
+  int nz_local = Grav.spatial_props.nz_local;
 
   int i, j, k, id_buffer, id_grid;
 
@@ -163,9 +163,9 @@ static void Compute_Potential_Isolated_Boundary_Helper(Real *pot_boundary, const
 {
   const SpatialDomainProps &spatial_props = Grav.spatial_props;
 
-  Real Lx_local = Grav.nx_local * spatial_props.dx;
-  Real Ly_local = Grav.ny_local * spatial_props.dy;
-  Real Lz_local = Grav.nz_local * spatial_props.dz;
+  Real Lx_local = spatial_props.nx_local * spatial_props.dx;
+  Real Ly_local = spatial_props.ny_local * spatial_props.dy;
+  Real Lz_local = spatial_props.nz_local * spatial_props.dz;
 
   int n_i   = boundary_buf_props.n_i;
   int n_j   = boundary_buf_props.n_j;
@@ -282,9 +282,9 @@ void Grid3D::Set_Potential_Boundaries_Periodic(int direction, int side, int *fla
   int i, j, k, indx_src, indx_dst;
   int nGHST, nx_g, ny_g, nz_g;
   nGHST = N_GHOST_POTENTIAL;
-  nx_g  = Grav.nx_local + 2 * nGHST;
-  ny_g  = Grav.ny_local + 2 * nGHST;
-  nz_g  = Grav.nz_local + 2 * nGHST;
+  nx_g  = Grav.spatial_props.nx_local + 2 * nGHST;
+  ny_g  = Grav.spatial_props.ny_local + 2 * nGHST;
+  nz_g  = Grav.spatial_props.nz_local + 2 * nGHST;
 
   // Copy X boundaries
   if (direction == 0) {
@@ -350,9 +350,9 @@ int Grid3D::Load_Gravity_Potential_To_Buffer(int direction, int side, Real *buff
   int i, j, k, indx, indx_buff, length;
   int nGHST, nx_g, ny_g, nz_g;
   nGHST = N_GHOST_POTENTIAL;
-  nx_g  = Grav.nx_local + 2 * nGHST;
-  ny_g  = Grav.ny_local + 2 * nGHST;
-  nz_g  = Grav.nz_local + 2 * nGHST;
+  nx_g  = Grav.spatial_props.nx_local + 2 * nGHST;
+  ny_g  = Grav.spatial_props.ny_local + 2 * nGHST;
+  nz_g  = Grav.spatial_props.nz_local + 2 * nGHST;
 
   // Load X boundaries
   if (direction == 0) {
@@ -418,9 +418,9 @@ void Grid3D::Unload_Gravity_Potential_from_Buffer(int direction, int side, Real 
   int i, j, k, indx, indx_buff;
   int nGHST, nx_g, ny_g, nz_g;
   nGHST = N_GHOST_POTENTIAL;
-  nx_g  = Grav.nx_local + 2 * nGHST;
-  ny_g  = Grav.ny_local + 2 * nGHST;
-  nz_g  = Grav.nz_local + 2 * nGHST;
+  nx_g  = Grav.spatial_props.nx_local + 2 * nGHST;
+  ny_g  = Grav.spatial_props.ny_local + 2 * nGHST;
+  nz_g  = Grav.spatial_props.nz_local + 2 * nGHST;
 
   // Load X boundaries
   if (direction == 0) {

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -11,14 +11,22 @@
   #include "../model/model_collection.h"
   #include "../utils/error_handling.h"
 
-/*! \brief aggregates properties of the buffer for boundary vals of the potential */
+/*! \brief aggregates properties of the buffer for boundary vals of the potential
+ *
+ *  \note It *might* make sense to generalize this for handling other kinds of boundary
+ *  conditions.
+ */
 struct BoundaryBufProps {
   int n_i;
   int n_j;
   int nGHST;
 };
 
-/*! \brief retrieve the boundary_buf for the potential and associated properties */
+/*! \brief retrieve the boundary_buf for the potential and associated properties
+ *
+ *  \note This is labelled maybe_unused since it isn't used unless certain compiler
+ *      macros are configured.
+ */
 [[maybe_unused]] static std::pair<Real *, BoundaryBufProps> Get_Boundary_Buf_(const Grav3D &Grav, int direction,
                                                                               int side)
 {
@@ -141,28 +149,19 @@ void Grid3D::Set_Potential_Boundaries_Isolated(int direction, int side, int *fla
  *
  *  \param[out] pot_boundary the buffer to be filled with the computed potential
  *  \param[in] boundary_buf_props Describes properties of \p pot_boundary
- *  \param[in] Grav Holds information needed to compute the spatial location of each
- *      location.
+ *  \param[in] SpatialDomainProps Holds information needed to compute the spatial
+ *      location of each location.
  *  \param[in] direction Encodes the axis of the boundary
  *  \param[in] side Encodes whether we are consider a left or right boundary
  *  \param[in] fn A function object that effectively has the signature
  *      `Real fn(Real x, Real y, Real z)`. In more detail, it returns the potential
  *      computed at a specified position.
- *
- *  \note
- *  Ideally, we might replace \p Grav with an instance of \ref SpatialDomainProps (or
- *  something similar). This will become in a future planned change that will factor
- *  out this logic and other logic pertaining the estimate for the dynamical potential.
- *  It's also more elegant (i.e. \ref Grav3D contains a lot of superfluous info) and
- *  makes it possible to invoke this logic on GPUs (we would just need to replace the
- *  for-loop with \ref gpuFor)
  */
 template <typename PotentialFn>
 static void Compute_Potential_Isolated_Boundary_Helper(Real *pot_boundary, const BoundaryBufProps &boundary_buf_props,
-                                                       const Grav3D &Grav, int direction, int side, PotentialFn fn)
+                                                       const SpatialDomainProps &spatial_props, int direction, int side,
+                                                       PotentialFn fn)
 {
-  const SpatialDomainProps &spatial_props = Grav.spatial_props;
-
   Real Lx_local = spatial_props.nx_local * spatial_props.dx;
   Real Ly_local = spatial_props.ny_local * spatial_props.dy;
   Real Lz_local = spatial_props.nz_local * spatial_props.dz;
@@ -233,7 +232,8 @@ void Grid3D::Compute_Potential_Isolated_Boundary(int direction, int side, int bc
     };
 
     // now, use the calc_potential function to actually fill the boundaries
-    Compute_Potential_Isolated_Boundary_Helper(pot_boundary, boundary_buf_props, Grav, direction, side, calc_potential);
+    Compute_Potential_Isolated_Boundary_Helper(pot_boundary, boundary_buf_props, Grav.spatial_props, direction, side,
+                                               calc_potential);
   } else if (bc_potential_type == 1) {
     // The underlying assumption of PARIS_GALACTIC is that we have a good analytic
     // approximation the gravitation potential at the boundaries due to the dynamical density
@@ -267,7 +267,8 @@ void Grid3D::Compute_Potential_Isolated_Boundary(int direction, int side, int bc
     };
 
     // now, use the calc_potential function to actually fill the boundaries
-    Compute_Potential_Isolated_Boundary_Helper(pot_boundary, boundary_buf_props, Grav, direction, side, calc_potential);
+    Compute_Potential_Isolated_Boundary_Helper(pot_boundary, boundary_buf_props, Grav.spatial_props, direction, side,
+                                               calc_potential);
   } else {
     CHOLLA_ERROR("Invalid bc_potential_type value: %d", bc_potential_type);
   }

--- a/src/gravity/gravity_boundaries.cu
+++ b/src/gravity/gravity_boundaries.cu
@@ -161,9 +161,11 @@ template <typename PotentialFn>
 static void Compute_Potential_Isolated_Boundary_Helper(Real *pot_boundary, const BoundaryBufProps &boundary_buf_props,
                                                        const Grav3D &Grav, int direction, int side, PotentialFn fn)
 {
-  Real Lx_local = Grav.nx_local * Grav.dx;
-  Real Ly_local = Grav.ny_local * Grav.dy;
-  Real Lz_local = Grav.nz_local * Grav.dz;
+  const SpatialDomainProps &spatial_props = Grav.spatial_props;
+
+  Real Lx_local = Grav.nx_local * spatial_props.dx;
+  Real Ly_local = Grav.ny_local * spatial_props.dy;
+  Real Lz_local = Grav.nz_local * spatial_props.dz;
 
   int n_i   = boundary_buf_props.n_i;
   int n_j   = boundary_buf_props.n_j;
@@ -177,29 +179,29 @@ static void Compute_Potential_Isolated_Boundary_Helper(Real *pot_boundary, const
         // calculate the position
         Real pos_x, pos_y, pos_z;
         if (direction == 0) {
-          // pos_x = Grav.spatial_props.xMin - ( nGHST + k + 0.5 ) * Grav.dx;
-          pos_x = Grav.spatial_props.xMin + (k + 0.5 - nGHST) * Grav.dx;
+          // pos_x = spatial_props.xMin - ( nGHST + k + 0.5 ) * spatial_props.dx;
+          pos_x = spatial_props.xMin + (k + 0.5 - nGHST) * spatial_props.dx;
           if (side == 1) {
-            pos_x += Lx_local + nGHST * Grav.dx;
+            pos_x += Lx_local + nGHST * spatial_props.dx;
           }
-          pos_y = Grav.spatial_props.yMin + (i + 0.5) * Grav.dy;
-          pos_z = Grav.spatial_props.zMin + (j + 0.5) * Grav.dz;
+          pos_y = spatial_props.yMin + (i + 0.5) * spatial_props.dy;
+          pos_z = spatial_props.zMin + (j + 0.5) * spatial_props.dz;
         } else if (direction == 1) {
-          // pos_y = Grav.spatial_props.yMin - ( nGHST + k + 0.5 ) * Grav.dy;
-          pos_y = Grav.spatial_props.yMin + (k + 0.5 - nGHST) * Grav.dy;
+          // pos_y = spatial_props.yMin - ( nGHST + k + 0.5 ) * spatial_props.dy;
+          pos_y = spatial_props.yMin + (k + 0.5 - nGHST) * spatial_props.dy;
           if (side == 1) {
-            pos_y += Ly_local + nGHST * Grav.dy;
+            pos_y += Ly_local + nGHST * spatial_props.dy;
           }
-          pos_x = Grav.spatial_props.xMin + (i + 0.5) * Grav.dx;
-          pos_z = Grav.spatial_props.zMin + (j + 0.5) * Grav.dz;
+          pos_x = spatial_props.xMin + (i + 0.5) * spatial_props.dx;
+          pos_z = spatial_props.zMin + (j + 0.5) * spatial_props.dz;
         } else {  // (direction == 2)
-          // pos_z = Grav.spatial_props.zMin - ( nGHST + k + 0.5 ) * Grav.dz;
-          pos_z = Grav.spatial_props.zMin + (k + 0.5 - nGHST) * Grav.dz;
+          // pos_z = spatial_props.zMin - ( nGHST + k + 0.5 ) * spatial_props.dz;
+          pos_z = spatial_props.zMin + (k + 0.5 - nGHST) * spatial_props.dz;
           if (side == 1) {
-            pos_z += Lz_local + nGHST * Grav.dz;
+            pos_z += Lz_local + nGHST * spatial_props.dz;
           }
-          pos_x = Grav.spatial_props.xMin + (i + 0.5) * Grav.dx;
-          pos_y = Grav.spatial_props.yMin + (j + 0.5) * Grav.dy;
+          pos_x = spatial_props.xMin + (i + 0.5) * spatial_props.dx;
+          pos_y = spatial_props.yMin + (j + 0.5) * spatial_props.dy;
         }
         pot_boundary[id] = fn(pos_x, pos_y, pos_z);
       }

--- a/src/gravity/gravity_boundaries_gpu.cu
+++ b/src/gravity/gravity_boundaries_gpu.cu
@@ -1,11 +1,12 @@
+
+#include <cmath>
+
+#include "../gravity/grav3D.h"
+#include "../grid/grid3D.h"
+#include "../io/io.h"
+#include "cholla_config.h"
+
 #if defined(GRAVITY) && defined(GRAVITY_GPU)
-
-  #include <cmath>
-
-  #include "../gravity/grav3D.h"
-  #include "../grid/grid3D.h"
-  #include "../io/io.h"
-
   #if defined(GRAV_ISOLATED_BOUNDARY_X) || defined(GRAV_ISOLATED_BOUNDARY_Y) || defined(GRAV_ISOLATED_BOUNDARY_Z)
 
 void __global__ Set_Potential_Boundaries_Isolated_kernel(int direction, int side, int size_buffer, int n_i, int n_j,

--- a/src/gravity/gravity_boundaries_gpu.cu
+++ b/src/gravity/gravity_boundaries_gpu.cu
@@ -58,15 +58,15 @@ void Grid3D::Set_Potential_Boundaries_Isolated_GPU(int direction, int side, int 
   int n_i, n_j, n_ghost, size_buffer;
   int nx_g, ny_g, nz_g;
   n_ghost = N_GHOST_POTENTIAL;
-  nx_g    = Grav.nx_local + 2 * n_ghost;
-  ny_g    = Grav.ny_local + 2 * n_ghost;
-  nz_g    = Grav.nz_local + 2 * n_ghost;
+  nx_g    = Grav.spatial_props.nx_local + 2 * n_ghost;
+  ny_g    = Grav.spatial_props.ny_local + 2 * n_ghost;
+  nz_g    = Grav.spatial_props.nz_local + 2 * n_ghost;
 
   Real *pot_boundary_h, *pot_boundary_d;
     #ifdef GRAV_ISOLATED_BOUNDARY_X
   if (direction == 0) {
-    n_i = Grav.ny_local;
-    n_j = Grav.nz_local;
+    n_i = Grav.spatial_props.ny_local;
+    n_j = Grav.spatial_props.nz_local;
     if (side == 0) {
       pot_boundary_h = Grav.F.pot_boundary_x0;
     }
@@ -83,8 +83,8 @@ void Grid3D::Set_Potential_Boundaries_Isolated_GPU(int direction, int side, int 
     #endif
     #ifdef GRAV_ISOLATED_BOUNDARY_Y
   if (direction == 1) {
-    n_i = Grav.nx_local;
-    n_j = Grav.nz_local;
+    n_i = Grav.spatial_props.nx_local;
+    n_j = Grav.spatial_props.nz_local;
     if (side == 0) {
       pot_boundary_h = Grav.F.pot_boundary_y0;
     }
@@ -101,8 +101,8 @@ void Grid3D::Set_Potential_Boundaries_Isolated_GPU(int direction, int side, int 
     #endif
     #ifdef GRAV_ISOLATED_BOUNDARY_Z
   if (direction == 2) {
-    n_i = Grav.nx_local;
-    n_j = Grav.ny_local;
+    n_i = Grav.spatial_props.nx_local;
+    n_j = Grav.spatial_props.ny_local;
     if (side == 0) {
       pot_boundary_h = Grav.F.pot_boundary_z0;
     }
@@ -203,9 +203,9 @@ void Grid3D::Set_Potential_Boundaries_Periodic_GPU(int direction, int side, int 
   int n_i, n_j, n_ghost, size;
   int nx_g, ny_g, nz_g;
   n_ghost = N_GHOST_POTENTIAL;
-  nx_g    = Grav.nx_local + 2 * n_ghost;
-  ny_g    = Grav.ny_local + 2 * n_ghost;
-  nz_g    = Grav.nz_local + 2 * n_ghost;
+  nx_g    = Grav.spatial_props.nx_local + 2 * n_ghost;
+  ny_g    = Grav.spatial_props.ny_local + 2 * n_ghost;
+  nz_g    = Grav.spatial_props.nz_local + 2 * n_ghost;
 
   if (direction == 0) {
     n_i = ny_g;
@@ -285,9 +285,9 @@ int Grid3D::Load_Gravity_Potential_To_Buffer_GPU(int direction, int side, Real *
   ;
   n_ghost_potential = N_GHOST_POTENTIAL;
   n_ghost_transfer  = N_GHOST_POTENTIAL;
-  nx_pot            = Grav.nx_local + 2 * n_ghost_potential;
-  ny_pot            = Grav.ny_local + 2 * n_ghost_potential;
-  nz_pot            = Grav.nz_local + 2 * n_ghost_potential;
+  nx_pot            = Grav.spatial_props.nx_local + 2 * n_ghost_potential;
+  ny_pot            = Grav.spatial_props.ny_local + 2 * n_ghost_potential;
+  nz_pot            = Grav.spatial_props.nz_local + 2 * n_ghost_potential;
 
   if (direction == 0) {
     n_i = ny_pot;
@@ -375,9 +375,9 @@ void Grid3D::Unload_Gravity_Potential_from_Buffer_GPU(int direction, int side, R
   ;
   n_ghost_potential = N_GHOST_POTENTIAL;
   n_ghost_transfer  = N_GHOST_POTENTIAL;
-  nx_pot            = Grav.nx_local + 2 * n_ghost_potential;
-  ny_pot            = Grav.ny_local + 2 * n_ghost_potential;
-  nz_pot            = Grav.nz_local + 2 * n_ghost_potential;
+  nx_pot            = Grav.spatial_props.nx_local + 2 * n_ghost_potential;
+  ny_pot            = Grav.spatial_props.ny_local + 2 * n_ghost_potential;
+  nz_pot            = Grav.spatial_props.nz_local + 2 * n_ghost_potential;
 
   if (direction == 0) {
     n_i = ny_pot;

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -368,9 +368,9 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
   if (P->bc_potential_type == 1) {
     const int ng    = N_GHOST_POTENTIAL;
     const int twoNG = ng + ng;
-    const int nk    = Grav.nz_local + twoNG;
-    const int nj    = Grav.ny_local + twoNG;
-    const int ni    = Grav.nx_local + twoNG;
+    const int nk    = spatial_props.nz_local + twoNG;
+    const int nj    = spatial_props.ny_local + twoNG;
+    const int ni    = spatial_props.nx_local + twoNG;
     const Real dr   = 0.5 - ng;
 
     const ClusteredDiskGalaxy *galaxy_model = models().try_get<ClusteredDiskGalaxy>();
@@ -405,15 +405,15 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
       }
     }
     #pragma omp parallel for
-    for (int k = 0; k < Grav.nz_local; k++) {
+    for (int k = 0; k < spatial_props.nz_local; k++) {
       const Real z  = spatial_props.zMin + spatial_props.dz * (k + 0.5);
       const Real zz = z * z;
-      const int njk = Grav.ny_local * k;
-      for (int j = 0; j < Grav.ny_local; j++) {
+      const int njk = spatial_props.ny_local * k;
+      for (int j = 0; j < spatial_props.ny_local; j++) {
         const Real y   = spatial_props.yMin + spatial_props.dy * (j + 0.5);
         const Real yy  = y * y;
-        const int nijk = Grav.nx_local * (j + njk);
-        for (int i = 0; i < Grav.nx_local; i++) {
+        const int nijk = spatial_props.nx_local * (j + njk);
+        for (int i = 0; i < spatial_props.nx_local; i++) {
           const Real x          = spatial_props.xMin + spatial_props.dx * (i + 0.5);
           const Real r          = sqrt(x * x + yy);
           const int ijk         = i + nijk;
@@ -428,10 +428,12 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     }
     Grav.Poisson_solver_test.Get_Potential(Grav.F.density_h, Grav.F.potential_h, Grav.Gconst, *galaxy_model);
     chprintf(" Paris Galactic");
-    printDiff(Grav.F.potential_h, exact.data(), Grav.nx_local, Grav.ny_local, Grav.nz_local);
+    printDiff(Grav.F.potential_h, exact.data(), Grav.spatial_props.nx_local, Grav.spatial_props.ny_local,
+              Grav.spatial_props.nz_local);
     Get_Potential_SOR(Grav.Gconst, 0, 0, P);
     chprintf(" SOR");
-    printDiff(Grav.F.potential_h, exact.data(), Grav.nx_local, Grav.ny_local, Grav.nz_local);
+    printDiff(Grav.F.potential_h, exact.data(), Grav.spatial_props.nx_local, Grav.spatial_props.ny_local,
+              Grav.spatial_props.nz_local);
   #endif
 
   #ifdef SOR
@@ -553,7 +555,8 @@ void Grid3D::Compute_Gravitational_Potential(struct Parameters *P)
   std::vector<Real> p(output_potential, output_potential + Grav.n_cells_potential);
   Get_Potential_SOR(Grav_Constant, dens_avrg, current_a, P);
   chprintf(" Paris vs SOR");
-  printDiff(p.data(), output_potential, Grav.nx_local, Grav.ny_local, Grav.nz_local, N_GHOST_POTENTIAL, false);
+  printDiff(p.data(), output_potential, Grav.spatial_props.nx_local, Grav.spatial_props.ny_local,
+            Grav.spatial_props.nz_local, N_GHOST_POTENTIAL, false);
     #else
   Get_Potential_SOR(Grav_Constant, dens_avrg, current_a, P);
     #endif
@@ -582,7 +585,7 @@ void Grid3D::Setup_Analytic_Potential(struct Parameters *P)
   CHOLLA_ASSERT(galaxy_model != nullptr, "no galaxy model was initialized");
 
     #ifndef PARALLEL_OMP
-  Setup_Analytic_Galaxy_Potential(0, Grav.nz_local + 2 * N_GHOST_POTENTIAL, *galaxy_model);
+  Setup_Analytic_Galaxy_Potential(0, Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL, *galaxy_model);
     #else
       #pragma omp parallel num_threads(N_OMP_THREADS)
   {
@@ -591,7 +594,7 @@ void Grid3D::Setup_Analytic_Potential(struct Parameters *P)
 
     omp_id      = omp_get_thread_num();
     n_omp_procs = omp_get_num_threads();
-    Get_OMP_Grid_Indxs(Grav.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
+    Get_OMP_Grid_Indxs(Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
 
     Setup_Analytic_Galaxy_Potential(g_start, g_end, *galaxy_model);
   }
@@ -609,7 +612,7 @@ void Grid3D::Add_Analytic_Potential()
   Add_Analytic_Potential_GPU();
     #else
       #ifndef PARALLEL_OMP
-  Add_Analytic_Potential(0, Grav.nz_local + 2 * N_GHOST_POTENTIAL);
+  Add_Analytic_Potential(0, Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL);
       #else
         #pragma omp parallel num_threads(N_OMP_THREADS)
   {
@@ -618,7 +621,7 @@ void Grid3D::Add_Analytic_Potential()
 
     omp_id      = omp_get_thread_num();
     n_omp_procs = omp_get_num_threads();
-    Get_OMP_Grid_Indxs(Grav.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
+    Get_OMP_Grid_Indxs(Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
 
     Add_Analytic_Potential(g_start, g_end);
   }
@@ -634,10 +637,10 @@ void Grid3D::Copy_Hydro_Density_to_Gravity_Function(int g_start, int g_end)
   Real dens;
   int i, j, k, id, id_grav;
   for (k = g_start; k < g_end; k++) {
-    for (j = 0; j < Grav.ny_local; j++) {
-      for (i = 0; i < Grav.nx_local; i++) {
+    for (j = 0; j < Grav.spatial_props.ny_local; j++) {
+      for (i = 0; i < Grav.spatial_props.nx_local; i++) {
         id      = (i + H.n_ghost) + (j + H.n_ghost) * H.nx + (k + H.n_ghost) * H.nx * H.ny;
-        id_grav = (i) + (j)*Grav.nx_local + (k)*Grav.nx_local * Grav.ny_local;
+        id_grav = (i) + (j)*Grav.spatial_props.nx_local + (k)*Grav.spatial_props.nx_local * Grav.spatial_props.ny_local;
 
         dens = C.density[id];
 
@@ -663,7 +666,7 @@ void Grid3D::Copy_Hydro_Density_to_Gravity()
   #else
 
     #ifndef PARALLEL_OMP
-  Copy_Hydro_Density_to_Gravity_Function(0, Grav.nz_local);
+  Copy_Hydro_Density_to_Gravity_Function(0, Grav.spatial_props.nz_local);
     #else
 
       #pragma omp parallel num_threads(N_OMP_THREADS)
@@ -673,7 +676,7 @@ void Grid3D::Copy_Hydro_Density_to_Gravity()
 
     omp_id      = omp_get_thread_num();
     n_omp_procs = omp_get_num_threads();
-    Get_OMP_Grid_Indxs(Grav.nz_local, n_omp_procs, omp_id, &g_start, &g_end);
+    Get_OMP_Grid_Indxs(Grav.spatial_props.nz_local, n_omp_procs, omp_id, &g_start, &g_end);
 
     Copy_Hydro_Density_to_Gravity_Function(g_start, g_end);
   }
@@ -685,9 +688,9 @@ void Grid3D::Copy_Hydro_Density_to_Gravity()
   #ifdef GRAVITY_ANALYTIC_COMP
 void Grid3D::Setup_Analytic_Galaxy_Potential(int g_start, int g_end, const DiskGalaxy &gal)
 {
-  int nx = Grav.nx_local + 2 * N_GHOST_POTENTIAL;
-  int ny = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
-  int nz = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
+  int nx = Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL;
+  int ny = Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL;
+  int nz = Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL;
 
   const SpatialDomainProps &spatial_props = Grav.spatial_props;
 
@@ -713,9 +716,9 @@ void Grid3D::Setup_Analytic_Galaxy_Potential(int g_start, int g_end, const DiskG
  */
 void Grid3D::Add_Analytic_Potential(int g_start, int g_end)
 {
-  int nx = Grav.nx_local + 2 * N_GHOST_POTENTIAL;
-  int ny = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
-  int nz = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
+  int nx = Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL;
+  int ny = Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL;
+  int nz = Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL;
 
   int k, j, i, id;
   Real x_pos, y_pos, z_pos, R;
@@ -735,9 +738,9 @@ void Grid3D::Extrapolate_Grav_Potential_Function(int g_start, int g_end)
 {
   // Use phi_n-1 and phi_n to extrapolate the potential and obtain phi_n+1/2
 
-  int nx_pot = Grav.nx_local + 2 * N_GHOST_POTENTIAL;
-  int ny_pot = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
-  int nz_pot = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
+  int nx_pot = Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL;
+  int ny_pot = Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL;
+  int nz_pot = Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL;
 
   int n_ghost_grid, nx_grid, ny_grid, nz_grid;
   Real *potential_in, *potential_out;
@@ -751,9 +754,9 @@ void Grid3D::Extrapolate_Grav_Potential_Function(int g_start, int g_end)
   n_ghost_grid = H.n_ghost;
 
   // Grid size for the output potential
-  nx_grid = Grav.nx_local + 2 * n_ghost_grid;
-  ny_grid = Grav.ny_local + 2 * n_ghost_grid;
-  nz_grid = Grav.nz_local + 2 * n_ghost_grid;
+  nx_grid = Grav.spatial_props.nx_local + 2 * n_ghost_grid;
+  ny_grid = Grav.spatial_props.ny_local + 2 * n_ghost_grid;
+  nz_grid = Grav.spatial_props.nz_local + 2 * n_ghost_grid;
 
   int nGHST = n_ghost_grid - N_GHOST_POTENTIAL;
   Real pot_now, pot_prev, pot_extrp;
@@ -797,7 +800,7 @@ void Grid3D::Extrapolate_Grav_Potential()
   #else
 
     #ifndef PARALLEL_OMP
-  Extrapolate_Grav_Potential_Function(0, Grav.nz_local + 2 * N_GHOST_POTENTIAL);
+  Extrapolate_Grav_Potential_Function(0, Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL);
     #else
 
       #pragma omp parallel num_threads(N_OMP_THREADS)
@@ -807,7 +810,7 @@ void Grid3D::Extrapolate_Grav_Potential()
 
     omp_id      = omp_get_thread_num();
     n_omp_procs = omp_get_num_threads();
-    Get_OMP_Grid_Indxs(Grav.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
+    Get_OMP_Grid_Indxs(Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL, n_omp_procs, omp_id, &g_start, &g_end);
 
     Extrapolate_Grav_Potential_Function(g_start, g_end);
   }

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -381,23 +381,23 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     std::vector<Real> exact(Grav.n_cells_potential);
     std::vector<Real> potential(Grav.n_cells_potential);
     const Real scale      = 4.0 * M_PI * Grav.Gconst;
-    const Real ddx        = 1.0 / (scale * Grav.dx * Grav.dx);
-    const Real ddy        = 1.0 / (scale * Grav.dy * Grav.dy);
-    const Real ddz        = 1.0 / (scale * Grav.dz * Grav.dz);
+    const Real ddx        = 1.0 / (scale * spatial_props.dx * spatial_props.dx);
+    const Real ddy        = 1.0 / (scale * spatial_props.dy * spatial_props.dy);
+    const Real ddz        = 1.0 / (scale * spatial_props.dz * spatial_props.dz);
     const Real *const phi = Grav.F.potential_h;
     const int nij         = ni * nj;
     const Real a0         = galaxy_model->phi_disk_D3D(0, 0);
     const Real da0        = 2.0 / (25.0 * scale);
     #pragma omp parallel for
     for (int k = 0; k < nk; k++) {
-      const Real z  = spatial_props.zMin + Grav.dz * (k + dr);
+      const Real z  = spatial_props.zMin + spatial_props.dz * (k + dr);
       const int njk = nj * k;
       for (int j = 0; j < nj; j++) {
-        const Real y   = spatial_props.yMin + Grav.dy * (j + dr);
+        const Real y   = spatial_props.yMin + spatial_props.dy * (j + dr);
         const Real yy  = y * y;
         const int nijk = ni * (j + njk);
         for (int i = 0; i < ni; i++) {
-          const Real x  = spatial_props.xMin + Grav.dx * (i + dr);
+          const Real x  = spatial_props.xMin + spatial_props.dx * (i + dr);
           const Real r  = sqrt(x * x + yy);
           const int ijk = i + nijk;
           exact[ijk] = potential[ijk] = Grav.F.potential_h[ijk] = galaxy_model->phi_disk_D3D(r, z);
@@ -406,15 +406,15 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     }
     #pragma omp parallel for
     for (int k = 0; k < Grav.nz_local; k++) {
-      const Real z  = spatial_props.zMin + Grav.dz * (k + 0.5);
+      const Real z  = spatial_props.zMin + spatial_props.dz * (k + 0.5);
       const Real zz = z * z;
       const int njk = Grav.ny_local * k;
       for (int j = 0; j < Grav.ny_local; j++) {
-        const Real y   = spatial_props.yMin + Grav.dy * (j + 0.5);
+        const Real y   = spatial_props.yMin + spatial_props.dy * (j + 0.5);
         const Real yy  = y * y;
         const int nijk = Grav.nx_local * (j + njk);
         for (int i = 0; i < Grav.nx_local; i++) {
-          const Real x          = spatial_props.xMin + Grav.dx * (i + 0.5);
+          const Real x          = spatial_props.xMin + spatial_props.dx * (i + 0.5);
           const Real r          = sqrt(x * x + yy);
           const int ijk         = i + nijk;
           const Real rr         = x * x + yy + zz;
@@ -438,14 +438,14 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     chprintf(" Initializing disk analytic potential\n");
     #pragma omp parallel for
     for (int k = 0; k < nk; k++) {
-      const Real z  = spatial_props.zMin + Grav.dz * (k + dr);
+      const Real z  = spatial_props.zMin + spatial_props.dz * (k + dr);
       const int njk = nj * k;
       for (int j = 0; j < nj; j++) {
-        const Real y   = spatial_props.yMin + Grav.dy * (j + dr);
+        const Real y   = spatial_props.yMin + spatial_props.dy * (j + dr);
         const Real yy  = y * y;
         const int nijk = ni * (j + njk);
         for (int i = 0; i < ni; i++) {
-          const Real x            = spatial_props.xMin + Grav.dx * (i + dr);
+          const Real x            = spatial_props.xMin + spatial_props.dx * (i + dr);
           const Real r            = sqrt(x * x + yy);
           const int ijk           = i + nijk;
           Grav.F.potential_h[ijk] = galaxy_model->phi_disk_D3D(r, z);
@@ -696,11 +696,11 @@ void Grid3D::Setup_Analytic_Galaxy_Potential(int g_start, int g_end, const DiskG
   for (k = g_start; k < g_end; k++) {
     for (j = 0; j < ny; j++) {
       for (i = 0; i < nx; i++) {
-        id                              = i + j * nx + k * nx * ny;
-        x_pos                           = spatial_props.xMin + Grav.dx * (i - N_GHOST_POTENTIAL) + 0.5 * Grav.dx;
-        y_pos                           = spatial_props.yMin + Grav.dy * (j - N_GHOST_POTENTIAL) + 0.5 * Grav.dy;
-        z_pos                           = spatial_props.zMin + Grav.dz * (k - N_GHOST_POTENTIAL) + 0.5 * Grav.dz;
-        R                               = sqrt(x_pos * x_pos + y_pos * y_pos);
+        id    = i + j * nx + k * nx * ny;
+        x_pos = spatial_props.xMin + spatial_props.dx * (i - N_GHOST_POTENTIAL) + 0.5 * spatial_props.dx;
+        y_pos = spatial_props.yMin + spatial_props.dy * (j - N_GHOST_POTENTIAL) + 0.5 * spatial_props.dy;
+        z_pos = spatial_props.zMin + spatial_props.dz * (k - N_GHOST_POTENTIAL) + 0.5 * spatial_props.dz;
+        R     = sqrt(x_pos * x_pos + y_pos * y_pos);
         Grav.F.analytic_potential_h[id] = gal.phi_disk_D3D(R, z_pos) + gal.phi_halo_D3D(R, z_pos);
       }
     }

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -390,14 +390,14 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     const Real da0        = 2.0 / (25.0 * scale);
     #pragma omp parallel for
     for (int k = 0; k < nk; k++) {
-      const Real z  = Grav.zMin + Grav.dz * (k + dr);
+      const Real z  = spatial_props.zMin + Grav.dz * (k + dr);
       const int njk = nj * k;
       for (int j = 0; j < nj; j++) {
-        const Real y   = Grav.yMin + Grav.dy * (j + dr);
+        const Real y   = spatial_props.yMin + Grav.dy * (j + dr);
         const Real yy  = y * y;
         const int nijk = ni * (j + njk);
         for (int i = 0; i < ni; i++) {
-          const Real x  = Grav.xMin + Grav.dx * (i + dr);
+          const Real x  = spatial_props.xMin + Grav.dx * (i + dr);
           const Real r  = sqrt(x * x + yy);
           const int ijk = i + nijk;
           exact[ijk] = potential[ijk] = Grav.F.potential_h[ijk] = galaxy_model->phi_disk_D3D(r, z);
@@ -406,15 +406,15 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     }
     #pragma omp parallel for
     for (int k = 0; k < Grav.nz_local; k++) {
-      const Real z  = Grav.zMin + Grav.dz * (k + 0.5);
+      const Real z  = spatial_props.zMin + Grav.dz * (k + 0.5);
       const Real zz = z * z;
       const int njk = Grav.ny_local * k;
       for (int j = 0; j < Grav.ny_local; j++) {
-        const Real y   = Grav.yMin + Grav.dy * (j + 0.5);
+        const Real y   = spatial_props.yMin + Grav.dy * (j + 0.5);
         const Real yy  = y * y;
         const int nijk = Grav.nx_local * (j + njk);
         for (int i = 0; i < Grav.nx_local; i++) {
-          const Real x          = Grav.xMin + Grav.dx * (i + 0.5);
+          const Real x          = spatial_props.xMin + Grav.dx * (i + 0.5);
           const Real r          = sqrt(x * x + yy);
           const int ijk         = i + nijk;
           const Real rr         = x * x + yy + zz;
@@ -438,14 +438,14 @@ void Grid3D::Initialize_Gravity(struct Parameters *P)
     chprintf(" Initializing disk analytic potential\n");
     #pragma omp parallel for
     for (int k = 0; k < nk; k++) {
-      const Real z  = Grav.zMin + Grav.dz * (k + dr);
+      const Real z  = spatial_props.zMin + Grav.dz * (k + dr);
       const int njk = nj * k;
       for (int j = 0; j < nj; j++) {
-        const Real y   = Grav.yMin + Grav.dy * (j + dr);
+        const Real y   = spatial_props.yMin + Grav.dy * (j + dr);
         const Real yy  = y * y;
         const int nijk = ni * (j + njk);
         for (int i = 0; i < ni; i++) {
-          const Real x            = Grav.xMin + Grav.dx * (i + dr);
+          const Real x            = spatial_props.xMin + Grav.dx * (i + dr);
           const Real r            = sqrt(x * x + yy);
           const int ijk           = i + nijk;
           Grav.F.potential_h[ijk] = galaxy_model->phi_disk_D3D(r, z);
@@ -689,15 +689,17 @@ void Grid3D::Setup_Analytic_Galaxy_Potential(int g_start, int g_end, const DiskG
   int ny = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
   int nz = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
 
+  const SpatialDomainProps &spatial_props = Grav.spatial_props;
+
   int k, j, i, id;
   Real x_pos, y_pos, z_pos, R;
   for (k = g_start; k < g_end; k++) {
     for (j = 0; j < ny; j++) {
       for (i = 0; i < nx; i++) {
         id                              = i + j * nx + k * nx * ny;
-        x_pos                           = Grav.xMin + Grav.dx * (i - N_GHOST_POTENTIAL) + 0.5 * Grav.dx;
-        y_pos                           = Grav.yMin + Grav.dy * (j - N_GHOST_POTENTIAL) + 0.5 * Grav.dy;
-        z_pos                           = Grav.zMin + Grav.dz * (k - N_GHOST_POTENTIAL) + 0.5 * Grav.dz;
+        x_pos                           = spatial_props.xMin + Grav.dx * (i - N_GHOST_POTENTIAL) + 0.5 * Grav.dx;
+        y_pos                           = spatial_props.yMin + Grav.dy * (j - N_GHOST_POTENTIAL) + 0.5 * Grav.dy;
+        z_pos                           = spatial_props.zMin + Grav.dz * (k - N_GHOST_POTENTIAL) + 0.5 * Grav.dz;
         R                               = sqrt(x_pos * x_pos + y_pos * y_pos);
         Grav.F.analytic_potential_h[id] = gal.phi_disk_D3D(R, z_pos) + gal.phi_halo_D3D(R, z_pos);
       }

--- a/src/gravity/gravity_functions_gpu.cu
+++ b/src/gravity/gravity_functions_gpu.cu
@@ -107,9 +107,9 @@ void __global__ Copy_Hydro_Density_to_Gravity_Kernel(Real *src_density_d, Real *
 void Grid3D::Copy_Hydro_Density_to_Gravity_GPU()
 {
   int nx_local, ny_local, nz_local, n_ghost;
-  nx_local = Grav.nx_local;
-  ny_local = Grav.ny_local;
-  nz_local = Grav.nz_local;
+  nx_local = Grav.spatial_props.nx_local;
+  ny_local = Grav.spatial_props.ny_local;
+  nz_local = Grav.spatial_props.nz_local;
   n_ghost  = H.n_ghost;
 
   // set values for GPU kernels
@@ -164,9 +164,9 @@ void __global__ Add_Analytic_Potential_Kernel(Real *analytic_d, Real *potential_
 void Grid3D::Add_Analytic_Potential_GPU()
 {
   int nx_pot, ny_pot, nz_pot;
-  nx_pot = Grav.nx_local + 2 * N_GHOST_POTENTIAL;
-  ny_pot = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
-  nz_pot = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
+  nx_pot = Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL;
+  ny_pot = Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL;
+  nz_pot = Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL;
 
   // set values for GPU kernels
   int tpb_x = TPBX_GRAV;
@@ -244,15 +244,15 @@ void __global__ Extrapolate_Grav_Potential_Kernel(Real *dst_potential, Real *src
 void Grid3D::Extrapolate_Grav_Potential_GPU()
 {
   int nx_pot, ny_pot, nz_pot;
-  nx_pot = Grav.nx_local + 2 * N_GHOST_POTENTIAL;
-  ny_pot = Grav.ny_local + 2 * N_GHOST_POTENTIAL;
-  nz_pot = Grav.nz_local + 2 * N_GHOST_POTENTIAL;
+  nx_pot = Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL;
+  ny_pot = Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL;
+  nz_pot = Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL;
 
   int n_ghost_grid, nx_grid, ny_grid, nz_grid;
   n_ghost_grid = H.n_ghost;
-  nx_grid      = Grav.nx_local + 2 * n_ghost_grid;
-  ny_grid      = Grav.ny_local + 2 * n_ghost_grid;
-  nz_grid      = Grav.nz_local + 2 * n_ghost_grid;
+  nx_grid      = Grav.spatial_props.nx_local + 2 * n_ghost_grid;
+  ny_grid      = Grav.spatial_props.ny_local + 2 * n_ghost_grid;
+  nz_grid      = Grav.spatial_props.nz_local + 2 * n_ghost_grid;
 
   int n_offset = n_ghost_grid - N_GHOST_POTENTIAL;
 

--- a/src/grid/spatial_domain_props.cpp
+++ b/src/grid/spatial_domain_props.cpp
@@ -3,34 +3,7 @@
 #include "../gravity/grav3D.h"
 #include "../grid/grid3D.h"
 
-SpatialDomainProps SpatialDomainProps::From_Grav3D(Grav3D& grav)
-{
-  SpatialDomainProps out;
-
-  out.nx_local = grav.nx_local;
-  out.ny_local = grav.ny_local;
-  out.nz_local = grav.nz_local;
-
-  out.nx_total = grav.nx_total;
-  out.ny_total = grav.ny_total;
-  out.nz_total = grav.nz_total;
-
-  out.dx = grav.dx;
-  out.dy = grav.dy;
-  out.dz = grav.dz;
-
-  // Left boundaries of the local domain
-  out.xMin = grav.xMin;
-  out.yMin = grav.yMin;
-  out.zMin = grav.zMin;
-
-  // Right boundaries of the local domain
-  out.xMax = grav.xMax;
-  out.yMax = grav.yMax;
-  out.zMax = grav.zMax;
-
-  return out;
-}
+SpatialDomainProps SpatialDomainProps::From_Grav3D(Grav3D& grav) { return grav.spatial_props; }
 
 SpatialDomainProps SpatialDomainProps::From_Grid3D(Grid3D& grid, struct Parameters* P)
 {

--- a/src/grid/spatial_domain_props.cpp
+++ b/src/grid/spatial_domain_props.cpp
@@ -3,8 +3,6 @@
 #include "../gravity/grav3D.h"
 #include "../grid/grid3D.h"
 
-SpatialDomainProps SpatialDomainProps::From_Grav3D(Grav3D& grav) { return grav.spatial_props; }
-
 SpatialDomainProps SpatialDomainProps::From_Grid3D(Grid3D& grid, struct Parameters* P)
 {
   SpatialDomainProps out;

--- a/src/grid/spatial_domain_props.h
+++ b/src/grid/spatial_domain_props.h
@@ -1,3 +1,7 @@
+/*! \file
+ *  \brief defines \ref SpatialDomainProps
+ */
+
 #pragma once
 
 #include "../global/global.h"
@@ -6,25 +10,25 @@ class Grav3D;
 class Grid3D;
 struct Parameters;
 
-/* This is a collection of 15 quantities that appear in 3 other locations throughout the codebase.
+/*! Aggregates 15 quantities describing the spatial domain that appear throughout the codebase.
  *
- * The struct primarily exists to simplify the process of copying these values from one place to
- * another. (But it may make sense to refactor other parts of the code in terms of this object)
+ *  The struct primarily exists to simplify the process of copying these values from one place to
+ *  another. (But it may make sense to refactor other parts of the code in terms of this object)
  */
 struct SpatialDomainProps {
-  // number of cells in the local domain
+  /// number of cells in the local domain
   int nx_local, ny_local, nz_local;
 
-  // total number of cells in the entire (global) domain
+  /// total number of cells in the entire (global) domain
   int nx_total, ny_total, nz_total;
 
-  // Left boundaries of the local domain
+  /// Left boundaries of the local domain
   Real xMin, yMin, zMin;
 
-  // Right boundaries of the local domain
+  /// Right boundaries of the local domain
   Real xMax, yMax, zMax;
 
-  // cell widths
+  /// cell widths
   Real dx, dy, dz;
 
   static SpatialDomainProps From_Grav3D(Grav3D& grav);

--- a/src/grid/spatial_domain_props.h
+++ b/src/grid/spatial_domain_props.h
@@ -6,7 +6,6 @@
 
 #include "../global/global.h"
 
-class Grav3D;
 class Grid3D;
 struct Parameters;
 
@@ -31,6 +30,5 @@ struct SpatialDomainProps {
   /// cell widths
   Real dx, dy, dz;
 
-  static SpatialDomainProps From_Grav3D(Grav3D& grav);
   static SpatialDomainProps From_Grid3D(Grid3D& grid, Parameters* P);
 };

--- a/src/io/FieldWriter.cpp
+++ b/src/io/FieldWriter.cpp
@@ -354,10 +354,11 @@ void Write_Fields_to_HDF5_helper_(const std::string& filename, Grid3D& G, const 
   #if defined(GRAVITY) && defined(OUTPUT_POTENTIAL)
     if (is_3D) {  // 3D case
       const Grav3D& Grav = G.Grav;
-      Write_Generic_HDF5_Field_GPU(Grav.nx_local + 2 * N_GHOST_POTENTIAL, Grav.ny_local + 2 * N_GHOST_POTENTIAL,
-                                   Grav.nz_local + 2 * N_GHOST_POTENTIAL, Grav.nx_local, Grav.ny_local, Grav.nz_local,
-                                   N_GHOST_POTENTIAL, file_id, host_dataset_buf, dev_dataset_buf, Grav.F.potential_d,
-                                   "/grav_potential");
+      Write_Generic_HDF5_Field_GPU(Grav.spatial_props.nx_local + 2 * N_GHOST_POTENTIAL,
+                                   Grav.spatial_props.ny_local + 2 * N_GHOST_POTENTIAL,
+                                   Grav.spatial_props.nz_local + 2 * N_GHOST_POTENTIAL, Grav.spatial_props.nx_local,
+                                   Grav.spatial_props.ny_local, Grav.spatial_props.nz_local, N_GHOST_POTENTIAL, file_id,
+                                   host_dataset_buf, dev_dataset_buf, Grav.F.potential_d, "/grav_potential");
     }
   #endif  // GRAVITY and OUTPUT_POTENTIAL
   }

--- a/src/particles/density_CIC.cpp
+++ b/src/particles/density_CIC.cpp
@@ -73,7 +73,7 @@ void Grid3D::Copy_Particles_Density()
   #elif defined(GRAVITY)
 
     #ifndef PARALLEL_OMP
-  Copy_Particles_Density_function(0, Grav.nz_local);
+  Copy_Particles_Density_function(0, Grav.spatial_props.nz_local);
     #else
 
       #pragma omp parallel num_threads(N_OMP_THREADS)
@@ -84,7 +84,7 @@ void Grid3D::Copy_Particles_Density()
     omp_id      = omp_get_thread_num();
     n_omp_procs = omp_get_num_threads();
 
-    Get_OMP_Grid_Indxs(Grav.nz_local, n_omp_procs, omp_id, &g_start, &g_end);
+    Get_OMP_Grid_Indxs(Grav.spatial_props.nz_local, n_omp_procs, omp_id, &g_start, &g_end);
 
     Copy_Particles_Density_function(g_start, g_end);
   }
@@ -103,9 +103,9 @@ void Grid3D::Copy_Particles_Density_function(int g_start, int g_end)
   nz_part = Particles.G.nz_local + 2 * nGHST;
 
   int nx_dens, ny_dens, nz_dens;
-  nx_dens = Grav.nx_local;
-  ny_dens = Grav.ny_local;
-  nz_dens = Grav.nz_local;
+  nx_dens = Grav.spatial_props.nx_local;
+  ny_dens = Grav.spatial_props.ny_local;
+  nz_dens = Grav.spatial_props.nz_local;
 
   int i, j, k, id_CIC, id_grid;
   for (k = g_start; k < g_end; k++) {

--- a/src/particles/gravity_CIC.cpp
+++ b/src/particles/gravity_CIC.cpp
@@ -112,9 +112,9 @@ void Grid3D::Get_Gravity_Field_Particles_function(int g_start, int g_end)
   potential  = Grav.F.potential_h;
   nGHST_grid = N_GHOST_POTENTIAL;
 
-  nx_grid = Grav.nx_local + 2 * nGHST_grid;
-  ny_grid = Grav.ny_local + 2 * nGHST_grid;
-  nz_grid = Grav.nz_local + 2 * nGHST_grid;
+  nx_grid = Grav.spatial_props.nx_local + 2 * nGHST_grid;
+  ny_grid = Grav.spatial_props.ny_local + 2 * nGHST_grid;
+  nz_grid = Grav.spatial_props.nz_local + 2 * nGHST_grid;
 
   int nGHST = nGHST_grid - nGHST_grav;
 

--- a/src/particles/gravity_CIC_gpu.cu
+++ b/src/particles/gravity_CIC_gpu.cu
@@ -326,9 +326,9 @@ void Grid3D::Copy_Particles_Density_GPU()
 {
   int nx_local, ny_local, nz_local, n_ghost;
   n_ghost  = Particles.G.n_ghost_particles_grid;
-  nx_local = Grav.nx_local;
-  ny_local = Grav.ny_local;
-  nz_local = Grav.nz_local;
+  nx_local = Grav.spatial_props.nx_local;
+  ny_local = Grav.spatial_props.ny_local;
+  nz_local = Grav.spatial_props.nz_local;
 
   // set values for GPU kernels
   int tpb_x   = 16;

--- a/src/particles/io_particles.cpp
+++ b/src/particles/io_particles.cpp
@@ -703,13 +703,14 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
 
     #if defined(OUTPUT_POTENTIAL) && defined(ONLY_PARTICLES)
   // Copy the potential array to the memory buffer
-  for (k = 0; k < Grav.nz_local; k++) {
-    for (j = 0; j < Grav.ny_local; j++) {
-      for (i = 0; i < Grav.nx_local; i++) {
-        id =
-            (i + N_GHOST_POTENTIAL) + (j + N_GHOST_POTENTIAL) * (Grav.nx_local + 2 * N_GHOST_POTENTIAL) +
-            (k + N_GHOST_POTENTIAL) * (Grav.nx_local + 2 * N_GHOST_POTENTIAL) * (Grav.ny_local + 2 * N_GHOST_POTENTIAL);
-        buf_id                 = k + j * Grav.nz_local + i * Grav.nz_local * Grav.ny_local;
+  const SpatialDomainProps &spatial_props = Grav.spatial_props;
+  for (k = 0; k < spatial_props.nz_local; k++) {
+    for (j = 0; j < spatial_props.ny_local; j++) {
+      for (i = 0; i < spatial_props.nx_local; i++) {
+        id = (i + N_GHOST_POTENTIAL) + (j + N_GHOST_POTENTIAL) * (spatial_props.nx_local + 2 * N_GHOST_POTENTIAL) +
+             (k + N_GHOST_POTENTIAL) * (spatial_props.nx_local + 2 * N_GHOST_POTENTIAL) *
+                 (spatial_props.ny_local + 2 * N_GHOST_POTENTIAL);
+        buf_id                 = k + j * spatial_props.nz_local + i * spatial_props.nz_local * spatial_props.ny_local;
         dataset_buffer[buf_id] = Grav.F.potential_h[id];
       }
     }

--- a/src/particles/particles_3D.cpp
+++ b/src/particles/particles_3D.cpp
@@ -30,7 +30,7 @@ void Grid3D::Initialize_Particles(struct Parameters *P)
   chprintf("\nInitializing Particles...\n");
 
   #ifdef GRAVITY
-  SpatialDomainProps spatial_props = SpatialDomainProps::From_Grav3D(Grav);
+  SpatialDomainProps spatial_props = Grav.spatial_props;
   #else
   SpatialDomainProps spatial_props = SpatialDomainProps::From_Grid3D(*this, P);
   #endif


### PR DESCRIPTION
This is a small, straight-forward PR to make `Grid3D` directly store a copy of `SpatialDomainProps`.

Currently, all of the members of `SpatialDomainProps` are also listed as members of `Grav3D` (this was an intentional choice back when I made it possible to initialize particles without Gravity). This is just some long overdue cleanup (it's been on my todo list for quite a while).

----

There is a minor merge conflict with PR #521 -- I'm happy to resolve those conflicts in whatever order they are merged

----

Longer term, I would also like to store a copy of `SpatialDomainProps` within `Particles3D`; currently, copies of all of `SpatialDomainProps`'s data members are stored within the `Particles3D::Grid` type (the names are all consistent too). But, that's somewhat beyond the scope of this PR.