### PR TITLE
Scalar Flux Bug Fix

### DIFF
--- a/src/riemann_solvers/hll_cuda.cu
+++ b/src/riemann_solvers/hll_cuda.cu
@@ -71,7 +71,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
       left_state.energy       = dev_bounds_L[4 * n_cells + tid];
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
-        left_state.scalar[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+        left_state.scalar[i] = dev_bounds_L[(5 + i) * n_cells + tid] / left_state.density;
       }
 #endif
 #ifdef DE
@@ -85,7 +85,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
       right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
-        right_state.scalar[i] = dev_bounds_R[(5 + i) * n_cells + tid];
+        right_state.scalar[i] = dev_bounds_R[(5 + i) * n_cells + tid] / right_state.density;
       }
 #endif
 #ifdef DE
@@ -193,7 +193,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
-      f_sc_l[i] = left_state.scalar[i] * left_state.velocity.x();
+      f_sc_l[i] = left_state.scalar[i] * f_d_l;
     }
 #endif
 
@@ -207,7 +207,7 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
-      f_sc_r[i] = right_state.scalar[i] * right_state.velocity.x();
+      f_sc_r[i] = right_state.scalar[i] * f_d_r;
     }
 #endif
 
@@ -259,8 +259,11 @@ __global__ void Calculate_HLL_Fluxes_CUDA(Real const *dev_conserved, Real const 
 #endif
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
-        f_sc[i] = ((Sr * f_sc_l[i]) - (Sl * f_sc_r[i]) + Sl * Sr * (right_state.scalar[i] - left_state.scalar[i])) /
-                  (Sr - Sl);
+        double left_scalar_density  = left_state.scalar[i] * left_state.density;
+        double right_scalar_density = right_state.scalar[i] * right_state.density;
+
+        f_sc[i] =
+            ((Sr * f_sc_l[i]) - (Sl * f_sc_r[i]) + Sl * Sr * (right_scalar_density - left_scalar_density)) / (Sr - Sl);
       }
 #endif
 

--- a/src/riemann_solvers/hllc_cuda.cu
+++ b/src/riemann_solvers/hllc_cuda.cu
@@ -37,8 +37,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
     Real Sl, Sr, Sm, cfl, cfr, ps;
 
 #ifdef SCALAR
-    Real dscl[NSCALARS], dscr[NSCALARS], scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS],
-        f_sc[NSCALARS];
+    Real scls[NSCALARS], scrs[NSCALARS], f_sc_l[NSCALARS], f_sc_r[NSCALARS], f_sc[NSCALARS];
 #endif
 
     Real etah = 0;
@@ -68,13 +67,6 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
     if constexpr (reconstruction == reconstruction::Kind::pcm) {
       reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
                                                                               n_cells, gamma, left_state, right_state);
-#ifdef SCALAR
-      // this is a hacky bugfix. The more correct solution is to eliminate dscl & dscr
-      for (int i = 0; i < NSCALARS; i++) {
-        dscl[i] = left_state.scalar[i] * left_state.density;
-        dscr[i] = right_state.scalar[i] * right_state.density;
-      }
-#endif
     } else {
       // retrieve conserved variables
       left_state.density      = dev_bounds_L[tid];
@@ -83,8 +75,9 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
       left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
       left_state.energy       = dev_bounds_L[4 * n_cells + tid];
 #ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        dscl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+      for (int i = 0; i < grid_enum::nscalars; i++) {
+        Real scalar_density  = dev_bounds_L[(grid_enum::scalar + i) * n_cells + tid];
+        left_state.scalar[i] = scalar_density / left_state.density;
       }
 #endif
 #ifdef DE
@@ -97,8 +90,9 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
       right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
       right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        dscr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
+      for (int i = 0; i < grid_enum::nscalars; i++) {
+        Real scalar_density   = dev_bounds_R[(grid_enum::scalar + i) * n_cells + tid];
+        right_state.scalar[i] = scalar_density / right_state.density;
       }
 #endif
 #ifdef DE
@@ -124,11 +118,6 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
                             (gamma - 1.0);
 #endif  // PRESSURE_DE
       left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
-#ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        left_state.scalar[i] = dscl[i] / left_state.density;
-      }
-#endif
 #ifdef DE
       left_state.gas_energy = gas_energy_left / left_state.density;
 #endif
@@ -150,11 +139,6 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
                              (gamma - 1.0);
 #endif  // PRESSURE_DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
-#ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        right_state.scalar[i] = dscr[i] / right_state.density;
-      }
-#endif
 #ifdef DE
       right_state.gas_energy = gas_energy_right / right_state.density;
 #endif
@@ -207,7 +191,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
-      f_sc_l[i] = dscl[i] * left_state.velocity.x();
+      f_sc_l[i] = left_state.scalar[i] * f_d_l;
     }
 #endif
 
