### PR TITLE
Reconcile cosmo-ics with dev

### DIFF
--- a/config/make.type.cosmology
+++ b/config/make.type.cosmology
@@ -10,11 +10,11 @@ DFLAGS += -DCOSMOLOGY
 
 
 # Include the FFT subroutines
-#DFLAGS += -DFFT
+DFLAGS += -DFFT
 
 
 # Solve the Primordial Chemical Network (H+He) on the GPU (Includes Radiative Cooling, Photoheating and Photoionization)
-#DFLAGS += -DCHEMISTRY_GPU -DOUTPUT_TEMPERATURE -DOUTPUT_CHEMISTRY
+DFLAGS += -DCHEMISTRY_GPU -DOUTPUT_TEMPERATURE -DOUTPUT_CHEMISTRY
 
 
 # Perform In-The-Fly analysis of Cosmological Simulations

--- a/config/make.type.cosmology
+++ b/config/make.type.cosmology
@@ -10,11 +10,11 @@ DFLAGS += -DCOSMOLOGY
 
 
 # Include the FFT subroutines
-DFLAGS += -DFFT
+#DFLAGS += -DFFT
 
 
 # Solve the Primordial Chemical Network (H+He) on the GPU (Includes Radiative Cooling, Photoheating and Photoionization)
-DFLAGS += -DCHEMISTRY_GPU -DOUTPUT_TEMPERATURE -DOUTPUT_CHEMISTRY
+#DFLAGS += -DCHEMISTRY_GPU -DOUTPUT_TEMPERATURE -DOUTPUT_CHEMISTRY
 
 
 # Perform In-The-Fly analysis of Cosmological Simulations

--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -37,7 +37,7 @@ void Grid3D::Initialize_Chemistry(struct Parameters *P)
     if (P->YHe != 0) {
       Chem.H.H_fraction = 1.0 - P->YHe;
       // CHOLLA_ERROR("About to initialize Chem.H.H_fraction incorrectly (P->YHe = %e)", P->YHe);
-    }else{
+    } else {
       Chem.H.H_fraction = INITIAL_FRACTION_HI + INITIAL_FRACTION_HII;
     }
   }

--- a/src/chemistry_gpu/chemistry_functions.cpp
+++ b/src/chemistry_gpu/chemistry_functions.cpp
@@ -35,9 +35,11 @@ void Grid3D::Initialize_Chemistry(struct Parameters *P)
 
   if (Chem.H.H_fraction == 0) {
     if (P->YHe != 0) {
-      CHOLLA_ERROR("About to initialize Chem.H.H_fraction incorrectly (P->YHe = %e)", P->YHe);
+      Chem.H.H_fraction = 1.0 - P->YHe;
+      // CHOLLA_ERROR("About to initialize Chem.H.H_fraction incorrectly (P->YHe = %e)", P->YHe);
+    }else{
+      Chem.H.H_fraction = INITIAL_FRACTION_HI + INITIAL_FRACTION_HII;
     }
-    Chem.H.H_fraction = INITIAL_FRACTION_HI + INITIAL_FRACTION_HII;
   }
 
   #ifdef COSMOLOGY

--- a/src/cosmology/cosmological_ics.cu
+++ b/src/cosmology/cosmological_ics.cu
@@ -320,7 +320,7 @@ void Grid3D::Save_Cosmo_Potential(struct Parameters const *P)
   Real *phi_out;  // output cosmological potential
 
   // Create a file name for each hdf5 output
-  sprintf(fname, "%s0/delta_ini.h5.%d", P->outdir, procID);
+  sprintf(fname, "delta_ini.h5.%d", procID);
 
   // create a file
   f_id = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/cosmology/cosmological_ics.cu
+++ b/src/cosmology/cosmological_ics.cu
@@ -320,7 +320,7 @@ void Grid3D::Save_Cosmo_Potential(struct Parameters const *P)
   Real *phi_out;  // output cosmological potential
 
   // Create a file name for each hdf5 output
-  sprintf(fname, "delta_ini.h5.%d", procID);
+  sprintf(fname, "%s0/delta_ini.h5.%d", P->outdir, procID);
 
   // create a file
   f_id = H5Fcreate(fname, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);

--- a/src/cosmology/cosmological_ics.cu
+++ b/src/cosmology/cosmological_ics.cu
@@ -494,7 +494,7 @@ void Grid3D::Initialize_Cosmo_Potential_RNG(struct Parameters *P)
   int n_cells = nx_local * ny_local * nz_local;
 
   // Record the RNG seed from the parameter file
