### PR TITLE
Factor out mutable state from `Header`

### DIFF
--- a/src/cosmology/cosmology_functions.cpp
+++ b/src/cosmology/cosmology_functions.cpp
@@ -22,7 +22,7 @@ void Grid3D::Initialize_Cosmology(struct Parameters *P)
   Change_Cosmological_Frame_System(true);
 
   if (fabs(Cosmo.current_a - Cosmo.next_output) < 1e-5) {
-    H.Output_Now = true;
+    state.Output_Now = true;
   }
 
   if (strcmp(P->init, "Cosmological_ICs") == 0) {

--- a/src/gravity/gravity_functions.cpp
+++ b/src/gravity/gravity_functions.cpp
@@ -84,14 +84,14 @@ void Grid3D::set_dt_Gravity()
 
   // Limit delta_a if it's time to output
   if ((Cosmo.current_a + da_min) > Cosmo.next_output) {
-    da_min       = Cosmo.next_output - Cosmo.current_a;
-    H.Output_Now = true;
+    da_min           = Cosmo.next_output - Cosmo.current_a;
+    state.Output_Now = true;
   }
 
       #ifdef ANALYSIS
   // Limit delta_a if it's time to run analysis
   if (Analysis.next_output_indx < Analysis.n_outputs) {
-    if (H.Output_Now && fabs(Cosmo.current_a + da_min - Analysis.next_output) < 1e-6)
+    if (state.Output_Now && fabs(Cosmo.current_a + da_min - Analysis.next_output) < 1e-6)
       Analysis.Output_Now = true;
     else if (Cosmo.current_a + da_min > Analysis.next_output) {
       da_min              = Analysis.next_output - Cosmo.current_a;

--- a/src/grid/boundary_conditions.cpp
+++ b/src/grid/boundary_conditions.cpp
@@ -25,9 +25,9 @@ void Grid3D::Set_Boundary_Conditions_Grid(Parameters P)
   #ifdef CPU_TIME
   Timer.Boundaries.Start();
   #endif  // CPU_TIME
-  H.TRANSFER_HYDRO_BOUNDARIES = true;
+  state.TRANSFER_HYDRO_BOUNDARIES = true;
   Set_Boundary_Conditions(P);
-  H.TRANSFER_HYDRO_BOUNDARIES = false;
+  state.TRANSFER_HYDRO_BOUNDARIES = false;
   #ifdef CPU_TIME
   Timer.Boundaries.End();
   #endif  // CPU_TIME
@@ -55,7 +55,7 @@ void Grid3D::Set_Boundary_Conditions(Parameters P)
 {
   // Check Only one boundary type id being transferred
   int n_bounds = 0;
-  n_bounds += (int)H.TRANSFER_HYDRO_BOUNDARIES;
+  n_bounds += (int)state.TRANSFER_HYDRO_BOUNDARIES;
 #ifdef GRAVITY
   n_bounds += (int)Grav.TRANSFER_POTENTIAL_BOUNDARIES;
   #ifdef SOR
@@ -72,7 +72,7 @@ void Grid3D::Set_Boundary_Conditions(Parameters P)
         "ERROR: More than one boundary type for transfer. N boundary types: "
         "%d\n",
         n_bounds);
-    printf(" Boundary Hydro: %d\n", (int)H.TRANSFER_HYDRO_BOUNDARIES);
+    printf(" Boundary Hydro: %d\n", (int)state.TRANSFER_HYDRO_BOUNDARIES);
 #ifdef GRAVITY
     printf(" Boundary Potential: %d\n", (int)Grav.TRANSFER_POTENTIAL_BOUNDARIES);
   #ifdef SOR

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -205,9 +205,6 @@ void Grid3D::Initialize(struct Parameters *P)
   // are transferred
   H.TRANSFER_HYDRO_BOUNDARIES = false;
 
-  // Set output to true when data has to be written to file;
-  H.Output_Now = false;
-
 // Values for lower limit for density and temperature
 #ifdef TEMPERATURE_FLOOR
   H.temperature_floor = P->temperature_floor;

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -201,10 +201,6 @@ void Grid3D::Initialize(struct Parameters *P)
   // and initialize the timestep
   H.dt = 0.0;
 
-  // Set Transfer flag to false, only set to true before Conserved boundaries
-  // are transferred
-  H.TRANSFER_HYDRO_BOUNDARIES = false;
-
 // Values for lower limit for density and temperature
 #ifdef TEMPERATURE_FLOOR
   H.temperature_floor = P->temperature_floor;

--- a/src/grid/grid3D.cpp
+++ b/src/grid/grid3D.cpp
@@ -231,7 +231,7 @@ void Grid3D::Initialize(struct Parameters *P)
   #endif
 #endif
 
-  H.Output_Initial = true;
+  state.Output_Initial = true;
 
   Set_Domain_Properties(*P);  // move the domain info forward
 

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -91,6 +91,14 @@ struct SimRuntimeState {
    *  on-the-fly analysis)
    */
   bool Output_Now = false;
+
+  /*! \brief set to true to dump all data to file (i.e. checkpoint files for restarts)
+   *
+   *  \todo
+   *  Stop tracking this as part of the Grid object. This variable is only used within
+   *  the io machinery and could be passed around as an argument.
+   */
+  bool Output_Complete_Data = false;
 };
 
 struct Header {
@@ -246,11 +254,6 @@ struct Header {
 #ifdef COSMOLOGY
   bool OUTPUT_SCALE_FACTOR;
 #endif
-
-  /*! \var Output_Complete_Data
-   *  \brief Flag set to true when all the data will  be written to file
-   * (Restart File ) */
-  bool Output_Complete_Data;
 
 #ifdef SCALAR
   #ifdef DUST

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -61,6 +61,29 @@
 
 class AttrRecorderInterface;
 
+/*! \brief This class tracks state that can be mutated by various components of the sim
+ *
+ *  In the vast majority of cases, it should not be necessary to add a mutable state
+ *  variable. But, if you must start tracking such a variable, please track it within
+ *  this struct.
+ *
+ *  \note
+ *  A central theme among these values is that they are modified in at least one
+ *  location outside of the top-level runtime loop. The quantites like the number of
+ *  complete cycles, the current sim time, the current timestep, and the elapsed
+ *  wall-clock time seem like they belong to a special category of variables (but maybe
+ *  we will revisit this distinction in the future?).
+ */
+struct SimRuntimeState {
+  /*! \brief set to true as we set up Cholla to customize the very first output
+   *
+   * \note
+   * This is only used with cosmology simulations. It would be very easy to get rid of
+   * this parameter.
+   */
+  bool Output_Initial = false;
+};
+
 struct Header {
   /*! \var n_cells
    *  \brief Total number of cells in the grid (including ghost cells) */
@@ -218,7 +241,6 @@ struct Header {
   /*! \var Output_Now
    *  \brief Flag set to true when data has to be written to file */
   bool Output_Now;
-  bool Output_Initial;
 
   /*! \var Output_Complete_Data
    *  \brief Flag set to true when all the data will  be written to file
@@ -244,6 +266,9 @@ class Grid3D
   /*! \var struct Header H
    *  \brief Header for the grid */
   struct Header H;
+
+  /*! tracks mutable runtime state */
+  SimRuntimeState state;
 
   /*! Describes the mapping between field names and field indices */
   FieldInfo field_info;

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -82,6 +82,15 @@ struct SimRuntimeState {
    * this parameter.
    */
   bool Output_Initial = false;
+
+  /*! \brief set to true to write data to file at end of current cycle
+   *
+   *  This is primarily tracked within \ref Grid3D to allow various simulation
+   *  components to trigger outputs at various times (at the time of writing, these
+   *  times typical pertain to particular cosmological times and moments relevant for
+   *  on-the-fly analysis)
+   */
+  bool Output_Now = false;
 };
 
 struct Header {
@@ -237,10 +246,6 @@ struct Header {
 #ifdef COSMOLOGY
   bool OUTPUT_SCALE_FACTOR;
 #endif
-
-  /*! \var Output_Now
-   *  \brief Flag set to true when data has to be written to file */
-  bool Output_Now;
 
   /*! \var Output_Complete_Data
    *  \brief Flag set to true when all the data will  be written to file

--- a/src/grid/grid3D.h
+++ b/src/grid/grid3D.h
@@ -99,6 +99,24 @@ struct SimRuntimeState {
    *  the io machinery and could be passed around as an argument.
    */
   bool Output_Complete_Data = false;
+
+  /*! \brief true indicates that Conserved boundaries should be transferred
+   *
+   *  This is **ONLY** set to true just before Conserved boundaries are transferred
+   *  (and is immediately reverted to false when that work is done).
+   *
+   *  \todo
+   *  We should give some thought to refactoring this data member:
+   *  - rather tracking this as one of 5 different boolean flags in different places
+   *    (other flags are for transferring Particles or Gravitational Potential), that
+   *    must all remain somewhat synchronized, we should probably replace all of the
+   *    boolean flags with a single enum-flag.
+   *  - under the current implementation, a compelling case could be made to entirely
+   *    get rid of this data-member. It seems like we can probably pass this information
+   *    as an argument to \ref Grid3D::Set_Boundary_Conditions (this would certainly be
+   *    more explicit).
+   */
+  bool TRANSFER_HYDRO_BOUNDARIES = false;
 };
 
 struct Header {
@@ -229,9 +247,6 @@ struct Header {
   Real scalar_floor;
 
   Real Ekin_avrg;
-
-  // Flag to indicate when to transfer the Conserved boundaries
-  bool TRANSFER_HYDRO_BOUNDARIES;
 
   // Parameters For Spherical Colapse Problem
   Real sphere_density;

--- a/src/grid/mpi_boundaries.cpp
+++ b/src/grid/mpi_boundaries.cpp
@@ -325,7 +325,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
   if (dir == 0) {
     if (flags[0] == 5) {
       // load left x communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_X0(d_send_buffer_x0);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_x0, d_send_buffer_x0, xbsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -395,7 +395,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
 
     if (flags[1] == 5) {
       // load right x communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_X1(d_send_buffer_x1);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_x1, d_send_buffer_x1, xbsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -476,7 +476,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
   if (dir == 1) {
     if (flags[2] == 5) {
       // load left y communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_Y0(d_send_buffer_y0);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_y0, d_send_buffer_y0, ybsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -548,7 +548,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
 
     if (flags[3] == 5) {
       // load right y communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_Y1(d_send_buffer_y1);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_y1, d_send_buffer_y1, ybsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -628,7 +628,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
   if (dir == 2) {
     if (flags[4] == 5) {
       // left z communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_Z0(d_send_buffer_z0);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_z0, d_send_buffer_z0, zbsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -699,7 +699,7 @@ void Grid3D::Load_and_Send_MPI_Comm_Buffers(int dir, int *flags)
 
     if (flags[5] == 5) {
       // load right z communication buffer
-      if (H.TRANSFER_HYDRO_BOUNDARIES) {
+      if (state.TRANSFER_HYDRO_BOUNDARIES) {
         buffer_length = Load_Hydro_DeviceBuffer_Z1(d_send_buffer_z1);
   #ifndef MPI_GPU
         cudaMemcpy(h_send_buffer_z1, d_send_buffer_z1, zbsize * sizeof(Real), cudaMemcpyDeviceToHost);
@@ -840,7 +840,7 @@ void Grid3D::Unload_MPI_Comm_Buffers(int index)
   Grid3D_PMF_UnloadGravityPotential Fptr_Unload_Gravity_Potential;
   Grid3D_PMF_UnloadParticleDensity Fptr_Unload_Particle_Density;
 
-  if (H.TRANSFER_HYDRO_BOUNDARIES) {
+  if (state.TRANSFER_HYDRO_BOUNDARIES) {
   #ifndef MPI_GPU
     copyHostToDeviceReceiveBuffer(index);
   #endif

--- a/src/io/FieldWriter.cpp
+++ b/src/io/FieldWriter.cpp
@@ -308,7 +308,7 @@ void Write_Fields_to_HDF5_helper_(const std::string& filename, Grid3D& G, const 
       Write_HDF5_Field_3D(H.nx, H.ny, nx_dset, ny_dset, nz_dset, H.n_ghost, file_id, host_dataset_buf, dev_dataset_buf,
                           ptr, cur_spec.name.c_str());
     } else {
-      if (cur_spec.condition == io::WriteCond::REQUIRE_COMPLETE_DATA && not H.Output_Complete_Data) continue;
+      if (cur_spec.condition == io::WriteCond::REQUIRE_COMPLETE_DATA && not G.state.Output_Complete_Data) continue;
       if (cur_spec.io_buf == field::IOBuf::HOST) {
         Real* ptr = &G.C.host[cur_spec.field_id * H.n_cells];
         Write_Grid_HDF5_Field_CPU(H, file_id, host_dataset_buf, ptr, cur_spec.name.c_str());
@@ -334,7 +334,7 @@ void Write_Fields_to_HDF5_helper_(const std::string& filename, Grid3D& G, const 
         Write_HDF5_Field_3D(H.nx, H.ny, nx_dset + 1, ny_dset + 1, nz_dset + 1, H.n_ghost - 1, file_id, host_dataset_buf,
                             dev_dataset_buf, ptr, dset_names[i]);
       } else {
-        if (not H.Output_Complete_Data) continue;
+        if (not G.state.Output_Complete_Data) continue;
         int real_shape[3] = {H.nx_real + (i == 0), H.ny_real + (i == 1), H.nz_real + (i == 2)};
         Write_HDF5_Field_3D(H.nx, H.ny, real_shape[0], real_shape[1], real_shape[2], H.n_ghost, file_id,
                             host_dataset_buf, dev_dataset_buf, ptr, dset_names[i], i);
@@ -441,7 +441,7 @@ int Record_Colnames_And_Get_Field_Ptrs_(const Real** ptr_arr, bool* is_cell_cent
     CHOLLA_ASSERT(entry.io_buf == field::IOBuf::HOST, "io_buf sanity check failed!");
     CHOLLA_ASSERT(field_info.is_cell_centered(entry.field_id).value_or(false), "field-centering sanity-check failed!");
 
-    if (entry.condition == io::WriteCond::REQUIRE_COMPLETE_DATA and not H.Output_Complete_Data) {
+    if (entry.condition == io::WriteCond::REQUIRE_COMPLETE_DATA and not G.state.Output_Complete_Data) {
       continue;
     }
 
@@ -519,7 +519,7 @@ void Write_Grid_Text_(const std::string& filename, const Grid3D& G, const Datase
   // Part 2: collect info about each field & write the initial header for the text file
   // ----------------------------------------------------------------------------------
   // these arrays will hold entries for each field that we want to serialize
-  // (the precise details may depend upon G.H.Output_Complete_Data)
+  // (the precise details may depend upon G.state.Output_Complete_Data)
   const Real* ptr_arr[MAX_FIELDS];
   bool is_cell_centered[MAX_FIELDS];
   int n_output_fields = Record_Colnames_And_Get_Field_Ptrs_(ptr_arr, is_cell_centered, fp, dataset_spec, G);

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -104,15 +104,15 @@ void Write_Data(Grid3D &G, struct Parameters P, int nfile, const io::WriterManag
 #ifdef N_OUTPUT_COMPLETE
   // If nfile is multiple of N_OUTPUT_COMPLETE then output all data
   if (nfile % N_OUTPUT_COMPLETE == 0) {
-    G.H.Output_Complete_Data = true;
+    G.state.Output_Complete_Data = true;
     chprintf(" Writing all data ( Restart File ).\n");
   } else {
-    G.H.Output_Complete_Data = false;
+    G.state.Output_Complete_Data = false;
   }
 
 #else
   // If NOT N_OUTPUT_COMPLETE: always output complete data
-  G.H.Output_Complete_Data = true;
+  G.state.Output_Complete_Data = true;
 #endif
 
 #ifdef COSMOLOGY

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -127,12 +127,12 @@ void Write_Data(Grid3D &G, struct Parameters P, int nfile, const io::WriterManag
   write_manager.Apply_Writers(G, P, nfile);
 
 #ifdef COSMOLOGY
-  if (G.H.OUTPUT_SCALE_FACTOR || G.H.Output_Initial) {
+  if (G.H.OUTPUT_SCALE_FACTOR || G.state.Output_Initial) {
     G.Cosmo.Set_Next_Scale_Output();
     if (!G.Cosmo.exit_now) {
       chprintf(" Saved Snapshot: %d     z:%f   next_output: %f\n", nfile, G.Cosmo.current_z,
                1 / G.Cosmo.next_output - 1);
-      G.H.Output_Initial = false;
+      G.state.Output_Initial = false;
     } else {
       chprintf(" Saved Snapshot: %d     z:%f   Exiting now\n", nfile, G.Cosmo.current_z);
     }

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -142,7 +142,7 @@ void Write_Data(Grid3D &G, struct Parameters P, int nfile, const io::WriterManag
   }
   G.Change_Cosmological_Frame_System(true);
   chprintf("\n");
-  G.H.Output_Now = false;
+  G.state.Output_Now = false;
 #endif
 
 #ifdef HDF5

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
   chprintf("Nstep = %d  Simulation time = %f\n", G.H.n_step, G.H.t);
 
 #ifdef OUTPUT
-  if (!is_restart || G.H.Output_Now) {
+  if (!is_restart || G.state.Output_Now) {
     // write the initial conditions to file
     chprintf("Writing initial conditions to file...\n");
     Write_Data(G, P, nfile, writer_manager);
@@ -402,7 +402,7 @@ int main(int argc, char *argv[])
         "%9.3f ms   total time = %9.4f s\n\n",
         G.H.n_step, G.H.t, G.H.dt, (stop_step - start_step) * 1000, G.H.t_wall);
 
-    if (P.output_always) G.H.Output_Now = true;
+    if (P.output_always) G.state.Output_Now = true;
 
 #ifdef ANALYSIS
     if (G.Analysis.Output_Now) G.Compute_and_Output_Analysis(&P);
@@ -412,9 +412,9 @@ int main(int argc, char *argv[])
 #endif
 
     // if ( P.n_steps_output > 0 && G.H.n_step % P.n_steps_output == 0)
-    // G.H.Output_Now = true;
+    // G.state.Output_Now = true;
 
-    if (G.H.t == outtime || G.H.Output_Now) {
+    if (G.H.t == outtime || G.state.Output_Now) {
 #ifdef OUTPUT
       /*output the grid data*/
       Write_Data(G, P, nfile, writer_manager);

--- a/src/particles/io_particles.cpp
+++ b/src/particles/io_particles.cpp
@@ -559,7 +559,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.pos_x_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/pos_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);
@@ -572,7 +572,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.pos_y_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/pos_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);
@@ -585,7 +585,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.pos_z_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/pos_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);
@@ -598,7 +598,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.vel_x_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/vel_x", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);
@@ -611,7 +611,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.vel_y_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/vel_y", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);
@@ -624,7 +624,7 @@ void Grid3D::Write_Particles_Data_HDF5(hid_t file_id)
     #ifdef PARTICLES_GPU
   Particles.Copy_Particles_Array_Real_Device_to_Host(Particles.vel_z_dev, dataset_buffer, Particles.n_local);
     #endif  // PARTICLES_GPU
-  if (output_particle_data || H.Output_Complete_Data) {
+  if (output_particle_data || state\.Output_Complete_Data) {
     dataset_id = H5Dcreate(file_id, "/vel_z", H5T_IEEE_F64BE, dataspace_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     status     = H5Dwrite(dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_buffer);
     status     = H5Dclose(dataset_id);

--- a/src/particles/particles_boundaries.cpp
+++ b/src/particles/particles_boundaries.cpp
@@ -93,7 +93,7 @@ void Grid3D::Unload_Particles_From_Buffers_BLOCK(int index, int *flags)
   if (Particles.TRANSFER_DENSITY_BOUNDARIES) {
     return;
   }
-  if (H.TRANSFER_HYDRO_BOUNDARIES) {
+  if (state.TRANSFER_HYDRO_BOUNDARIES) {
     return;
   }
     #ifdef GRAVITY


### PR DESCRIPTION
## Overview

This PR aims to factor out some of the data members used for tracking internal state variables:
- I created the `SimRuntimeState`[^1] class for this purpose
- I transferred the `Output_Initial`, `Output_Now`, `Output_Complete_Data`, and `TRANSFER_HYDRO_BOUNDARIES` data members from the `Header` class into the `SimRuntimeState` class.

## About Integration Counters

At the moment, I have left the integration counters (e.g. current simulation time, current timestep, elapsed wall-clock time, number of of complete cycles) in place in `Header`. A case could be made for transferring these quantities into the this new class, my instinct is that they are a different category of quantities (i.e. unlike the quantities inside `SimRuntimeState`, these quantities are **ONLY** modified by the top-level loop).

I suspect I'm being a bit of a perfectionist here (part of it may be laziness -- I would need to make some adjustments for recording these quantities to the HDF5 file) and could be convinced to transfer these quantities. It probably makes a sense to do this (but perhaps in a separate PR -- that change will touch a LOT of code).

## Motivation

The purpose of this PR is to move us closer to having the `Header` class just track immutable values that don't change once the are initialized. I think this is desirable from a code-organization perspective in three (semi-related) respects:

1. In my experience, its easier to reason about large programs (without without needing to be familiar with every aspect of the codebase) when mutable state is clearly denoted as such.

2. In general, we want to minimize the number of these variables to the greatest extent possible. Introducing a new variable is often the easiest way to implement certain kinds of logic, because they make the control-flow much harder to follow (e.g. figuring out how the various `Output_` variables worked was a bit of a chore and I've never been a fan of `TRANSFER_HYDRO_BOUNDARIES`). By giving these variables a dedicated home, it will make it easier for reviewers to see when a new one of these variables is introduced. Often times, it may not be necessary to introduce one of these variables at all (and instead pass the information they denote as explicit function arguments):  
   - for example, I'm pretty sure it would be straight-forward to eliminate `Output_Initial` and it would take a little more effort to eliminate `Output_Complete_Data`
   - I'm also pretty sure we convert `TRANSFER_HYDRO_BOUNDARIES` into a dedicated argument, but this would take quite a bit more work.[^2]

3. (Less importantly) this is a step in the direction towards streamlining the initialization process of `Grid3D`. Let me explain:
   - I've never been a fan of of the way that initialization of `Grid3D` is so spread out. As a rule of thumb, a constructor should leave an object in a valid state, whereas we create a partially initialized `Grid3D` and initialize things piece-by-piece. In more (don't get me wrong, I understand why we do this)
   - For unrelated reasons, I plan to introduce a constructor for `Header` that fully constructs a fully initialized object directly from a `ParameterMap` (i.e. this will help us remove stuff from the `Parameters` object and it will help us pass a fully initialized `Headers` object onto `Rad3D`)
   - If the `Headers` object is fully initialized by the constructor (its all self-contained  -- and we don't immediately start overwriting intermediate state), I think this could make it easier to follow the initialization of `Grid3D`.

[^1]: I could be convinced to change the name
[^2]: I fleshed out what this might take in the data-member's docstring