@@ -221,7 +205,7 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
 #endif
 #ifdef SCALAR
     for (int i = 0; i < NSCALARS; i++) {
-      f_sc_r[i] = dscr[i] * right_state.velocity.x();
+      f_sc_r[i] = right_state.scalar[i] * f_d_r;
     }
 #endif
 
@@ -320,8 +304,10 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
 #endif
 #ifdef SCALAR
       for (int i = 0; i < NSCALARS; i++) {
-        f_sc[i] = 0.5 * (f_sc_l[i] + f_sc_r[i] + (Sr - fabs(Sm)) * scrs[i] + (Sl + fabs(Sm)) * scls[i] - Sl * dscl[i] -
-                         Sr * dscr[i]);
+        double left_scalar_density  = left_state.scalar[i] * left_state.density;
+        double right_scalar_density = right_state.scalar[i] * right_state.density;
+        f_sc[i] = 0.5 * (f_sc_l[i] + f_sc_r[i] + (Sr - fabs(Sm)) * scrs[i] + (Sl + fabs(Sm)) * scls[i] -
+                         Sl * left_scalar_density - Sr * right_scalar_density);
       }
 #endif
 

--- a/src/riemann_solvers/hllc_cuda.cu
+++ b/src/riemann_solvers/hllc_cuda.cu
@@ -68,6 +68,13 @@ __global__ void Calculate_HLLC_Fluxes_CUDA(Real const *dev_conserved, Real const
     if constexpr (reconstruction == reconstruction::Kind::pcm) {
       reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
                                                                               n_cells, gamma, left_state, right_state);
+#ifdef SCALAR
+      // this is a hacky bugfix. The more correct solution is to eliminate dscl & dscr
+      for (int i = 0; i < NSCALARS; i++) {
+        dscl[i] = left_state.scalar[i] * left_state.density;
+        dscr[i] = right_state.scalar[i] * right_state.density;
+      }
+#endif
     } else {
       // retrieve conserved variables
       left_state.density      = dev_bounds_L[tid];

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -40,7 +40,7 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
   int hlle_flag = 0;
 
 #ifdef SCALAR
-  Real dscalarl[NSCALARS], dscalarr[NSCALARS], f_scalar_l[NSCALARS], f_scalar_r[NSCALARS];
+  Real f_scalar_l[NSCALARS], f_scalar_r[NSCALARS];
 #endif
 
   int o1, o2, o3;
@@ -70,13 +70,6 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
     if constexpr (reconstruction == reconstruction::Kind::pcm) {
       reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
                                                                               n_cells, gamma, left_state, right_state);
-#ifdef SCALAR
-      // this is a hacky bugfix. The more correct solution is to eliminate dscalarl & dscalarr
-      for (int i = 0; i < NSCALARS; i++) {
-        dscalarl[i] = left_state.scalar[i] * left_state.density;
-        dscalarr[i] = right_state.scalar[i] * right_state.density;
-      }
-#endif
     } else {
       // retrieve conserved variables
       left_state.density      = dev_bounds_L[tid];
@@ -85,8 +78,9 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       left_state.momentum.z() = dev_bounds_L[o3 * n_cells + tid];
       left_state.energy       = dev_bounds_L[4 * n_cells + tid];
 #ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        dscalarl[i] = dev_bounds_L[(5 + i) * n_cells + tid];
+      for (int i = 0; i < grid_enum::nscalars; i++) {
+        Real scalar_density  = dev_bounds_L[(grid_enum::scalar + i) * n_cells + tid];
+        left_state.scalar[i] = scalar_density / left_state.density;
       }
 #endif
 #ifdef DE
@@ -99,8 +93,9 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
       right_state.momentum.z() = dev_bounds_R[o3 * n_cells + tid];
       right_state.energy       = dev_bounds_R[4 * n_cells + tid];
 #ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        dscalarr[i] = dev_bounds_R[(5 + i) * n_cells + tid];
+      for (int i = 0; i < grid_enum::nscalars; i++) {
+        Real scalar_density   = dev_bounds_R[(grid_enum::scalar + i) * n_cells + tid];
+        right_state.scalar[i] = scalar_density / right_state.density;
       }
 #endif
 #ifdef DE
@@ -126,11 +121,6 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
                             (gamma - 1.0);
 #endif  // PRESSURE_DE
       left_state.pressure = fmax(left_state.pressure, (Real)TINY_NUMBER);
-#ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        left_state.scalar[i] = dscalarl[i] / left_state.density;
-      }
-#endif
 #ifdef DE
       left_state.gas_energy = gas_energy_left / left_state.density;
 #endif
@@ -152,11 +142,6 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
                              (gamma - 1.0);
 #endif  // PRESSURE_DE
       right_state.pressure = fmax(right_state.pressure, (Real)TINY_NUMBER);
-#ifdef SCALAR
-      for (int i = 0; i < NSCALARS; i++) {
-        right_state.scalar[i] = dscalarr[i] / right_state.density;
-      }
-#endif
 #ifdef DE
       right_state.gas_energy = gas_energy_right / right_state.density;
 #endif