-  CP.rng_seed = P->cosmoics_seed;
+  CP.rng_seed = P->cosmo_ics_seed;
 
   // Call the RNG initialization function on the GPUs
   GPU_Error_Check(cudaMalloc((void **)&rng_states, n_cells * sizeof(rng_parallel_state_t)));
@@ -734,7 +734,7 @@ void Grid3D::Generate_Normal_Random_Field(Real *d_field, struct Parameters *P, r
   cuda_utilities::AutomaticLaunchParams static const launchParams(RNG_Normal_Field_GPU, n_cells);
   hipLaunchKernelGGL(RNG_Normal_Field_GPU, launchParams.get_numBlocks(), launchParams.get_threadsPerBlock(), 0, 0,
                      d_field, nx_local, ny_local, nz_local, nx_local_start, ny_local_start, nz_local_start, P->nx,
-                     P->ny, P->nz, P->cosmoics_seed, rng_states);
+                     P->ny, P->nz, P->cosmo_ics_seed, rng_states);
 }
 
 void Grid3D::Rescale_Field(Real *d_x, Real A)

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -356,15 +356,15 @@ Parameters::Parameters(ParameterMap &pmap)
   // it turns out that Init_redshift is only needed for special test-problems
   // -> it commonly isn't given a value.
   // -> Since it never had a default value before, we have it fall back to an obviously wrong value
-  parms->Init_redshift = pmap.value_or("Init_redshift", -1.0);
-  parms->H0            = pmap.value<double>("H0");
-  parms->Omega_M       = pmap.value<double>("Omega_M");
-  parms->Omega_L       = pmap.value<double>("Omega_L");
-  parms->Omega_b       = pmap.value<double>("Omega_b");
-  parms->Omega_R       = pmap.value_or("Omega_R", 0.0);
-  parms->T_init        = pmap.value_or("T_init", -1.0);
-  parms->w0            = pmap.value_or("w0", -1.0);
-  parms->wa            = pmap.value_or("wa", 0.0);
+  parms->Init_redshift  = pmap.value_or("Init_redshift", -1.0);
+  parms->H0             = pmap.value<double>("H0");
+  parms->Omega_M        = pmap.value<double>("Omega_M");
+  parms->Omega_L        = pmap.value<double>("Omega_L");
+  parms->Omega_b        = pmap.value<double>("Omega_b");
+  parms->Omega_R        = pmap.value_or("Omega_R", 0.0);
+  parms->T_init         = pmap.value_or("T_init", -1.0);
+  parms->w0             = pmap.value_or("w0", -1.0);
+  parms->wa             = pmap.value_or("wa", 0.0);
   parms->cosmo_ics_seed = pmap.value_or("cosmo_ics_seed", 1337);
   // Hydrogen, Helium ionization fractions and helium mass fraction
   parms->YHe           = pmap.value_or("YHe", 0.24);

--- a/src/global/global.cpp
+++ b/src/global/global.cpp
@@ -365,7 +365,7 @@ Parameters::Parameters(ParameterMap &pmap)
   parms->T_init        = pmap.value_or("T_init", -1.0);
   parms->w0            = pmap.value_or("w0", -1.0);
   parms->wa            = pmap.value_or("wa", 0.0);
