### PR TITLE
Update cuda and rocm dockerfiles to include clang-tidy

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -34,6 +34,13 @@ env:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # we list suffix (of the image name) path (to the dockerfile) pairs
+        sp_pair:
+          - [ROCm, docker/rocm/Dockerfile]
+          - [cuda, docker/cuda/Dockerfile]
+
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in
     # this job.
     permissions:
@@ -70,7 +77,7 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           # the `images` argument sets the base name that we use for the image
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-ROCm
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.sp_pair[0] }}
           # we primarily name the image based on the (shortenned) hash of the
           # git-commit that we used to generate the image.
           tags: type=sha
@@ -82,9 +89,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: ${{ env.IS_WORKFLOW_DISPATCH }}
-          context: .
+          context: ./docker
           # obviously specifies the path to the docker file
-          file: docker/rocm/Dockerfile
+          file: ${{ matrix.sp_pair[1] }}
           # use the tags collected by the "Extract metadata" step
           tags: ${{ steps.meta.outputs.tags }}
           # use the labels collected by the "Extract metadata" step

--- a/docker/cuda/Dockerfile
+++ b/docker/cuda/Dockerfile
@@ -1,9 +1,41 @@
-FROM nvidia/cuda:11.7.1-devel-ubuntu22.04
+# this is a 2-stage build
+
+ARG SOURCE_IMAGE="nvidia/cuda:11.7.1-devel-ubuntu22.04"
 # Needs to be devel, not base or runtime, to have nvcc
 # Ubuntu 22 is better than 18 because Ubuntu 22 default git is > 2.17
 # Github actions requires git > 2.17 so that cholla is pulled into a git repo
 # Which is required for the Makefile
 # With ubuntu 22.04 this grabs 2.34.1
+
+ARG TARGET_LLVM_VERSION="17.0.1"
+
+# =========================
+# Stage 1: Build clang-tidy
+# =========================
+# -> we will build clang-tidy in this stage and then in the next stage, we will
+#    copy the files out of here (so that we minimize the size of the resulting
+#    image)
+FROM ${SOURCE_IMAGE} AS builder
+
+# Install llvm build dependencies.
+# -> this dependency list was loosely inspired by the build-defaults inside of
+#    llvm's sample dockerfile
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates cmake 2to3 python-is-python3 subversion ninja-build git && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD scripts /tmp/scripts
+
+RUN python /tmp/scripts/get_clang_tidy.py \
+    --work-dir=/tmp/clang-build \
+    --install-dir=/tmp/clang-install \
+    --llvm-version=17.0.1
+
+# ===========================================================
+# Stage 2: Actually build the image used for compiling cholla
+# ===========================================================
+FROM ${SOURCE_IMAGE}
 
 RUN apt-get -y update && apt install -y \
     cmake \
@@ -16,14 +48,29 @@ RUN apt-get -y update && apt install -y \
     software-properties-common \
     wget
 
-# Install Clang and Tools
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    echo "\n" | ./llvm.sh 15 all && \
-    find /usr/bin/ -name 'clang*15'  | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+## Install Clang and Tools
+#RUN wget https://apt.llvm.org/llvm.sh && \
+#    chmod +x llvm.sh && \
+#    echo "\n" | ./llvm.sh 15 all && \
+#    find /usr/bin/ -name 'clang*15'  | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
+
+# Copy clang installation into this container
+# -------------------------------------------
+# if we also wanted to install the clang compiler, we should just invoke:
+#COPY --from=builder /tmp/clang-install/ /usr/local/
+
+# in the current version, we perform the following
+COPY --from=builder /tmp/clang-install/include /usr/local/include
+COPY --from=builder /tmp/clang-install/bin/clang-tidy /usr/local/bin/clang-tidy
+COPY --from=builder /tmp/clang-install/bin/run-clang-tidy /usr/local/bin/run-clang-tidy
+
 
 # Needed by Cholla Makefile
 ENV CHOLLA_MACHINE=github
 ENV CUDA_ROOT=/usr/local/cuda-11/
 ENV HDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial/
 ENV MPI_ROOT=/usr/lib/x86_64-linux-gnu/openmpi/
+
+# inspired by https://hub.docker.com/_/ubuntu#locales
+# -> this is useful for employing this image as a dev container
+ENV LANG=C.UTF-8