@@ -368,8 +353,8 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
 
 #ifdef SCALAR
         for (int i = 0; i < NSCALARS; i++) {
-          f_scalar_l[i] = dscalarl[i] * (left_state.velocity.x() - bm);
-          f_scalar_r[i] = dscalarr[i] * (right_state.velocity.x() - bp);
+          f_scalar_l[i] = left_state.scalar[i] * f_d_l;
+          f_scalar_r[i] = right_state.scalar[i] * f_d_r;
         }
 #endif
 

--- a/src/riemann_solvers/roe_cuda.cu
+++ b/src/riemann_solvers/roe_cuda.cu
@@ -70,6 +70,13 @@ __global__ void Calculate_Roe_Fluxes_CUDA(Real const *dev_conserved, Real const 
     if constexpr (reconstruction == reconstruction::Kind::pcm) {
       reconstruction::Reconstruct_Interface_States<reconstruction, direction>(dev_conserved, xid, yid, zid, nx, ny,
                                                                               n_cells, gamma, left_state, right_state);
+#ifdef SCALAR
+      // this is a hacky bugfix. The more correct solution is to eliminate dscalarl & dscalarr
+      for (int i = 0; i < NSCALARS; i++) {
+        dscalarl[i] = left_state.scalar[i] * left_state.density;
+        dscalarr[i] = right_state.scalar[i] * right_state.density;
+      }
+#endif
     } else {
       // retrieve conserved variables
       left_state.density      = dev_bounds_L[tid];


### PR DESCRIPTION
## Overview

This PR introduces bugfixes for the HLL, HLLC and Roe Riemann Solvers when computing fluxes for passive scalars and using the piecewise constant method for reconstruction. I'm pretty sure that these bug were introduced by PR #377.

This bug affects any simulation that used passive scalars AND:

- HLL, HLLC or Roe Riemann Solvers with the SIMPLE integrator and piecewise constant reconstruction (I'd be stunned if this actually happened)

- HLL, HLLC or Roe Riemann Solvers with the Van Leer integrator (since piecewise constant reconstruction is always used to predict state at the half timestep).

In practice, there were actually 2 kinds of bugs:
1. The HLLC and Roe Riemann Solver both had the same bug that produces undefined behavior when computing the passive scalar flux(es) with piecewise constant reconstruction (the computed flux used uninitialized values).
2. The HLL solver had a separate bug, that simply produced incorrect flux(es) with piecewise constant reconstruction (however, they were always wrong in a well-defined way). I stumbled onto this while addressing the other bug

> [!important]
> To be clear, the bug invoking undefined behavior was present on all systems. It just manifested differently based on the hardware/compiler-toolchain. While we only noticed it on Betty, it was DEFINITELY present on other systems!

## About the bugs

### General Background
Prior to PR #377, reconstructed values of the (magneto)hydrodynamic variables were computed for the entirety of the local grid in one kernel-call and they were subsequently used in a separate kernel call to compute fluxes.

Bob sought to change this in PR #377. He wanted to start fusing the logic for reconstruction and flux calculations into a single kernel. He made that precise change for piecewise constant reconstruction. However, the other reconstruction mechanisms are still performed ahead of time (I suspect we have a hybrid solution because he ran out of time to finish it all up).

Unfortunately, he made minor oversights in the HLL, HLLC, and Roe Riemann solvers.

### Bug in HLLC and Roe Riemann Solvers

The problem for the HLLC and Roe Riemann solvers is that a pair of vestigial temporary arrays for holding passive scalar densities (named `dscl` & `dscr` in HLLC or `dscalarl` & `dscalarr` in Roe) persisted in the flux calculations. These arrays are temporarily used for higher-order reconstruction. However, for piecewise piecewise constant reconstruction, these arrays are never initialized. Since the scalar fluxes are computed from values in these arrays, they are have undefined values with piecewise constant reconstruction.

### Bug in the HLL Riemann Solver

This bug pertains to the ``reconstruction::InterfaceState`` class:
- when reconstruction and the riemann solver are part of a fused kernel (reminder: this currently just applies to piecewise constant reconstruction), the ``reconstruction::Reconstruct_Interface_States`` function fills instances of the ``reconstruction::InterfaceState`` are filled that represent the right and left interfaces.
- for higher order reconstruction methods, all of the Riemann Solvers currently fill in the various members of the ``reconstruction::InterfaceState`` class with the corresponding values from reconstructed values that were computed ahead of time.

The problem specifically relates to the treatment of ``reconstruction::InterfaceState::scalar[i]``. The convention observed in  ``reconstruction::Reconstruct_Interface_States`` for piecewise constant reconstruction (as well as in other Riemann Solvers) is that this is a mass fraction. Unfortunately, for higher order reconstruction methods, the HLL solver filled ``reconstruction::InterfaceState::scalar[i]`` with a scalar density. Furthermore, the associated flux calculations also assumed that the quantity is a scalar density.

This means that with piecewise constant reconstruction, the HLL solver would return an incorrect scalar flux.