### PR TITLE
Adjustments to make CI catch all clang-tidy errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,10 +238,17 @@ tidy:
 # - --warnings-as-errors=<string> Upgrade all warnings to error, good for CI
 	clang-tidy --verify-config
 	@echo -e
-	(time clang-tidy $(CLANG_TIDY_ARGS) $(CPPFILES_TIDY) -- $(CXXFLAGS_CLANG_TIDY) $(LIBS_CLANG_TIDY)) > tidy_results_cpp_$(TYPE).log 2>&1 & \
+	((time clang-tidy $(CLANG_TIDY_ARGS) $(CPPFILES_TIDY) -- $(CXXFLAGS_CLANG_TIDY) $(LIBS_CLANG_TIDY)) > tidy_results_cpp_$(TYPE).log 2>&1 & \
 	(time clang-tidy $(CLANG_TIDY_ARGS) $(GPUFILES_TIDY) -- $(GPUFLAGS_CLANG_TIDY) $(LIBS_CLANG_TIDY)) > tidy_results_gpu_$(TYPE).log 2>&1 & \
-	for i in 1 2; do wait -n; done
-	@echo -e "\nResults from clang-tidy are available in the 'tidy_results_cpp_$(TYPE).log' and 'tidy_results_gpu_$(TYPE).log' files."
+	wait -n; ExitCodeA=$$?; \
+	wait -n; ExitCodeB=$$?; \
+	echo -e "\nResults from clang-tidy are available in the 'tidy_results_cpp_$(TYPE).log' and 'tidy_results_gpu_$(TYPE).log' files."; \
+	if [ $$ExitCodeA -eq 0 ] && [ $$ExitCodeB -eq 0 ]; then \
+	  exit 0; \
+	else \
+	  echo "clang-tidy failed"; \
+	  exit 1; \
+	fi)
 
 clean:
 	rm -f $(CLEAN_OBJS) $(DLINK) src/cholla_config.h

--- a/src/cosmology/tabulated_dynamicalDE_EoS_tests.cpp
+++ b/src/cosmology/tabulated_dynamicalDE_EoS_tests.cpp
@@ -134,6 +134,7 @@ TEST(tALLTabulatedDynamicalDarkEnergyEoSDeathTest, ThreeElemsOnLine2)
 
 // define parametrized tests where we try to read files without real contents
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 class tALLTabulatedDynamicalDarkEnergyEoSNoContentsDeathTest : public testing::TestWithParam<FileVariation>
 {
 };

--- a/src/cosmology/tabulated_dynamicalDE_EoS_tests.cpp
+++ b/src/cosmology/tabulated_dynamicalDE_EoS_tests.cpp
@@ -46,6 +46,7 @@ const std::string GOOD_CONTENTS_ = R"LITERAL(# z, w
 # this is a random meaningless comment!
 1.392540755881421788e-02 -9.772263520514015145e-01)LITERAL";
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 class tALLTabulatedDynamicalDarkEnergyEoS : public testing::TestWithParam<FileVariation>
 {
 };