--- a/docker/rocm/Dockerfile
+++ b/docker/rocm/Dockerfile
@@ -1,4 +1,38 @@
-FROM rocm/dev-ubuntu-20.04:5.5.1
+# this is a 2-stage build
+
+ARG SOURCE_IMAGE="rocm/dev-ubuntu-22.04:5.5.1"
+# -> we try to match the underlying ubuntu image used in the cuda container
+
+ARG TARGET_LLVM_VERSION="17.0.1"
+
+# =========================
+# Stage 1: Build clang-tidy
+# =========================
+# -> we will build clang-tidy in this stage and then in the next stage, we will
+#    copy the files out of here (so that we minimize the size of the resulting
+#    image)
+FROM ${SOURCE_IMAGE} AS builder
+
+# Install llvm build dependencies.
+# -> this dependency list was loosely inspired by the build-defaults inside of
+#    llvm's sample dockerfile
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates cmake 2to3 python-is-python3 subversion ninja-build git && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD scripts /tmp/scripts
+
+RUN python /tmp/scripts/get_clang_tidy.py \
+    --work-dir=/tmp/clang-build \
+    --install-dir=/tmp/clang-install \
+    --llvm-version=17.0.1
+
+# ===========================================================
+# Stage 2: Actually build the image used for compiling cholla
+# ===========================================================
+FROM ${SOURCE_IMAGE}
+
 
 # Avoid annoying cmake -> tzdata install prompt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -28,9 +62,23 @@ RUN apt-get -y install rocrand
 #     echo "\n" | ./llvm.sh 15 all && \
 #     find /usr/bin/ -name 'clang*15'  | sed -E 's/^(\/usr\/bin\/.*)(\-[0-9]*)$/ln -s -v \1\2 \1/' | xargs -d '\n' -n 1 bash -c
 
+# Copy clang installation into this container
+# -------------------------------------------
+# if we also wanted to install the clang compiler, we should just invoke:
+#COPY --from=builder /tmp/clang-install/ /usr/local/
+
+# in the current version, we perform the following
+COPY --from=builder /tmp/clang-install/include /usr/local/include
+COPY --from=builder /tmp/clang-install/bin/clang-tidy /usr/local/bin/clang-tidy
+COPY --from=builder /tmp/clang-install/bin/run-clang-tidy /usr/local/bin/run-clang-tidy
+
 # Needed by Cholla Makefile
 ENV CHOLLA_MACHINE=github
 ENV HIPCONFIG=/opt/rocm-5.5.1
 ENV ROCM_PATH=/opt/rocm-5.5.1
 ENV HDF5_ROOT=/usr/lib/x86_64-linux-gnu/hdf5/serial
 ENV MPI_ROOT=/usr/lib/x86_64-linux-gnu/openmpi
+
+# inspired by https://hub.docker.com/_/ubuntu#locales
+# -> this is useful for employing this image as a dev container
+ENV LANG=C.UTF-8

