### PR TITLE
WIP: Delete `PARIS_3PT` and `PARIS_5PT` macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,6 @@ ifeq ($(findstring -DPARIS,$(DFLAGS)),-DPARIS)
       LIBS += -lcufft
     endif
   endif
-  ifeq ($(findstring -DGRAVITY_5_POINTS_GRADIENT,$(DFLAGS)),-DGRAVITY_5_POINTS_GRADIENT)
-    DFLAGS += -DPARIS_5PT
-  else
-    DFLAGS += -DPARIS_3PT
-  endif
 endif
 
 ifeq ($(findstring -DFEEDBACK,$(DFLAGS)),-DFEEDBACK)

--- a/docs/sphinx/Physics/Gravity.md
+++ b/docs/sphinx/Physics/Gravity.md
@@ -63,10 +63,6 @@ In general, this module relies on a particle-mesh scheme. Broadly speaking, for 
 
 ``GRAVITY_ANALYTIC_COMP``: Add an analytic component to the gravitational potential. As of 10-27-2023, this is hard-coded to a Milky Way galaxy model in the function `Setup_Analytic_Potential` from [gravity_functions.cpp](https://github.com/cholla-hydro/cholla/blob/dev/src/gravity/gravity_functions.cpp). 
 
-``PARIS_3PT``: Use a 3-point gradient for the divergence operator approximation in Paris (default behavior is to use a spectral method)
-
-``PARIS_5PT``: Use a 5-point gradient for the divergence operator approximation in Paris
-
 ``PARIS_GALACTIC``: Use the Paris Poisson solver on a domain with analytic boundaries set to match the selected model in the DiskGalaxy class.
 As of 10-27-2023, this is hard-coded to a Milky Way galaxy model in the function `Compute_Gravitational_Potential` from [gravity_functions.cpp](https://github.com/cholla-hydro/cholla/blob/dev/src/gravity/gravity_functions.cpp) and in `Compute_Potential_Isolated_Boundary` from [gravity_boundaries.cpp](https://github.com/cholla-hydro/cholla/blob/dev/src/gravity/gravity_boundaries.cpp).
 

--- a/src/cholla_config.h.in
+++ b/src/cholla_config.h.in
@@ -131,11 +131,6 @@
 #configurefile_define PARIS_NO_GPU_MPI
 #configurefile_define SOR
 #configurefile_define STATIC_GRAV
-#if defined(PARIS) && defined(GRAVITY_5_POINTS_GRADIENT)
-#define PARIS_5PT
-#elif defined(PARIS)
-#define PARIS_3PT
-#endif
 
 
 // ======================

--- a/src/cholla_config.h.in
+++ b/src/cholla_config.h.in
@@ -127,12 +127,16 @@
 #configurefile_define GRAVITY_GPU
 #configurefile_define GRAVITY_LONG_INTS
 #configurefile_define PARIS
-#configurefile_define PARIS_3PT
-#configurefile_define PARIS_5PT
 #configurefile_define PARIS_GALACTIC
 #configurefile_define PARIS_NO_GPU_MPI
 #configurefile_define SOR
 #configurefile_define STATIC_GRAV
+#if defined(PARIS) && defined(GRAVITY_5_POINTS_GRADIENT)
+#define PARIS_5PT
+#elif defined(PARIS)
+#define PARIS_3PT
+#endif
+
 
 // ======================
 // Feedback Configuration

--- a/src/gravity/paris/ParisPeriodic.cu
+++ b/src/gravity/paris/ParisPeriodic.cu
@@ -10,20 +10,16 @@ ParisPeriodic::ParisPeriodic(const int n[3], const double lo[3], const double hi
                              double dx)
     : ni_(n[0]),
       nj_(n[1]),
-  #ifdef PARIS_3PT
+  #ifndef GRAVITY_5_POINTS_GRADIENT
       nk_(n[2]),
       ddi_(2.0 * double(n[0] - 1) / (hi[0] - lo[0])),
       ddj_(2.0 * double(n[1] - 1) / (hi[1] - lo[1])),
       ddk_(2.0 * double(n[2] - 1) / (hi[2] - lo[2])),
-  #elif defined PARIS_5PT
+  #else
       nk_(n[2]),
       ddi_(Sqr(double(n[0] - 1) / (hi[0] - lo[0])) / 6.0),
       ddj_(Sqr(double(n[1] - 1) / (hi[1] - lo[1])) / 6.0),
       ddk_(Sqr(double(n[2] - 1) / (hi[2] - lo[2])) / 6.0),
-  #else
-      ddi_{2.0 * M_PI * double(n[0] - 1) / (double(n[0]) * (hi[0] - lo[0]))},
-      ddj_{2.0 * M_PI * double(n[1] - 1) / (double(n[1]) * (hi[1] - lo[1]))},
-      ddk_{2.0 * M_PI * double(n[2] - 1) / (double(n[2]) * (hi[2] - lo[2]))},
   #endif
       henry(n, lo, hi, m, id),
       dx_(dx),                                                                  // RT
@@ -40,12 +36,12 @@ void ParisPeriodic::solve(const size_t bytes, double *const density, double *con
   const double ddi = ddi_, ddj = ddj_, ddk = ddk_;
 
   // Poisson-solve constants that depend on divergence-operator approximation
-  #ifdef PARIS_3PT
+  #ifndef GRAVITY_5_POINTS_GRADIENT
   const int nk    = nk_;
   const double si = M_PI / double(ni);
   const double sj = M_PI / double(nj);
   const double sk = M_PI / double(nk);
-  #elif defined PARIS_5PT
+  #else
   const int nk    = nk_;
   const double si = 2.0 * M_PI / double(ni);
   const double sj = 2.0 * M_PI / double(nj);
@@ -56,21 +52,17 @@ void ParisPeriodic::solve(const size_t bytes, double *const density, double *con
   henry.filter(bytes, density, potential,
                [=] __device__(const int i, const int j, const int k, const cufftDoubleComplex b) {
                  if (i || j || k) {
-  #ifdef PARIS_3PT
+  #ifndef GRAVITY_5_POINTS_GRADIENT
                    const double i2 = Sqr(sin(double(min(i, ni - i)) * si) * ddi);
                    const double j2 = Sqr(sin(double(min(j, nj - j)) * sj) * ddj);
                    const double k2 = Sqr(sin(double(k) * sk) * ddk);
-  #elif defined PARIS_5PT
+  #else
           const double ci = cos(double(min(i, ni - i)) * si);
           const double cj = cos(double(min(j, nj - j)) * sj);
           const double ck = cos(double(k) * sk);
           const double i2 = ddi * (2.0 * ci * ci - 16.0 * ci + 14.0);
           const double j2 = ddj * (2.0 * cj * cj - 16.0 * cj + 14.0);
           const double k2 = ddk * (2.0 * ck * ck - 16.0 * ck + 14.0);
-  #else
-          const double i2 = Sqr(double(min(i, ni - i)) * ddi);
-          const double j2 = Sqr(double(min(j, nj - j)) * ddj);
-          const double k2 = Sqr(double(k) * ddk);
   #endif
                    const double d = -1.0 / (i2 + j2 + k2);
                    return cufftDoubleComplex{d * b.x, d * b.y};

--- a/src/gravity/paris/ParisPeriodic.hpp
+++ b/src/gravity/paris/ParisPeriodic.hpp
@@ -48,10 +48,7 @@ class ParisPeriodic
 #endif  // RT
 
  private:
-  int ni_, nj_;  //!< Number of elements in X and Y dimensions
-#if defined(PARIS_3PT) || defined(PARIS_5PT)
-  int nk_;  //!< Number of elements in Z dimension
-#endif
+  int ni_, nj_, nk_;                //!< Number of elements in X, Y, and Z dimensions
   double ddi_, ddj_, ddk_;          //!< Frequency-independent terms in Poisson solve
   double dx_, dd2i_, dd2j_, dd2k_;  //!< Frequency-independent terms in Poisson solve, for RT
   HenryPeriodic henry;              //!< FFT filter object

--- a/src/gravity/potential_paris_3D.cu
+++ b/src/gravity/potential_paris_3D.cu
@@ -214,12 +214,10 @@ void PotentialParis3D::Initialize(const Real lx, const Real ly, const Real lz, c
                                   const int nyReal, const int nzReal, const Real dx, const Real dy, const Real dz)
 {
   chprintf(" Using Poisson Solver: Paris Periodic");
-  #ifdef PARIS_5PT
+  #ifdef GRAVITY_5_POINTS_GRADIENT
   chprintf(" 5-Point\n");
-  #elif defined PARIS_3PT
-  chprintf(" 3-Point\n");
   #else
-  chprintf(" Spectral\n");
+  chprintf(" 3-Point\n");
   #endif
 
   const long nl012 = long(nxReal) * long(nyReal) * long(nzReal);


### PR DESCRIPTION
The goal of this PR is straight-forward:
- prior to this PR, we would always define `PARIS_5PT` or `PARIS_3PT` based on whether `GRAVITY_5_POINTS_GRADIENT` was defined or not.
- This PR effectively replaces all checks for whether `PARIS_5PT` or `PARIS_3PT` is defined with a check for whether `GRAVITY_5_POINTS_GRADIENT` is defined.

Based on a discussion with Trey and Brant I'm going to adjust this PR so that we retain the Paris Solver's logic when neither `PARIS_5PT` or `PARIS_3PT` is defined. [^1]

[^1]: I haven't fully decided how to proceed yet. I may simply drop the second commit (the first commit is still useful since it shifts the logic for controlling whether `PARIS_3PT` or `PARIS_5PT` was defined got moved out of the Makefile and into `cholla_config.h`)