--- a/src/grid/field_info.cpp
+++ b/src/grid/field_info.cpp
@@ -78,7 +78,7 @@ FieldInfo FieldInfo::create()
   std::vector<std::string> v;
   v.reserve(n_fields_);
   for (std::size_t i = 0; i < n_fields_; i++) {
-    v.push_back(std::string(pack_arr_[i].name));
+    v.emplace_back(pack_arr_[i].name);
     out.io_buf_.push_back(pack_arr_[i].io_buf);
     switch (pack_arr_[i].kind) {
       case field::Kind::HYDRO:

--- a/src/io/SliceWriter.cpp
+++ b/src/io/SliceWriter.cpp
@@ -182,7 +182,7 @@ static void Write_Slices_HDF5_(const Grid3D &G, hid_t file_id,
     }
 
     // record slices of all cell-centered fields
-    for (const std::pair<int, std::string> pair : cc_field_id_dset_name_pairs) {
+    for (const std::pair<int, std::string> &pair : cc_field_id_dset_name_pairs) {
       int field_id          = pair.first;
       std::string dset_name = pair.second;
 

--- a/src/io/WriterManager.cpp
+++ b/src/io/WriterManager.cpp
@@ -44,7 +44,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     // setup the data output routine for Hydro data
     std::pair<io::WriterFn, std::string> rslt = io::FieldWriter::try_create(ndim, pmap, field_info, false);
     if (rslt.first) {
-      packs_.push_back(io::detail::WriterPack{"hydro", n_hydro, rslt.first});
+      packs_.emplace_back(io::detail::WriterPack{"hydro", n_hydro, rslt.first});
     } else {
       chprintf("WARNING: %s\n", rslt.second.c_str());
     }
@@ -67,20 +67,21 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     if (not rslt.first) {
       CHOLLA_ERROR("Error while preparing dumps for f32 hdf5 outputs: %s", rslt.second.c_str());
     }
-    packs_.push_back(io::detail::WriterPack{"hydro-f32", cadence, rslt.first});
+    packs_.emplace_back(io::detail::WriterPack{"hydro-f32", cadence, rslt.first});
   }
 
 #ifdef PROJECTION
-  packs_.push_back(io::detail::WriterPack{"projection", pmap.value_or("n_projection", 1), ProjectionWriter()});
+  packs_.emplace_back(io::detail::WriterPack{"projection", pmap.value_or("n_projection", 1), ProjectionWriter()});
 #endif /*PROJECTION*/
 
 #ifdef ROTATED_PROJECTION
-  packs_.push_back(io::detail::WriterPack{
+  packs_.emplace_back(io::detail::WriterPack{
       "rotated_projection", pmap.value_or("n_rotated_projection", 1), {io::RotatedProjWriter(pmap)}});
 #endif /*ROTATED_PROJECTION*/
 
 #ifdef SLICES
-  packs_.push_back(io::detail::WriterPack{"slice", pmap.value_or("n_slice", 1), {io::SliceWriter(pmap, field_info)}});
+  packs_.emplace_back(
+      io::detail::WriterPack{"slice", pmap.value_or("n_slice", 1), {io::SliceWriter(pmap, field_info)}});
 #endif /*SLICES*/
 
 #ifdef PARTICLES
@@ -88,7 +89,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
   auto write_particle = [](Grid3D& G, Parameters P, int nfile, const FnameTemplate& fname_template) {
     G.WriteData_Particles(P, nfile, fname_template);
   };
-  packs_.push_back(io::detail::WriterPack{"particle", pmap.value_or("n_particle", 1), write_particle});
+  packs_.emplace_back(io::detail::WriterPack{"particle", pmap.value_or("n_particle", 1), write_particle});
 
 #endif
 
@@ -97,7 +98,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     G.Grav.Write_Restart_HDF5(&P, nfile, fname_template);
   };
   int n_gravity = 1;  // <- this is the historical choice
-  packs_.push_back(io::detail::WriterPack{"gravity", n_gravity, write_gravity});
+  packs_.emplace_back(io::detail::WriterPack{"gravity", n_gravity, write_gravity});
 
 #endif
 }

--- a/src/io/WriterManager.cpp
+++ b/src/io/WriterManager.cpp
@@ -44,7 +44,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     // setup the data output routine for Hydro data
     std::pair<io::WriterFn, std::string> rslt = io::FieldWriter::try_create(ndim, pmap, field_info, false);
     if (rslt.first) {
-      packs_.emplace_back(io::detail::WriterPack{"hydro", n_hydro, rslt.first});
+      packs_.emplace_back("hydro", n_hydro, rslt.first);
     } else {
       chprintf("WARNING: %s\n", rslt.second.c_str());
     }
@@ -67,21 +67,19 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     if (not rslt.first) {
       CHOLLA_ERROR("Error while preparing dumps for f32 hdf5 outputs: %s", rslt.second.c_str());
     }
-    packs_.emplace_back(io::detail::WriterPack{"hydro-f32", cadence, rslt.first});
+    packs_.emplace_back("hydro-f32", cadence, rslt.first);
   }
 
 #ifdef PROJECTION
-  packs_.emplace_back(io::detail::WriterPack{"projection", pmap.value_or("n_projection", 1), ProjectionWriter()});
+  packs_.emplace_back("projection", pmap.value_or("n_projection", 1), ProjectionWriter());
 #endif /*PROJECTION*/
 
 #ifdef ROTATED_PROJECTION
-  packs_.emplace_back(io::detail::WriterPack{
-      "rotated_projection", pmap.value_or("n_rotated_projection", 1), {io::RotatedProjWriter(pmap)}});
+  packs_.emplace_back("rotated_projection", pmap.value_or("n_rotated_projection", 1), io::RotatedProjWriter(pmap));
 #endif /*ROTATED_PROJECTION*/
 
 #ifdef SLICES
-  packs_.emplace_back(
-      io::detail::WriterPack{"slice", pmap.value_or("n_slice", 1), {io::SliceWriter(pmap, field_info)}});
+  packs_.emplace_back("slice", pmap.value_or("n_slice", 1), io::SliceWriter(pmap, field_info));
 #endif /*SLICES*/
 
 #ifdef PARTICLES
@@ -89,7 +87,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
   auto write_particle = [](Grid3D& G, Parameters P, int nfile, const FnameTemplate& fname_template) {
     G.WriteData_Particles(P, nfile, fname_template);
   };
-  packs_.emplace_back(io::detail::WriterPack{"particle", pmap.value_or("n_particle", 1), write_particle});
+  packs_.emplace_back("particle", pmap.value_or("n_particle", 1), write_particle);
 
 #endif
 
@@ -98,7 +96,7 @@ io::WriterManager::WriterManager(const Parameters& P, ParameterMap& pmap, const 
     G.Grav.Write_Restart_HDF5(&P, nfile, fname_template);
   };
   int n_gravity = 1;  // <- this is the historical choice
-  packs_.emplace_back(io::detail::WriterPack{"gravity", n_gravity, write_gravity});
+  packs_.emplace_back("gravity", n_gravity, write_gravity);
 
 #endif
 }

--- a/src/io/WriterManager.h
+++ b/src/io/WriterManager.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <string>
+#include <utility>  // std::move
 #include <vector>
 
 #include "../global/global.h"
@@ -40,7 +41,10 @@ struct WriterPack {
    *  initialization" but lets you surround the arguments in parentheses (in c++20, we
    *  can get rid of this)
    */
-  WriterPack(std::string name, int cadence, WriterFn fn) noexcept : name(name), cadence{cadence}, fn(fn) {}
+  WriterPack(std::string name, int cadence, WriterFn fn) noexcept
+      : name(std::move(name)), cadence{cadence}, fn(std::move(fn))
+  {
+  }
 };
 
 }  // namespace detail