-  parms->cosmoics_seed = pmap.value_or("cosmoics_seed", 1337);
+  parms->cosmo_ics_seed = pmap.value_or("cosmo_ics_seed", 1337);
   // Hydrogen, Helium ionization fractions and helium mass fraction
   parms->YHe           = pmap.value_or("YHe", 0.24);
   parms->xHp_ion_init  = pmap.value_or("xHp_ion_init", 0.0);

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -273,8 +273,8 @@ struct Parameters {
   int zug_bcnd;
 #endif /*MPI_CHOLLA*/
   char custom_bcnd[MAXLEN];
-  char indir[MAXLEN];  // Folder to load Initial conditions from
-  char outdir[MAXLEN]; // Folder where output data is written
+  char indir[MAXLEN];   // Folder to load Initial conditions from
+  char outdir[MAXLEN];  // Folder where output data is written
   Real rho;
   Real vx;
   Real vy;
@@ -322,7 +322,7 @@ struct Parameters {
 #endif  // PARTICLES
 
 #if defined(CHEMISTRY_GPU) || defined(COSMOLOGY)
-  Real YHe;            // helium mass fraction
+  Real YHe;  // helium mass fraction
 #endif
 #ifdef COSMOLOGY
   Real H0;

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -274,7 +274,7 @@ struct Parameters {
 #endif /*MPI_CHOLLA*/
   char custom_bcnd[MAXLEN];
   char indir[MAXLEN];  // Folder to load Initial conditions from
-  char outdir[MAXLEN];  // Folder to load Initial conditions from
+  char outdir[MAXLEN]; // Folder where output data is written
   Real rho;
   Real vx;
   Real vy;

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -334,7 +334,7 @@ struct Parameters {
   Real Init_redshift;
   Real End_redshift;
   Real T_init;
-  unsigned long long cosmoics_seed;  // Cosmological ICs seed
+  unsigned long long cosmo_ics_seed;  // Cosmological ICs seed
   char cosmo_ics_pk_file[MAXLEN];
   Real xHp_ion_init;   // hydrogen ionization fraction
   Real xHep_ion_init;  // helium ionization fraction

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -274,6 +274,7 @@ struct Parameters {
 #endif /*MPI_CHOLLA*/
   char custom_bcnd[MAXLEN];
   char indir[MAXLEN];  // Folder to load Initial conditions from
+  char outdir[MAXLEN];  // Folder to load Initial conditions from
   Real rho;
   Real vx;
   Real vy;

--- a/src/global/global.h
+++ b/src/global/global.h
@@ -320,8 +320,8 @@ struct Parameters {
   std::uint_fast64_t prng_seed = 0;
 #endif  // PARTICLES
 
-#ifdef CHEMISTRY_GPU
-  Real YHe;
+#if defined(CHEMISTRY_GPU) || defined(COSMOLOGY)
+  Real YHe;            // helium mass fraction
 #endif
 #ifdef COSMOLOGY
   Real H0;
@@ -336,7 +336,6 @@ struct Parameters {
   Real T_init;
   unsigned long long cosmoics_seed;  // Cosmological ICs seed
   char cosmo_ics_pk_file[MAXLEN];
-  Real YHe;            // helium mass fraction
   Real xHp_ion_init;   // hydrogen ionization fraction
   Real xHep_ion_init;  // helium ionization fraction
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
   if (is_restart) {
     chprintf("Input directory:  %s\n", P.indir);
   }
-  std::strncpy(P.outdir, writer_manager.fname_template().nominal_output_dir_path().c_str(), sizeof(P.outdir)-1);
+  std::strncpy(P.outdir, writer_manager.fname_template().nominal_output_dir_path().c_str(), sizeof(P.outdir) - 1);
   chprintf("Output directory:  %s\n", P.outdir);
 
   // Check the configuration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -118,7 +118,6 @@ int main(int argc, char *argv[])
     chprintf("Input directory:  %s\n", P.indir);
   }
   std::strncpy(P.outdir, writer_manager.fname_template().nominal_output_dir_path().c_str(), sizeof(P.outdir)-1);
-  chprintf("Output directory:  %s\n", writer_manager.fname_template().nominal_output_dir_path().c_str());
   chprintf("Output directory:  %s\n", P.outdir);
 
   // Check the configuration

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,9 @@ int main(int argc, char *argv[])
   if (is_restart) {
     chprintf("Input directory:  %s\n", P.indir);
   }
+  std::strncpy(P.outdir, writer_manager.fname_template().nominal_output_dir_path().c_str(), sizeof(P.outdir)-1);
   chprintf("Output directory:  %s\n", writer_manager.fname_template().nominal_output_dir_path().c_str());
+  chprintf("Output directory:  %s\n", P.outdir);
 
   // Check the configuration
   Check_Configuration(P);

--- a/src/rk/rk4.cpp
+++ b/src/rk/rk4.cpp
@@ -88,6 +88,7 @@ void RKIntegrator::rk4_ode(std::vector<Real> (*dydx)(Real x, const std::vector<R
       }
     }
 
+    max_error = 0;
     for (int k = 0; k < ny; k++) {
       error = (yp[k] - yprime[k]);
 


### PR DESCRIPTION
The merge process with dev broke a few things with cosmo-ics, which this PR attempts to fix. This is a small, targeted PR meant to actually enable the cosmological ICs to run.

* The behavior of the Runge-Kutta scheme changed. We've reinitialized a variable inside a loop and it seems to work.
* A check in `chemistry_functions.cpp` now is triggered regarding how / whether `H_fraction` is set. I think there is an initialization step that must have been removed somehow. I've added this back.
* There were two `YHe` declared in global.h.

Minor item:
* Renamed `cosmoics_seed` to `cosmo_ics_seed`.

Output directory
* The Parameter member `P.outdir` was removed and replaced with `writer_manager.fname_template().nominal_output_dir_path().c_str()`. This is not very user friendly, and seems to require the API to the initialization functions to be re-written if you want to write a file during initialization. Instead of making those more extensive changes, I added `P.outdir` back and then just copy the writer manager result into it. I don't seem the harm in this, so hopefully that is a minor addition that will pass muster.