--- a/docker/scripts/get_clang_tidy.py
+++ b/docker/scripts/get_clang_tidy.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Fetch, build, and install a particular version of clang-tidy.
+
+This is intended to be used within a Dockerfile. This is useful for both:
+1. running clang-tidy directly via GitHub Actions (i.e. not just in Jenkins)
+2. for devcontainers
+
+This was heavily influenced by the shell scripts provided by LLVM at
+- llvm/utils/docker/build_docker_image.sh
+- llvm/utils/docker/scripts/checkout.sh
+- llvm/utils/docker/scripts/build_install_llvm.sh
+Both of these files are licensed under Apache-2.0 WITH LLVM-exception
+
+In the future, we may want to add support for downloading from prebuilt
+repositories for debian/ubuntu that are maintained by LLVM.
+- However, doing that limits our control over specifying the precise
+  minor/patch version of clang-tidy. Based on some recent reproducibility
+  challenges, its a little unclear whether this is a significant issue.
+- If we do want to take this approach, we could reuse logic from a script
+  that I wrote for Grackle for this precise purpose
+  https://github.com/grackle-project/grackle/blob/newchem-cpp/scripts/ci/install_dependencies.py
+"""
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+logger = logging.getLogger("get_clang_tidy")
+logger.setLevel(logging.DEBUG)
+
+
+def configure_logger(color: bool = False):
+    """Configure logger outputs. Should be called once (& only once) @ startup."""
+    global logger
+    color_start, color_stop = ("\x1b[36;20m", "\x1b[0m") if color else ("", "")
+    fmt = f"{color_start}%(name)s{color_stop} > %(message)s"
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(console_handler)
+
+
+def _run(
+    *args: str, dry_run: bool = False, check: bool = True, **kw: Any
+) -> subprocess.CompletedProcess:
+    """Log and execute the specified command."""
+    msg = f"$ {' '.join(args)}"
+    if len(kw) != 0:
+        msg += f"; {kw!r}"
+    logger.info(msg)
+
+    if dry_run:
+        return subprocess.run("true", check=check)
+    else:
+        return subprocess.run(args, check=check, **kw)
+
+
+def main(args: argparse.Namespace):
+    configure_logger(color=args.color)
+
+    target_llvm_version = args.llvm_version
+    working_dir = "/tmp/clang-build"
+    checkout_dir = os.path.join(working_dir, "src")
+    build_dir = os.path.join(working_dir, "build")
+    install_dir = "/tmp/clang-install"
+
+    # clone llvm
+    major_llvm_version = target_llvm_version.split(".")[0]
+    git_cmd = [
+        "git",
+        "clone",
+        f"--branch=release/{major_llvm_version}.x",
+        "https://github.com/llvm/llvm-project.git",
+        checkout_dir,
+    ]
+    _run(*git_cmd, dry_run=args.dry_run)
+
+    # checkout appropriate branch
+    tag = f"llvmorg-{target_llvm_version}"
+    _run("git", "-C", checkout_dir, "checkout", tag, dry_run=args.dry_run)
+
+    # move onto the build
+    logger.info(f"ensure that {install_dir} exist")
+    if not args.dry_run:
+        os.makedirs(install_dir, exist_ok=True)
+
+    # configure the build
+    config_cmd = [
+        "cmake",
+        "-GNinja",
+        "-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra",
+        f"-DCMAKE_INSTALL_PREFIX={install_dir}",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SHARED_LIBS=OFF",
+        "-DLLVM_ENABLE_ZSTD=OFF",  # <- inspired by clang-tidy-wheel
+        f"-B{build_dir}",
+        f"-S{os.path.join(checkout_dir, 'llvm')}",
+    ]
+    _run(*config_cmd, dry_run=args.dry_run)
+
+    # run the build and install
+    _install_targets = ["install", "install-clang-resource-headers"]
+    _run("ninja", f"-C{build_dir}", *_install_targets, dry_run=args.dry_run)
+
+    # cleanup from the build
+    logger.info("clean up the build-dir")
+    if not args.dry_run:
+        shutil.rmtree(build_dir)
+    return 0
+
+
+_SHORT_DESCR = "Install clang-tidy"
+parser = argparse.ArgumentParser(description=_SHORT_DESCR, allow_abbrev=False)
+parser.add_argument("--color", action="store_true", help="use color")
+parser.add_argument("--dry-run", action="store_true")
+parser.add_argument(
+    "--work-dir", required=True, help="location where source code is cloned & built"
+)
+parser.add_argument(
+    "--install-dir", required=True, help="location where build-products are installed"
+)
+parser.add_argument(
+    "--llvm-version", required=True, help="specify desired clang-tidy version"
+)
+
+if __name__ == "__main__":
+    sys.exit(main(parser.parse_args()))


### PR DESCRIPTION
The dockerfiles have been updated to install our preferred version of clang-tidy. The goal of this change is three-fold:

1. It will let me test discrepancies between clang-tidy on different machines.[^1]

2. It will let us set up GitHub Actions to directly run clang-tidy. This will allow people to see linting errors without requiring credentials to log into Jenkins.

3. This paves the way for development in containers. In other words, someone could locally spin up a docker container using one of our images and compile the code there (even if they don't own a GPU). VSCode has builtin machinery for this purpose called [dev containers](https://code.visualstudio.com/docs/devcontainers/create-dev-container). This has has 2 benefits:
   - if there are issues with clang-tidy lints it will be easier to reproduce them locally.[^2]
   - this is probably the best path to unlocking IDE-like features, with tools like the [clangd](https://clangd.llvm.org/) language server.[^3] I've used this with Grackle, and the real-time feedback makes dealing with clang-tidy **much** easier.

I think this is also a useful step towards eventually updating the clang-tidy version (this is desirable if we ever want to use something like the clangd language server).

[^1]: I know that the c++ standard libraries sometimes have different headers on different architectures. Its highly unlikely, but I want to make sure that this isn't the cause of discrepancies.
[^2]: In practice, clang-tidy shouldn't have a strong dependence on its patch version (e.g. 17.0.1 vs 17.0.6 shouldn't make a difference). I'm hoping to sort this out.
[^3]: Some extra work is definitely required before we can get that working.