--- a/src/io/WriterManager.h
+++ b/src/io/WriterManager.h
@@ -32,6 +32,15 @@ struct WriterPack {
   int cadence;
   /*! specifes the writer-function or function-like object */
   const WriterFn fn;
+
+  /*! \brief Primary Constructor
+   *
+   *  \note this primarily exists to satisfy a clang-tidy warning about using
+   *  the `vector::emplace_back`. Essentially, this acts just like "aggregate
+   *  initialization" but lets you surround the arguments in parentheses (in c++20, we
+   *  can get rid of this)
+   */
+  WriterPack(std::string name, int cadence, WriterFn fn) noexcept : name(name), cadence{cadence}, fn(fn) {}
 };
 
 }  // namespace detail

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -227,7 +227,7 @@ H5Space1D &H5Space1D::operator=(H5Space1D &&other) noexcept
 H5Space1D &H5Space1D::ensure_dim(hsize_t dim)
 {
   if (this->id_ == H5I_INVALID_HID) {  // <- first time setting dim
-    this->dim_ = std::unique_ptr<hsize_t>(new hsize_t{dim});
+    this->dim_ = std::make_unique<hsize_t>(dim);
   } else if (*this->dim_ == dim) {  // <- dim isn't changing
     return *this;
   } else {
@@ -884,17 +884,22 @@ void Grid3D::Print_Grid_Stats(void)
 // - earlier versions of this logic wouldn't work with Grackle
 static void cosmo_init_chemical_species_(const Header &H, const FieldInfo &field_info, Real *host_field_ptr)
 {
-  if (!field_info.field_id("HI_density").has_value()) {
-    CHOLLA_ERROR("This function has been erroneously executed. There are no chemical species");
-  }
+  auto get_ptr_or_abort = [&](const char *name) -> Real * {
+    std::optional<int> maybe_id = field_info.field_id(name).value();
+    if (maybe_id.has_value()) {
+      return &host_field_ptr[H.n_cells * maybe_id.value()];
+    } else {
+      CHOLLA_ERROR("%s is not the name of a defined field", name);
+    }
+  };
 
-  Real *density       = &host_field_ptr[H.n_cells * field_info.field_id("density").value()];
-  Real *HI_density    = &host_field_ptr[H.n_cells * field_info.field_id("HI_density").value()];
-  Real *HII_density   = &host_field_ptr[H.n_cells * field_info.field_id("HII_density").value()];
-  Real *HeI_density   = &host_field_ptr[H.n_cells * field_info.field_id("HeI_density").value()];
-  Real *HeII_density  = &host_field_ptr[H.n_cells * field_info.field_id("HeII_density").value()];
-  Real *HeIII_density = &host_field_ptr[H.n_cells * field_info.field_id("HeIII_density").value()];
-  Real *e_density     = &host_field_ptr[H.n_cells * field_info.field_id("e_density").value()];
+  Real *density       = get_ptr_or_abort("density");
+  Real *HI_density    = get_ptr_or_abort("HI_density");
+  Real *HII_density   = get_ptr_or_abort("HII_density");
+  Real *HeI_density   = get_ptr_or_abort("HeI_density");
+  Real *HeII_density  = get_ptr_or_abort("HeII_density");
+  Real *HeIII_density = get_ptr_or_abort("HeIII_density");
+  Real *e_density     = get_ptr_or_abort("e_density");
 
   for (int k = 0; k < H.nz_real; k++) {
     for (int j = 0; j < H.ny_real; j++) {
@@ -940,8 +945,12 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct Parameters P)
 
   // load all of the hydro fields (include GasEnergy if using dual-energy formalism)
   for (int field_id : field_info.get_id_range(field::Kind::HYDRO)) {
-    Real *dest_ptr        = &C.host[field_id * H.n_cells];
-    std::string dset_name = "/" + field_info.field_name(field_id).value();
+    Real *dest_ptr                 = &C.host[field_id * H.n_cells];
+    std::optional<std::string> tmp = field_info.field_name(field_id);
+    if (!tmp.has_value()) {
+      CHOLLA_ERROR("this should be unreachable");
+    }
+    std::string dset_name = "/" + tmp.value();
     Read_Grid_HDF5_Field(file_id, dataset_buffer, H, dest_ptr, dset_name.c_str());
   }
 
@@ -960,8 +969,12 @@ void Grid3D::Read_Grid_HDF5(hid_t file_id, struct Parameters P)
 
   // try to load all of the scalars (that aren't within skip_loading_scalar)
   for (int field_id : field_info.get_id_range(field::Kind::PASSIVE_SCALAR)) {
-    Real *dest_ptr         = &C.host[field_id * H.n_cells];
-    std::string field_name = field_info.field_name(field_id).value();
+    Real *dest_ptr                 = &C.host[field_id * H.n_cells];
+    std::optional<std::string> tmp = field_info.field_name(field_id);
+    if (!tmp.has_value()) {
+      CHOLLA_ERROR("this should be unreachable");
+    }
+    std::string field_name = tmp.value();
     if (skip_loading_scalar.find(field_name) != skip_loading_scalar.end()) {
       continue;
     }


### PR DESCRIPTION
It has come to my attention that clang-tidy errors in .cpp files tend to slip through CI.

This is because the Makefile would only report the errors of the second execution of clang-tidy that would exit and it appears that the clang-tidy almost always runs more quickly for the .cpp files (perhaps the .cu files are simply more numerous).

The first commit tweaks the Makefile's `tidy` recipe so that we now report the correct result. This causes CI to correctly report a linting error (rather than suppress it). The subsequent commit commit tries to address all of the warnings that piled up

---

ASIDE: if we make a build-directory, there are more robust ways to run clang-tidy that would let us distribute clang-tidy runs across an arbitrary number of CPU cores, in the same way we can distribute regular compilation commands. These approaches involve the creation of a compile_commands.json file -- but that is an idea for a subsequent PR